### PR TITLE
Fix DD docs copy into site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -80,12 +80,11 @@ jobs:
           source: ./.github/pages
           destination: ./_site
 
-      - name: Copy DD docs into site
-        run: cp -r .github/pages/dd-output/* ./_site/dd/
-
       - name: Build search index with Pagefind
         run: |
           cp -r ./_site ./_site_searchable
+          mkdir -p ./_site_searchable/dd
+          cp -r .github/pages/dd-output/* ./_site_searchable/dd/
           npx pagefind --site ./_site_searchable
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- Fix the DD docs copy step that failed due to root-owned _site directory from Jekyll Docker build
- Copy DD output into _site_searchable (which we own) before Pagefind indexing

## Test plan
- [ ] Verify GitHub Actions build succeeds
- [ ] Check DD pages appear at tools.reso.org/dd/

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>