### PR TITLE
Fix Pagefind build: upload writable copy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -69,13 +69,13 @@ jobs:
 
       - name: Build search index with Pagefind
         run: |
-          cp -r ./_site ./_site_writable
-          npx pagefind --site ./_site_writable
-          rm -rf ./_site
-          mv ./_site_writable ./_site
+          cp -r ./_site ./_site_searchable
+          npx pagefind --site ./_site_searchable
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./_site_searchable
 
   deploy:
     environment:


### PR DESCRIPTION
Fixes Pagefind build failure: rm -rf _site fails because the directory is root-owned from the Jekyll Docker action. Instead of trying to replace _site, point upload-pages-artifact at the writable copy with the Pagefind index.