### PR TITLE
Publish-prep: ready the public packages for npm (#220)

### DIFF
--- a/SECURITY_AUDIT.md
+++ b/SECURITY_AUDIT.md
@@ -4,6 +4,31 @@ Findings are prepended newest-first. Close the linked GitHub issue when each fin
 
 ---
 
+## v1.0.0 Security Notes – 2026-07-15
+
+Pre-publish adversarial review of the six public npm packages ahead of the npm publish and public/private split (#220). All six are clean on the security-critical axes — zero known vulnerabilities, no secrets in shipped code, no dangerous runtime patterns. The findings below are publish hygiene and packaging mechanics.
+
+### Findings Addressed
+
+- **Consumer-side install hook** (High → Fixed, #230): reso-client and reso-certification shipped a `preinstall` hook (`node ../scripts/bootstrap-deps.mjs`) that ran on every consumer install and pointed at a path outside the package. Removed; clean-clone development uses the root bootstrap. The remaining hooks are removed in the workspaces migration.
+- **reso-certification package leak** (High → Fixed, #220): with no `files` allowlist, `npm publish` would have shipped 661 files / 31 MB — all of `src/`, `tests/`, `coverage/`, `.reso-cert/` local run artifacts and `__pycache__/`. Added `files: ["dist"]`; the tarball is now 306 files / 3.8 MB.
+- **Publish metadata** (Medium → Fixed, #220): added `license` (RESO EULA), `publishConfig.access: public`, `repository` and `prepublishOnly` to the packages that lacked them.
+- **reso-common version conflict** (High → Fixed, #220): 0.1.2 was already published with different content; bumped to 0.2.0, a backward-compatible export addition.
+
+### Noted Risks (Accepted / Pending)
+
+- **`reso-certification-etl` supply chain** (High → Pending, #230): resolves to a mutable GitHub `main` tarball with no version pin or integrity check. Being published to public npm and pinned to a version in the workspaces migration.
+- **`file:` dependencies** (Pending, #230): reso-client and reso-certification carry `file:../` deps that cannot resolve for consumers; the workspaces migration converts them to `^` version ranges resolved from the registry.
+- **LICENSE as EULA pointer** (Accepted): the `LICENSE` file references the RESO EULA at reso.org/eula rather than inlining full text, matching the already-published reso-common.
+- **Broken sourcemaps** (Low → Pending): shipped `.js.map` files reference `../src` paths not in the tarball; to be resolved with `inlineSources` or by dropping map emission for the published build.
+- **Missing or stale READMEs** (Low → Pending): reso-metadata-utils has none; reso-validation's is stale.
+
+### Method
+
+Automated adversarial per-package review, one agent per package: `npm audit`, `npm pack --dry-run`, and secret, supply-chain and dangerous-code scans over shipped output, followed by manual verification of the resolved items.
+
+---
+
 ## v0.5 Security Notes – 2026-04-06
 
 ### Findings

--- a/odata-expression-parser/LICENSE
+++ b/odata-expression-parser/LICENSE
@@ -1,0 +1,11 @@
+REAL ESTATE STANDARDS ORGANIZATION
+End-user License Agreement (EULA)
+
+By downloading these resources, you confirm that you agree to the RESO EULA: https://www.reso.org/eula/
+
+Contact Information:
+Attn:     Sam DeBord, Chief Executive Officer
+Address:  P.O. Box 10824
+          Raleigh, NC 27605
+Phone:    206.658.3225
+Email:    sam@reso.org

--- a/odata-expression-parser/package.json
+++ b/odata-expression-parser/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@reso-standards/odata-expression-parser",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RESOStandards/reso-tools.git",
+    "directory": "odata-expression-parser"
+  },
   "description": "OData expression parsers — $filter and $expand tokenizer and recursive descent parsers producing typed ASTs. Inspired by Apache Olingo's UriParser.",
+  "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -11,11 +17,16 @@
       "import": "./dist/index.js"
     }
   },
+  "sideEffects": false,
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
+    "prepublishOnly": "npm run build",
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/reso-certification/LICENSE
+++ b/reso-certification/LICENSE
@@ -1,0 +1,11 @@
+REAL ESTATE STANDARDS ORGANIZATION
+End-user License Agreement (EULA)
+
+By downloading these resources, you confirm that you agree to the RESO EULA: https://www.reso.org/eula/
+
+Contact Information:
+Attn:     Sam DeBord, Chief Executive Officer
+Address:  P.O. Box 10824
+          Raleigh, NC 27605
+Phone:    206.658.3225
+Email:    sam@reso.org

--- a/reso-certification/package.json
+++ b/reso-certification/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@reso-standards/reso-certification",
   "version": "0.10.0",
+  "license": "SEE LICENSE IN LICENSE",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RESOStandards/reso-tools.git",
+    "directory": "reso-certification"
+  },
   "description": "RESO certification testing toolkit — Add/Edit (RCP-010), Web API Core, Data Dictionary",
   "type": "module",
   "engines": {
@@ -17,9 +23,15 @@
   "bin": {
     "reso-cert": "./dist/cli/index.js"
   },
+  "files": [
+    "dist"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
-    "preinstall": "node ../scripts/bootstrap-deps.mjs || true",
     "build": "tsc && rm -rf dist/legacy dist/etl && cp -r src/legacy dist/legacy && cp -r src/etl dist/etl",
+    "prepublishOnly": "npm run build",
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/reso-client/LICENSE
+++ b/reso-client/LICENSE
@@ -1,0 +1,11 @@
+REAL ESTATE STANDARDS ORGANIZATION
+End-user License Agreement (EULA)
+
+By downloading these resources, you confirm that you agree to the RESO EULA: https://www.reso.org/eula/
+
+Contact Information:
+Attn:     Sam DeBord, Chief Executive Officer
+Address:  P.O. Box 10824
+          Raleigh, NC 27605
+Phone:    206.658.3225
+Email:    sam@reso.org

--- a/reso-client/package.json
+++ b/reso-client/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@reso-standards/reso-client",
   "version": "0.2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RESOStandards/reso-tools.git",
+    "directory": "reso-client"
+  },
   "description": "RESO Client SDK for TypeScript — OData 4.01 URI builder, CRUD helpers, CSDL metadata validation, and query parsing.",
+  "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -11,13 +17,17 @@
       "import": "./dist/index.js"
     }
   },
+  "sideEffects": false,
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
-    "preinstall": "node ../scripts/bootstrap-deps.mjs || true",
     "prebuild": "node scripts/sync-version.mjs",
     "build": "tsc",
+    "prepublishOnly": "npm run build",
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/reso-common/package.json
+++ b/reso-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reso-standards/reso-common",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/RESOStandards/reso-tools.git",

--- a/reso-metadata-utils/LICENSE
+++ b/reso-metadata-utils/LICENSE
@@ -1,0 +1,11 @@
+REAL ESTATE STANDARDS ORGANIZATION
+End-user License Agreement (EULA)
+
+By downloading these resources, you confirm that you agree to the RESO EULA: https://www.reso.org/eula/
+
+Contact Information:
+Attn:     Sam DeBord, Chief Executive Officer
+Address:  P.O. Box 10824
+          Raleigh, NC 27605
+Phone:    206.658.3225
+Email:    sam@reso.org

--- a/reso-validation/LICENSE
+++ b/reso-validation/LICENSE
@@ -1,0 +1,11 @@
+REAL ESTATE STANDARDS ORGANIZATION
+End-user License Agreement (EULA)
+
+By downloading these resources, you confirm that you agree to the RESO EULA: https://www.reso.org/eula/
+
+Contact Information:
+Attn:     Sam DeBord, Chief Executive Officer
+Address:  P.O. Box 10824
+          Raleigh, NC 27605
+Phone:    206.658.3225
+Email:    sam@reso.org

--- a/reso-validation/package.json
+++ b/reso-validation/package.json
@@ -1,7 +1,13 @@
 {
   "name": "@reso-standards/reso-validation",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RESOStandards/reso-tools.git",
+    "directory": "reso-validation"
+  },
   "description": "RESO validation library — isomorphic, no Node/browser APIs.",
+  "license": "SEE LICENSE IN LICENSE",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -15,11 +21,16 @@
       "import": "./dist/metadata/index.js"
     }
   },
+  "sideEffects": false,
   "files": [
     "dist"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
+    "prepublishOnly": "npm run build",
     "dev": "tsc --watch",
     "test": "vitest run",
     "test:watch": "vitest",


### PR DESCRIPTION
Publish-readiness prep for the public packages, ahead of the npm publish + public/private split (#220). Informed by a per-package adversarial security review (all six public packages clean on vulnerabilities, secrets and dangerous code — every finding was publish hygiene or mechanics).

## Changes

- Add the RESO EULA `LICENSE` to the five packages that lacked one.
- Manifest hygiene on odata-expression-parser, reso-validation, reso-client, reso-certification: `license` (`SEE LICENSE IN LICENSE`), `repository` (with `directory`), `publishConfig.access: public`, `prepublishOnly`.
- Remove the monorepo `preinstall` bootstrap hook from reso-client + reso-certification — it ran on **consumer** installs and pointed at a path outside the package. Clean-clone dev uses the root bootstrap.
- Add a `files` allowlist to reso-certification — it was set to publish **661 files / 31 MB** (all of `src/`, `tests/`, `coverage/`, `.reso-cert/` run artifacts, `__pycache__/`); now `dist` only (**306 files / 3.8 MB**).
- Bump reso-common `0.1.2` → `0.2.0` — 0.1.2 is already published with different content; the surface diff vs the published tarball shows two added public exports (`SIMPLE_IDENTIFIER_RE`, `isValidSimpleIdentifier`), no removals — a backward-compatible addition.

## Not in this PR (tracked separately)

- **#230** — the npm-workspaces migration: converts the remaining `file:`→`^` ranges, removes the other `preinstall` hooks, and retires `bootstrap.sh`.
- **`@reso/reso-certification-etl` — no longer published to npm; it is being cut.** The two symbols reso-certification uses from it (`getReferenceMetadata`, `processLookupResourceMetadataFiles`) already exist in the in-package v2 ETL (`src/etl`), so the 5 legacy requires repoint there and the mutable-`main`-tarball dependency is dropped entirely — which also closes the `reso-certification-etl` supply-chain item in the security audit. The old package stays recoverable from the `reso-certification-utils` repo. Tracked in the v1.0.0 publish work (Phase 1), not here.
- Remaining pre-publish items from the v1.0.0 security audit: sourcemaps, READMEs, reso-certification `files` completeness.

Refs #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
