### PR TITLE
variations: /compute payload guard (#227) + metadata-report.json convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,7 @@ The GitHub repo merges PRs with **Rebase and merge** — the trunk stays linear,
 - The OData client handles URI building, CRUD, pagination, and metadata parsing – it is used by both the web UI and the certification runner
 - Validation rules are isomorphic (shared between client and server)
 - The DD docs site is in a separate repo — see `RESOStandards/reso-data-dictionary-documentation` for styling and generator code
+- **Metadata reports — `metadata-report.json` is canonical.** As of v1.0.0-pre the scheme was inverted so `metadata-report.json` is **ALWAYS** the canonical *final* report (merged when a Lookup Resource is present, else the base), and the pre-merge base is written as `metadata-report.raw.json`. New runs no longer emit `.processed`, so downstream can **always rely on `metadata-report.json`** (see `src/sdk/dd.ts:159`, `metadata/lookup-resource.ts:158`). **Legacy exception:** older cert-utils bundles used the *opposite* pair — `metadata-report.json` = base, `metadata-report.processed.json` = merged — so when consuming a pre-inversion bundle, prefer `metadata-report.processed.json` when present, falling back to `metadata-report.json` (cf. desktop `main.ts:307`). This carve-out retires once old bundles age out.
 
 ## DD Reference-Metadata Regeneration
 

--- a/reso-certification/src/variations/constants.ts
+++ b/reso-certification/src/variations/constants.ts
@@ -12,3 +12,12 @@ export const DEFAULT_DD_VERSION = '2.0';
 
 /** Report filename written into the output directory (unchanged from legacy). */
 export const VARIATIONS_REPORT_FILENAME = 'data-dictionary-variations.json';
+
+/**
+ * Max compressed request payload for the `/compute` call. The Lambda synchronous
+ * invocation payload is capped at 6 MB, and the `base64(gzip)` body is essentially
+ * the whole event — so a report that compresses over this fails at the gateway.
+ * The client flags it with an actionable message instead of a cryptic 4xx. The
+ * durable fix (presigned-URL or chunked upload) is tracked in reso-tools #227.
+ */
+export const MAX_COMPUTE_PAYLOAD_BYTES = 6 * 1024 * 1024;

--- a/reso-certification/src/variations/constants.ts
+++ b/reso-certification/src/variations/constants.ts
@@ -14,10 +14,15 @@ export const DEFAULT_DD_VERSION = '2.0';
 export const VARIATIONS_REPORT_FILENAME = 'data-dictionary-variations.json';
 
 /**
- * Max compressed request payload for the `/compute` call. The Lambda synchronous
- * invocation payload is capped at 6 MB, and the `base64(gzip)` body is essentially
- * the whole event — so a report that compresses over this fails at the gateway.
- * The client flags it with an actionable message instead of a cryptic 4xx. The
- * durable fix (presigned-URL or chunked upload) is tracked in reso-tools #227.
+ * Rough client-side pre-check for the `/compute` compressed payload. The Lambda
+ * sync limit is 6 MB on the whole *event* (body + the envelope API Gateway injects:
+ * headers, `requestContext`, authorizer context) — which the client can't measure
+ * or predict precisely. So this only catches *obviously* oversized bodies to avoid
+ * a wasted upload; the gateway's **413** (caught in `service.ts`) is the precise
+ * backstop for the envelope edge. Durable fix for the giants: reso-tools #227.
  */
 export const MAX_COMPUTE_PAYLOAD_BYTES = 6 * 1024 * 1024;
+
+/** Shared user-facing message for both the client-side pre-check and a gateway 413. */
+export const PAYLOAD_TOO_LARGE_MESSAGE =
+  'This metadata report is too large for the variations service. Please contact dev@reso.org.';

--- a/reso-certification/src/variations/service.ts
+++ b/reso-certification/src/variations/service.ts
@@ -75,10 +75,12 @@ export const computeVariationsViaService = async (
   const compressedBody = gzipSync(JSON.stringify(body)).toString('base64');
 
   // Guard the Lambda's 6 MB sync-invocation ceiling client-side so an oversized
-  // report gets an actionable message, not a cryptic gateway failure. Even
-  // Cotality-scale reports (~45 MB raw → ~3.2 MB compressed) clear this today;
-  // the durable fix for the giants is reso-tools #227.
-  if (compressedBody.length > MAX_COMPUTE_PAYLOAD_BYTES) {
+  // report gets an actionable message, not a cryptic gateway failure. Reject at
+  // `>=` the limit, not `>`: the 6 MB cap is on the whole event (body + request
+  // envelope), so the compressed body must be *strictly under* 6 MB to fit. Even
+  // Cotality-scale reports (~45 MB raw → ~3.2 MB compressed) clear this; the
+  // durable fix for the giants is reso-tools #227.
+  if (compressedBody.length >= MAX_COMPUTE_PAYLOAD_BYTES) {
     const mb = (bytes: number): string => (bytes / 1024 / 1024).toFixed(1);
     throw serviceError(
       'SERVICE_ERROR',

--- a/reso-certification/src/variations/service.ts
+++ b/reso-certification/src/variations/service.ts
@@ -19,7 +19,7 @@
 import { gzipSync, gunzipSync } from 'node:zlib';
 import { mintProviderToken, serviceError, isServiceAuthError } from '../sdk/common.js';
 import type { ServiceErrorCode } from '../sdk/common.js';
-import { MAX_COMPUTE_PAYLOAD_BYTES } from './constants.js';
+import { MAX_COMPUTE_PAYLOAD_BYTES, PAYLOAD_TOO_LARGE_MESSAGE } from './constants.js';
 import type { VariationSuggestionItem } from './csv.js';
 
 export interface ComputeVariationsViaServiceInput {
@@ -74,17 +74,16 @@ export const computeVariationsViaService = async (
   // reports compress well, and the handler compresses its response in kind.
   const compressedBody = gzipSync(JSON.stringify(body)).toString('base64');
 
-  // Guard the Lambda's 6 MB sync-invocation ceiling client-side so an oversized
-  // report gets an actionable message, not a cryptic gateway failure. Reject at
-  // `>=` the limit, not `>`: the 6 MB cap is on the whole event (body + request
-  // envelope), so the compressed body must be *strictly under* 6 MB to fit. Even
-  // Cotality-scale reports (~45 MB raw → ~3.2 MB compressed) clear this; the
-  // durable fix for the giants is reso-tools #227.
+  // Rough pre-check: reject an obviously-oversized compressed body before the
+  // upload. `>=` because the 6 MB cap is on the whole event (body + envelope), so
+  // an exactly-6 MB body already can't fit. The gateway 413 below is the precise
+  // backstop for the envelope edge; both hand back the same message. Cotality-scale
+  // reports (~45 MB raw → ~3.2 MB compressed) clear this easily.
   if (compressedBody.length >= MAX_COMPUTE_PAYLOAD_BYTES) {
     const mb = (bytes: number): string => (bytes / 1024 / 1024).toFixed(1);
     throw serviceError(
       'SERVICE_ERROR',
-      `This metadata report is too large for the variations service: the compressed request is ${mb(compressedBody.length)} MB, over the ${mb(MAX_COMPUTE_PAYLOAD_BYTES)} MB limit. Please contact dev@reso.org.`,
+      `Compressed request is ${mb(compressedBody.length)} MB (limit ~${mb(MAX_COMPUTE_PAYLOAD_BYTES)} MB). ${PAYLOAD_TOO_LARGE_MESSAGE}`,
     );
   }
 
@@ -101,6 +100,11 @@ export const computeVariationsViaService = async (
         ? 'Variations check: the provider token was rejected. Re-check your CERT_AUTH_API_* .env credentials.'
         : 'Variations check: your session token was rejected or has expired. Log in again to continue.',
     );
+  }
+  if (response.status === 413) {
+    // Gateway rejected the payload (event exceeded Lambda's 6 MB ceiling despite the
+    // client pre-check). Hand back the same graceful message as the local guard.
+    throw serviceError('SERVICE_ERROR', PAYLOAD_TOO_LARGE_MESSAGE);
   }
   if (!response.ok) {
     throw serviceError('SERVICE_ERROR', `Variations Service /compute failed: ${response.status} ${response.statusText}`);

--- a/reso-certification/src/variations/service.ts
+++ b/reso-certification/src/variations/service.ts
@@ -19,6 +19,7 @@
 import { gzipSync, gunzipSync } from 'node:zlib';
 import { mintProviderToken, serviceError, isServiceAuthError } from '../sdk/common.js';
 import type { ServiceErrorCode } from '../sdk/common.js';
+import { MAX_COMPUTE_PAYLOAD_BYTES } from './constants.js';
 import type { VariationSuggestionItem } from './csv.js';
 
 export interface ComputeVariationsViaServiceInput {
@@ -71,10 +72,24 @@ export const computeVariationsViaService = async (
 
   // text/plain + gzip+base64 mirrors the legacy /search call: large metadata
   // reports compress well, and the handler compresses its response in kind.
+  const compressedBody = gzipSync(JSON.stringify(body)).toString('base64');
+
+  // Guard the Lambda's 6 MB sync-invocation ceiling client-side so an oversized
+  // report gets an actionable message, not a cryptic gateway failure. Even
+  // Cotality-scale reports (~45 MB raw → ~3.2 MB compressed) clear this today;
+  // the durable fix for the giants is reso-tools #227.
+  if (compressedBody.length > MAX_COMPUTE_PAYLOAD_BYTES) {
+    const mb = (bytes: number): string => (bytes / 1024 / 1024).toFixed(1);
+    throw serviceError(
+      'SERVICE_ERROR',
+      `This metadata report is too large for the variations service: the compressed request is ${mb(compressedBody.length)} MB, over the ${mb(MAX_COMPUTE_PAYLOAD_BYTES)} MB limit. Please contact dev@reso.org.`,
+    );
+  }
+
   const response = await fetch(`${servicesUrl}/v2/certification/variations/compute`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'text/plain' },
-    body: gzipSync(JSON.stringify(body)).toString('base64'),
+    body: compressedBody,
   });
 
   if (response.status === 401 || response.status === 403) {

--- a/reso-certification/tests/variations/service.test.ts
+++ b/reso-certification/tests/variations/service.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { gzipSync } from 'node:zlib';
+import { randomBytes } from 'node:crypto';
 import { computeVariationsViaService, isVariationsAuthError } from '../../src/variations/index.js';
 
 const report = {
@@ -112,5 +113,19 @@ describe('computeVariationsViaService — service failures', () => {
     const err = await computeVariationsViaService({ metadataReportJson: {}, version: '2.1', bearerToken: 't' }).catch(e => e);
     expect(codeOf(err)).toBe('SERVICE_ERROR');
     expect((err as Error).message).toMatch(/503/);
+  });
+
+  it('guards the compressed-payload ceiling: SERVICE_ERROR at dev@reso.org, before any POST', async () => {
+    // ~6 MB of random data → incompressible → base64(gzip) clears the 6 MB Lambda ceiling.
+    const oversized = randomBytes(6 * 1024 * 1024).toString('base64');
+    const err = await computeVariationsViaService({
+      metadataReportJson: { fields: [], _pad: oversized },
+      version: '2.1',
+      bearerToken: 't',
+    }).catch(e => e);
+    expect(codeOf(err)).toBe('SERVICE_ERROR');
+    expect((err as Error).message).toMatch(/too large/i);
+    expect((err as Error).message).toMatch(/dev@reso\.org/);
+    expect(mockFetch()).not.toHaveBeenCalled();
   });
 });

--- a/reso-certification/tests/variations/service.test.ts
+++ b/reso-certification/tests/variations/service.test.ts
@@ -128,4 +128,12 @@ describe('computeVariationsViaService — service failures', () => {
     expect((err as Error).message).toMatch(/dev@reso\.org/);
     expect(mockFetch()).not.toHaveBeenCalled();
   });
+
+  it('a 413 from /compute: SERVICE_ERROR with the same graceful too-large message', async () => {
+    mockFetch().mockResolvedValue({ ok: false, status: 413, statusText: 'Payload Too Large' });
+    const err = await computeVariationsViaService({ metadataReportJson: {}, version: '2.1', bearerToken: 't' }).catch(e => e);
+    expect(codeOf(err)).toBe('SERVICE_ERROR');
+    expect((err as Error).message).toMatch(/too large/i);
+    expect((err as Error).message).toMatch(/dev@reso\.org/);
+  });
 });


### PR DESCRIPTION
Client-side guard so an oversized `/compute` request fails **gracefully** instead of hitting a cryptic gateway 4xx, plus the `metadata-report.json` canonical convention in CLAUDE.md. Targets `v1.0.0-pre`.

## Guard
`computeVariationsViaService` now checks the **compressed** (`base64(gzip)`) body size before POSTing and, if it exceeds `MAX_COMPUTE_PAYLOAD_BYTES` (6 MB — the Lambda sync-invocation ceiling), throws a coded `SERVICE_ERROR` telling the operator to contact **dev@reso.org**.

- Checks the **compressed** payload, not raw file size — a **45 MB Cotality report compresses to ~3.2 MB (54% of the limit)** and clears it fine, so this only trips on genuinely oversized reports.
- The durable fix for the giants (**presigned-URL upload** preferred, or chunking) is tracked in **#227**; this is the graceful-degradation interim.
- Test: an oversized incompressible payload throws **before any `fetch`**.

## Docs
CLAUDE.md now records that `metadata-report.json` is the canonical (merged-or-base) report as of v1.0.0-pre (`.raw.json` = pre-merge base; `.processed` retired), with the legacy-bundle `.processed`-first fallback.

## Validation context
This lands alongside the `/compute` cutover sanity sweep (24 DD-2.0 providers + the real Cotality report): `/compute` is live on QA, compression carries even Cotality, and v2 detection is a clean superset of v1. Full precommit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
