### PR TITLE
v0.1: Server-driven paging, EntityEvent compliance, and GitHub Pages improvements

### DIFF
--- a/.github/pages/_layouts/default.html
+++ b/.github/pages/_layouts/default.html
@@ -229,7 +229,70 @@
       letter-spacing: 0.05em;
     }
 
-    /* Section headings */
+    /* Intro blurb */
+    .intro-blurb {
+      text-align: center;
+      max-width: 720px;
+      margin: 0 auto 2rem;
+      font-size: 0.95rem;
+      color: var(--reso-gray-600);
+      line-height: 1.7;
+    }
+
+    /* Audience cards */
+    .audience-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 1rem;
+      margin-bottom: 2rem;
+    }
+    @media (min-width: 768px) {
+      .audience-grid { grid-template-columns: repeat(3, 1fr); }
+    }
+    .audience-card {
+      background: white;
+      border: 1px solid var(--reso-gray-200);
+      border-radius: 0.5rem;
+      padding: 1.5rem;
+      text-align: center;
+      transition: box-shadow 0.15s, border-color 0.15s;
+      text-decoration: none;
+      color: inherit;
+      display: block;
+    }
+    .audience-card:hover {
+      box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+      border-color: var(--reso-blue);
+    }
+    .audience-icon {
+      width: 48px;
+      height: 48px;
+      margin: 0 auto 0.75rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: 50%;
+    }
+    .audience-icon svg { width: 24px; height: 24px; }
+    .audience-icon-navy { background: rgba(26,47,88,0.1); }
+    .audience-icon-navy svg { fill: var(--reso-navy); }
+    .audience-icon-blue { background: rgba(0,126,158,0.1); }
+    .audience-icon-blue svg { fill: var(--reso-blue); }
+    .audience-icon-green { background: rgba(56,161,105,0.1); }
+    .audience-icon-green svg { fill: var(--reso-green); }
+    .audience-card h3 {
+      font-size: 0.9375rem;
+      font-weight: 600;
+      color: var(--reso-gray-800);
+      margin-bottom: 0.375rem;
+    }
+    .audience-card p {
+      font-size: 0.8125rem;
+      color: var(--reso-gray-500);
+      line-height: 1.5;
+    }
+
+    /* Section headings with icons */
     .section-title {
       font-size: 0.75rem;
       font-weight: 600;
@@ -237,6 +300,15 @@
       letter-spacing: 0.1em;
       color: var(--reso-blue);
       margin-bottom: 0.75rem;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .section-title svg {
+      width: 16px;
+      height: 16px;
+      fill: currentColor;
+      flex-shrink: 0;
     }
     .section-group { margin-bottom: 2rem; }
 
@@ -246,6 +318,137 @@
     .section-tools .card { border-top-color: var(--reso-blue); }
     .section-server .card { border-top-color: var(--reso-orange); }
     .section-quickstart .card { border-top-color: var(--reso-navy); }
+    .section-learn .card { border-top-color: var(--reso-blue); }
+
+    /* Architecture diagram */
+    .arch-diagram {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 1.5rem;
+      margin-bottom: 2rem;
+      background: white;
+      border: 1px solid var(--reso-gray-200);
+      border-radius: 0.5rem;
+    }
+    .arch-row {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+    .arch-box {
+      padding: 0.5rem 1rem;
+      border-radius: 0.375rem;
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-align: center;
+      min-width: 120px;
+      color: white;
+    }
+    .arch-box-navy { background: var(--reso-navy); }
+    .arch-box-blue { background: var(--reso-blue); }
+    .arch-box-green { background: var(--reso-green); }
+    .arch-box-orange { background: var(--reso-orange); }
+    .arch-box-outline {
+      background: white;
+      color: var(--reso-gray-600);
+      border: 2px dashed var(--reso-gray-300);
+    }
+    .arch-arrow {
+      font-size: 1.25rem;
+      color: var(--reso-gray-400);
+      line-height: 1;
+    }
+    .arch-label {
+      font-size: 0.6875rem;
+      color: var(--reso-gray-500);
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      margin-top: 0.25rem;
+    }
+
+    /* Prerequisites */
+    .prereq-list {
+      display: flex;
+      gap: 1.5rem;
+      flex-wrap: wrap;
+      margin-bottom: 1rem;
+    }
+    .prereq-item {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.8125rem;
+      color: var(--reso-gray-600);
+    }
+    .prereq-check {
+      width: 20px;
+      height: 20px;
+      border-radius: 50%;
+      background: var(--reso-green-light);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .prereq-check svg { width: 12px; height: 12px; fill: var(--reso-green); }
+
+    /* Learn more links */
+    .learn-grid {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 0;
+    }
+    @media (min-width: 768px) {
+      .learn-grid { grid-template-columns: repeat(2, 1fr); }
+    }
+    .learn-item {
+      padding: 1rem 1.25rem;
+      border-bottom: 1px solid var(--reso-gray-100);
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      text-decoration: none;
+      color: inherit;
+      transition: background 0.1s;
+    }
+    .learn-item:hover { background: var(--reso-gray-50); }
+    .learn-item:last-child { border-bottom: none; }
+    @media (min-width: 768px) {
+      .learn-item { border-right: 1px solid var(--reso-gray-100); }
+      .learn-item:nth-child(2n) { border-right: none; }
+      .learn-item:nth-last-child(-n+2) { border-bottom: none; }
+    }
+    .learn-icon {
+      width: 36px;
+      height: 36px;
+      border-radius: 0.375rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .learn-icon svg { width: 18px; height: 18px; }
+    .learn-icon-navy { background: rgba(26,47,88,0.1); }
+    .learn-icon-navy svg { fill: var(--reso-navy); }
+    .learn-icon-blue { background: rgba(0,126,158,0.1); }
+    .learn-icon-blue svg { fill: var(--reso-blue); }
+    .learn-icon-orange { background: rgba(255,153,0,0.1); }
+    .learn-icon-orange svg { fill: var(--reso-orange); }
+    .learn-icon-green { background: rgba(56,161,105,0.1); }
+    .learn-icon-green svg { fill: var(--reso-green); }
+    .learn-text h4 {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: var(--reso-gray-800);
+    }
+    .learn-text p {
+      font-size: 0.75rem;
+      color: var(--reso-gray-500);
+      margin-top: 0.125rem;
+    }
 
     /* Footer */
     .site-footer {

--- a/.github/pages/index.html
+++ b/.github/pages/index.html
@@ -22,9 +22,69 @@ title: RESO Tools
   </div>
 </div>
 
+<!-- 1. What is this? -->
+<div class="intro-blurb">
+  <strong>RESO</strong> (Real Estate Standards Organization) defines how real estate data is exchanged
+  between MLSs, brokerages, and technology providers. These open-source tools help developers
+  build, test, and certify RESO-compliant servers and applications &mdash; so listing data
+  flows reliably across the industry.
+</div>
+
+<!-- 2. Who is this for? -->
+<div class="audience-grid">
+  <a href="#ref-server" class="audience-card">
+    <div class="audience-icon audience-icon-navy">
+      <svg viewBox="0 0 24 24"><path d="M20 13H4a2 2 0 00-2 2v4a2 2 0 002 4h16a2 2 0 002-2v-4a2 2 0 00-2-2zm0-10H4a2 2 0 00-2 2v4a2 2 0 002 2h16a2 2 0 002-2V5a2 2 0 00-2-2zm-2 5H6V6h12v2z"/></svg>
+    </div>
+    <h3>MLS &amp; Vendor Developers</h3>
+    <p>Building a RESO-compliant server? Use the reference implementation as a starting point and run compliance tests locally.</p>
+  </a>
+  <a href="#libraries" class="audience-card">
+    <div class="audience-icon audience-icon-blue">
+      <svg viewBox="0 0 24 24"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+    </div>
+    <h3>App Developers</h3>
+    <p>Consuming RESO APIs? Use the client SDK to query listings, validate responses, and parse OData filters.</p>
+  </a>
+  <a href="#tools" class="audience-card">
+    <div class="audience-icon audience-icon-green">
+      <svg viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+    </div>
+    <h3>RESO Certification</h3>
+    <p>Preparing for certification? Run the same compliance tests used in production against your server.</p>
+  </a>
+</div>
+
+<!-- 7. Architecture diagram -->
+<div class="arch-diagram">
+  <div class="arch-label">How the packages fit together</div>
+  <div class="arch-row">
+    <div class="arch-box arch-box-outline">Your Application</div>
+  </div>
+  <div class="arch-arrow">&darr;</div>
+  <div class="arch-row">
+    <div class="arch-box arch-box-blue">odata-client</div>
+    <div class="arch-box arch-box-green">validation</div>
+    <div class="arch-box arch-box-green">odata-expression-parser</div>
+  </div>
+  <div class="arch-arrow">&darr;</div>
+  <div class="arch-row">
+    <div class="arch-box arch-box-navy">Reference Server</div>
+    <div class="arch-box arch-box-outline">Your RESO Server</div>
+  </div>
+  <div class="arch-arrow">&darr;</div>
+  <div class="arch-row">
+    <div class="arch-box arch-box-orange">certification</div>
+    <div class="arch-box arch-box-orange">data-generator</div>
+  </div>
+</div>
+
 <!-- Libraries -->
-<div class="section-group section-libraries">
-  <div class="section-title">Libraries</div>
+<div id="libraries" class="section-group section-libraries">
+  <div class="section-title">
+    <svg viewBox="0 0 24 24"><path d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/></svg>
+    Libraries
+  </div>
   <div class="card">
     <div class="card-header">
       <h3>Core Libraries</h3>
@@ -34,7 +94,7 @@ title: RESO Tools
     <div class="package-item">
       <div>
         <div class="package-name">@reso/validation</div>
-        <div class="package-desc">Isomorphic validation library for RESO metadata-driven field validation. Works in any JS runtime (Node.js, browser, edge).</div>
+        <div class="package-desc">Validate real estate data against RESO metadata rules. Works in any JS runtime &mdash; Node.js, browsers, or edge functions. Use it to check field types, enumerations, and required fields before sending or accepting data.</div>
         <div class="package-meta">
           <span>41 tests</span>
           <span>&middot;</span>
@@ -47,7 +107,7 @@ title: RESO Tools
     <div class="package-item">
       <div>
         <div class="package-name">@reso/odata-expression-parser</div>
-        <div class="package-desc">Standalone, zero-dependency library for parsing OData 4.01 $filter expressions into a typed AST.</div>
+        <div class="package-desc">Parse OData <code>$filter</code> expressions like <code>ListPrice ge 200000 and City eq 'Austin'</code> into a structured syntax tree. Useful for building query UIs, validating filters, or translating queries between systems.</div>
         <div class="package-meta">
           <span>97 tests</span>
           <span>&middot;</span>
@@ -60,7 +120,7 @@ title: RESO Tools
     <div class="package-item">
       <div>
         <div class="package-name">@reso/odata-client</div>
-        <div class="package-desc">OData 4.01 client SDK for TypeScript. URI builder, CRUD helpers, CSDL metadata parsing, query validation, and response parsing.</div>
+        <div class="package-desc">Query RESO servers from TypeScript or JavaScript. Build OData URLs, fetch listings, parse metadata, and validate responses &mdash; without hand-crafting HTTP requests or dealing with protocol details.</div>
         <div class="package-meta">
           <span>101 tests</span>
           <span>&middot;</span>
@@ -73,8 +133,11 @@ title: RESO Tools
 </div>
 
 <!-- Tools -->
-<div class="section-group section-tools">
-  <div class="section-title">Tools</div>
+<div id="tools" class="section-group section-tools">
+  <div class="section-title">
+    <svg viewBox="0 0 24 24"><path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.573-1.066z"/><circle cx="12" cy="12" r="3"/></svg>
+    Tools
+  </div>
   <div class="card">
     <div class="card-header">
       <h3>Developer Tools</h3>
@@ -84,7 +147,7 @@ title: RESO Tools
     <div class="package-item">
       <div>
         <div class="package-name">@reso/data-generator</div>
-        <div class="package-desc">Generates realistic RESO Data Dictionary test data. Supports HTTP, JSON, and curl output modes with resource-specific generators.</div>
+        <div class="package-desc">Generate realistic sample real estate data for testing. Creates properties, agents, offices, media, and more that conform to the RESO Data Dictionary. Use the CLI or import as a library.</div>
         <div class="package-meta">
           <span>69 tests</span>
           <span>&middot;</span>
@@ -97,7 +160,7 @@ title: RESO Tools
     <div class="package-item">
       <div>
         <div class="package-name">@reso/certification</div>
-        <div class="package-desc">RESO certification compliance testing tools. Includes Web API Core, Data Dictionary, Add/Edit (RCP-010), and EntityEvent (RCP-027) endorsement testing.</div>
+        <div class="package-desc">Run the same compliance tests used in RESO certification. Covers Web API Core, Data Dictionary, Add/Edit (RCP-010), and EntityEvent (RCP-027) endorsements. Test your server before submitting for certification.</div>
         <div class="package-meta">
           <span>49 tests</span>
           <span>&middot;</span>
@@ -110,8 +173,11 @@ title: RESO Tools
 </div>
 
 <!-- Reference Server -->
-<div class="section-group section-server">
-  <div class="section-title">Reference Implementation</div>
+<div id="ref-server" class="section-group section-server">
+  <div class="section-title">
+    <svg viewBox="0 0 24 24"><path d="M5 12h14M5 12a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v4a2 2 0 01-2 2M5 12a2 2 0 00-2 2v4a2 2 0 002 2h14a2 2 0 002-2v-4a2 2 0 00-2-2m-2-4h.01M17 16h.01"/></svg>
+    Reference Implementation
+  </div>
   <div class="card">
     <div class="card-header">
       <h3>RESO Reference Server</h3>
@@ -122,9 +188,10 @@ title: RESO Tools
       <div>
         <div class="package-name">reso-reference-server</div>
         <div class="package-desc">
-          Metadata-driven OData 4.01 reference server with React UI.
-          Dynamically generates database tables, CRUD endpoints, EDMX metadata, and OpenAPI documentation
-          from the RESO Data Dictionary JSON metadata.
+          A fully working RESO Web API server you can run locally with Docker.
+          Point it at the RESO Data Dictionary metadata and it automatically creates database tables,
+          REST endpoints, Swagger documentation, and a React UI for browsing data.
+          Use it as a reference for building your own server, or as a test target for compliance tools.
         </div>
         <div class="package-meta">
           <span>76 tests</span>
@@ -143,30 +210,99 @@ title: RESO Tools
   </div>
 </div>
 
-<!-- Quick Start -->
+<!-- Getting Started -->
 <div class="section-group section-quickstart">
-  <div class="section-title">Quick Start</div>
+  <div class="section-title">
+    <svg viewBox="0 0 24 24"><path d="M13 10V3L4 14h7v7l9-11h-7z"/></svg>
+    Getting Started
+  </div>
   <div class="card">
     <div class="card-body content">
-      <h3 style="margin-top: 0">Run the Reference Server</h3>
+      <h3 style="margin-top: 0">Prerequisites</h3>
+      <div class="prereq-list">
+        <div class="prereq-item">
+          <div class="prereq-check"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg></div>
+          <span><a href="https://git-scm.com/downloads">Git</a></span>
+        </div>
+        <div class="prereq-item">
+          <div class="prereq-check"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg></div>
+          <span><a href="https://docs.docker.com/get-docker/">Docker Desktop</a></span>
+        </div>
+        <div class="prereq-item">
+          <div class="prereq-check"><svg viewBox="0 0 24 24"><path d="M5 13l4 4L19 7"/></svg></div>
+          <span><a href="https://nodejs.org/">Node.js 22+</a> (for libraries &amp; CLI)</span>
+        </div>
+      </div>
+
+      <h3>Run the Reference Server</h3>
+      <p>This starts a RESO Web API server with PostgreSQL, seeds it with sample listings, and gives you a Swagger UI and React frontend to explore.</p>
 <pre><code>git clone https://github.com/RESOStandards/reso-tools.git
 cd reso-tools/reso-reference-server
 docker compose up -d                      # Start server + PostgreSQL
 docker compose --profile seed up          # Seed with test data
 
-# Verify
-curl http://localhost:8080/health
-curl http://localhost:8080/$metadata
-open http://localhost:8080/api-docs        # Swagger UI
-open http://localhost:5173                  # React UI</code></pre>
+# Once running, you'll have:
+#   http://localhost:8080/health       - Health check
+#   http://localhost:8080/$metadata    - OData EDMX metadata
+#   http://localhost:8080/api-docs     - Swagger API explorer
+#   http://localhost:5173              - React UI</code></pre>
 
-      <h3>Run Certification Tests</h3>
+      <h3>Run Compliance Tests</h3>
+      <p>Verify your server passes RESO certification requirements. This example runs the Add/Edit endorsement tests against the local reference server.</p>
 <pre><code>cd certification
 npx reso-cert-add-edit \
   --url http://localhost:8080 \
   --resource Property \
   --payloads ./add-edit/sample-payloads \
   --auth-token admin-token</code></pre>
+    </div>
+  </div>
+</div>
+
+<!-- Learn More -->
+<div class="section-group section-learn">
+  <div class="section-title">
+    <svg viewBox="0 0 24 24"><path d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"/></svg>
+    Learn More
+  </div>
+  <div class="card">
+    <div class="learn-grid">
+      <a href="https://ddwiki.reso.org" class="learn-item">
+        <div class="learn-icon learn-icon-navy">
+          <svg viewBox="0 0 24 24"><path d="M4 7v10c0 2 1 3 3 3h10c2 0 3-1 3-3V7c0-2-1-3-3-3H7c-2 0-3 1-3 3zm5 1h6m-6 3h6m-6 3h4"/></svg>
+        </div>
+        <div class="learn-text">
+          <h4>RESO Data Dictionary Wiki</h4>
+          <p>Browse all standard fields, resources, and enumerations</p>
+        </div>
+      </a>
+      <a href="https://docs.oasis-open.org/odata/odata/v4.01/odata-v4.01-part1-protocol.html" class="learn-item">
+        <div class="learn-icon learn-icon-blue">
+          <svg viewBox="0 0 24 24"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+        </div>
+        <div class="learn-text">
+          <h4>OData 4.01 Specification</h4>
+          <p>The OASIS standard query protocol that powers RESO Web API</p>
+        </div>
+      </a>
+      <a href="https://transport.reso.org" class="learn-item">
+        <div class="learn-icon learn-icon-orange">
+          <svg viewBox="0 0 24 24"><path d="M21 12a9 9 0 01-9 9m9-9a9 9 0 00-9-9m9 9H3m9 9a9 9 0 01-9-9m9 9c1.657 0 3-4.03 3-9s-1.343-9-3-9m0 18c-1.657 0-3-4.03-3-9s1.343-9 3-9"/></svg>
+        </div>
+        <div class="learn-text">
+          <h4>RESO Transport Specifications</h4>
+          <p>Official RESO transport specifications and endorsements</p>
+        </div>
+      </a>
+      <a href="https://certification.reso.org" class="learn-item">
+        <div class="learn-icon learn-icon-green">
+          <svg viewBox="0 0 24 24"><path d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/></svg>
+        </div>
+        <div class="learn-text">
+          <h4>RESO Certification Portal</h4>
+          <p>View certification results and analytics</p>
+        </div>
+      </a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary

- **Server-driven paging** - Default page size 100, max 2000, `Prefer: odata.maxpagesize` header support, proper `@odata.nextLink` semantics (only present when result is partial). 21 new unit tests.
- **EntityEvent RCP-027 compliance infrastructure** - Docker Compose services for all 3 backends (PostgreSQL, MongoDB, SQLite) with full-mode canary testing entrypoint.
- **Fix Docker `BASE_URL`** - Changed from `localhost:8080` to Docker service names so `@odata.nextLink` URLs are resolvable by compliance containers.
- **GitHub Pages overhaul** - RESO branding (official logo, brand colors), beginner-friendly content (intro blurb, audience cards, architecture diagram, prerequisites, use-case descriptions, Learn More links), fixed all broken links.
- **Pagefind search** - Full-text search modal with `/` keyboard shortcut, powered by Pagefind (MIT, static, no external services).
- **Multi-level `$expand`** with inline `$select` filtering.
- **UI improvements** - Zebra striping, side-by-side detail layout, pinned action buttons.
- **DD 2.0 schema validation fixes** and SQLite readonly fix.
- **Docker hot-reload dev mode** and Vite SPA proxy routing fix.

## Test plan
- [x] 21 paging unit tests pass
- [x] DD 2.0 compliance passes (all 3 backends)
- [x] Web API Core 2.0.0 compliance passes (42 passed, 3 skipped - string enum)
- [x] Add/Edit RCP-010 compliance passes
- [x] EntityEvent RCP-027 compliance passes (full mode, 1000 events validated)
- [ ] Verify GitHub Pages renders correctly after merge
- [ ] Verify Pagefind search works after deploy