### PR TITLE
Fix Pagefind build: copy _site to writable directory

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -69,8 +69,10 @@ jobs:
 
       - name: Build search index with Pagefind
         run: |
-          chmod -R u+w ./_site
-          npx pagefind --site ./_site
+          cp -r ./_site ./_site_writable
+          npx pagefind --site ./_site_writable
+          rm -rf ./_site
+          mv ./_site_writable ./_site
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
## Summary
- Fixes the Pagefind build failure from PR #30
- The jekyll-build-pages Docker action creates _site with root ownership, so chmod fails
- Copies _site to a writable directory, runs Pagefind there, then swaps it back

## Test plan
- [ ] Pages workflow completes successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)