### PR TITLE
Phase 2: Trusted-Publishing workflows + fix cert's published XSD assets (#220)

### DIFF
--- a/.github/workflows/publish-odata-expression-parser.yml
+++ b/.github/workflows/publish-odata-expression-parser.yml
@@ -1,0 +1,52 @@
+name: Publish odata-expression-parser
+
+# Publishes @reso-standards/odata-expression-parser to npm via npm Trusted Publishing (GitHub OIDC — no token).
+# Trigger: push a tag `odata-expression-parser-v<version>` matching odata-expression-parser/package.json.
+# Deps: none (tier 0). Provenance is generated automatically (public repo + OIDC).
+on:
+  push:
+    tags:
+      - 'odata-expression-parser-v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC handshake for npm Trusted Publishing
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      # Trusted Publishing requires npm >= 11.5.1
+      - name: Ensure recent npm
+        run: npm install -g npm@latest
+
+      - name: Verify tag matches package version
+        if: github.ref_type == 'tag'
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#odata-expression-parser-v}"
+          PKG_VERSION="$(node -p "require('./odata-expression-parser/package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match odata-expression-parser/package.json ($PKG_VERSION)"
+            exit 1
+          fi
+
+      # Workspace-scoped install + build — pulls in only the target (and any @reso-standards
+      # deps), not the private/UI packages (electron, vite).
+      - name: Install and build
+        run: |
+          npm install -w @reso-standards/odata-expression-parser --include-workspace-root
+          npm run build -w @reso-standards/odata-expression-parser --if-present
+
+      - name: Test
+        run: npm test -w @reso-standards/odata-expression-parser
+
+      - name: Publish (Trusted Publishing / OIDC)
+        run: npm publish -w @reso-standards/odata-expression-parser --access public

--- a/.github/workflows/publish-reso-certification.yml
+++ b/.github/workflows/publish-reso-certification.yml
@@ -1,0 +1,69 @@
+name: Publish reso-certification
+
+# Publishes @reso-standards/reso-certification to npm via npm Trusted Publishing (GitHub OIDC — no token).
+# Trigger: push a tag `reso-certification-v<version>` matching reso-certification/package.json.
+# Deps (publish these FIRST): odata-expression-parser, reso-metadata-utils, reso-common,
+# reso-validation, reso-client. Publish LAST of the set (tier 2).
+# Provenance is generated automatically (public repo + OIDC).
+on:
+  push:
+    tags:
+      - 'reso-certification-v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC handshake for npm Trusted Publishing
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      # Trusted Publishing requires npm >= 11.5.1
+      - name: Ensure recent npm
+        run: npm install -g npm@latest
+
+      - name: Verify tag matches package version
+        if: github.ref_type == 'tag'
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#reso-certification-v}"
+          PKG_VERSION="$(node -p "require('./reso-certification/package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match reso-certification/package.json ($PKG_VERSION)"
+            exit 1
+          fi
+
+      # Workspace-scoped install + build: the target and its @reso-standards deps, in
+      # topological order — not the private/UI packages (electron, vite). reso-certification's
+      # own build copies src/legacy + src/etl into dist (see its package.json build script).
+      - name: Install and build (target + deps)
+        run: |
+          npm install \
+            -w @reso-standards/odata-expression-parser \
+            -w @reso-standards/reso-metadata-utils \
+            -w @reso-standards/reso-common \
+            -w @reso-standards/reso-validation \
+            -w @reso-standards/reso-client \
+            -w @reso-standards/reso-certification \
+            --include-workspace-root
+          npm run build \
+            -w @reso-standards/odata-expression-parser \
+            -w @reso-standards/reso-metadata-utils \
+            -w @reso-standards/reso-common \
+            -w @reso-standards/reso-validation \
+            -w @reso-standards/reso-client \
+            -w @reso-standards/reso-certification \
+            --if-present
+
+      - name: Test
+        run: npm test -w @reso-standards/reso-certification
+
+      - name: Publish (Trusted Publishing / OIDC)
+        run: npm publish -w @reso-standards/reso-certification --access public

--- a/.github/workflows/publish-reso-client.yml
+++ b/.github/workflows/publish-reso-client.yml
@@ -1,0 +1,61 @@
+name: Publish reso-client
+
+# Publishes @reso-standards/reso-client to npm via npm Trusted Publishing (GitHub OIDC — no token).
+# Trigger: push a tag `reso-client-v<version>` matching reso-client/package.json.
+# Deps (publish these FIRST): odata-expression-parser, reso-metadata-utils.
+# Provenance is generated automatically (public repo + OIDC).
+on:
+  push:
+    tags:
+      - 'reso-client-v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC handshake for npm Trusted Publishing
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      # Trusted Publishing requires npm >= 11.5.1
+      - name: Ensure recent npm
+        run: npm install -g npm@latest
+
+      - name: Verify tag matches package version
+        if: github.ref_type == 'tag'
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#reso-client-v}"
+          PKG_VERSION="$(node -p "require('./reso-client/package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match reso-client/package.json ($PKG_VERSION)"
+            exit 1
+          fi
+
+      # Workspace-scoped install + build: the target and its @reso-standards deps, in
+      # topological order — not the private/UI packages (electron, vite).
+      - name: Install and build (target + deps)
+        run: |
+          npm install \
+            -w @reso-standards/odata-expression-parser \
+            -w @reso-standards/reso-metadata-utils \
+            -w @reso-standards/reso-client \
+            --include-workspace-root
+          npm run build \
+            -w @reso-standards/odata-expression-parser \
+            -w @reso-standards/reso-metadata-utils \
+            -w @reso-standards/reso-client \
+            --if-present
+
+      - name: Test
+        run: npm test -w @reso-standards/reso-client
+
+      - name: Publish (Trusted Publishing / OIDC)
+        run: npm publish -w @reso-standards/reso-client --access public

--- a/.github/workflows/publish-reso-metadata-utils.yml
+++ b/.github/workflows/publish-reso-metadata-utils.yml
@@ -1,0 +1,52 @@
+name: Publish reso-metadata-utils
+
+# Publishes @reso-standards/reso-metadata-utils to npm via npm Trusted Publishing (GitHub OIDC — no token).
+# Trigger: push a tag `reso-metadata-utils-v<version>` matching reso-metadata-utils/package.json.
+# Deps: none (tier 0). Provenance is generated automatically (public repo + OIDC).
+on:
+  push:
+    tags:
+      - 'reso-metadata-utils-v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC handshake for npm Trusted Publishing
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      # Trusted Publishing requires npm >= 11.5.1
+      - name: Ensure recent npm
+        run: npm install -g npm@latest
+
+      - name: Verify tag matches package version
+        if: github.ref_type == 'tag'
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#reso-metadata-utils-v}"
+          PKG_VERSION="$(node -p "require('./reso-metadata-utils/package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match reso-metadata-utils/package.json ($PKG_VERSION)"
+            exit 1
+          fi
+
+      # Workspace-scoped install + build — pulls in only the target (and any @reso-standards
+      # deps), not the private/UI packages (electron, vite).
+      - name: Install and build
+        run: |
+          npm install -w @reso-standards/reso-metadata-utils --include-workspace-root
+          npm run build -w @reso-standards/reso-metadata-utils --if-present
+
+      - name: Test
+        run: npm test -w @reso-standards/reso-metadata-utils
+
+      - name: Publish (Trusted Publishing / OIDC)
+        run: npm publish -w @reso-standards/reso-metadata-utils --access public

--- a/.github/workflows/publish-reso-reference-server.yml
+++ b/.github/workflows/publish-reso-reference-server.yml
@@ -1,0 +1,63 @@
+name: Publish reso-reference-server
+
+# Publishes @reso-standards/reso-reference-server to npm via npm Trusted Publishing (GitHub OIDC — no token).
+# Trigger: push a tag `reso-reference-server-v<version>` matching reso-reference-server/package.json.
+# Deps (publish these FIRST): odata-expression-parser, reso-common, reso-validation.
+# Provenance is generated automatically (public repo + OIDC).
+on:
+  push:
+    tags:
+      - 'reso-reference-server-v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC handshake for npm Trusted Publishing
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      # Trusted Publishing requires npm >= 11.5.1
+      - name: Ensure recent npm
+        run: npm install -g npm@latest
+
+      - name: Verify tag matches package version
+        if: github.ref_type == 'tag'
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#reso-reference-server-v}"
+          PKG_VERSION="$(node -p "require('./reso-reference-server/package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match reso-reference-server/package.json ($PKG_VERSION)"
+            exit 1
+          fi
+
+      # Workspace-scoped install + build: the target and its @reso-standards deps, in
+      # topological order — not the private/UI packages (electron, vite).
+      - name: Install and build (target + deps)
+        run: |
+          npm install \
+            -w @reso-standards/odata-expression-parser \
+            -w @reso-standards/reso-common \
+            -w @reso-standards/reso-validation \
+            -w @reso-standards/reso-reference-server \
+            --include-workspace-root
+          npm run build \
+            -w @reso-standards/odata-expression-parser \
+            -w @reso-standards/reso-common \
+            -w @reso-standards/reso-validation \
+            -w @reso-standards/reso-reference-server \
+            --if-present
+
+      - name: Test
+        run: npm test -w @reso-standards/reso-reference-server
+
+      - name: Publish (Trusted Publishing / OIDC)
+        run: npm publish -w @reso-standards/reso-reference-server --access public

--- a/.github/workflows/publish-reso-validation.yml
+++ b/.github/workflows/publish-reso-validation.yml
@@ -1,0 +1,52 @@
+name: Publish reso-validation
+
+# Publishes @reso-standards/reso-validation to npm via npm Trusted Publishing (GitHub OIDC — no token).
+# Trigger: push a tag `reso-validation-v<version>` matching reso-validation/package.json.
+# Deps: none (tier 0). Provenance is generated automatically (public repo + OIDC).
+on:
+  push:
+    tags:
+      - 'reso-validation-v*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC handshake for npm Trusted Publishing
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      # Trusted Publishing requires npm >= 11.5.1
+      - name: Ensure recent npm
+        run: npm install -g npm@latest
+
+      - name: Verify tag matches package version
+        if: github.ref_type == 'tag'
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#reso-validation-v}"
+          PKG_VERSION="$(node -p "require('./reso-validation/package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag version ($TAG_VERSION) does not match reso-validation/package.json ($PKG_VERSION)"
+            exit 1
+          fi
+
+      # Workspace-scoped install + build — pulls in only the target (and any @reso-standards
+      # deps), not the private/UI packages (electron, vite).
+      - name: Install and build
+        run: |
+          npm install -w @reso-standards/reso-validation --include-workspace-root
+          npm run build -w @reso-standards/reso-validation --if-present
+
+      - name: Test
+        run: npm test -w @reso-standards/reso-validation
+
+      - name: Publish (Trusted Publishing / OIDC)
+        run: npm publish -w @reso-standards/reso-validation --access public

--- a/package-lock.json
+++ b/package-lock.json
@@ -7277,6 +7277,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/libxml2-wasm": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/libxml2-wasm/-/libxml2-wasm-0.7.1.tgz",
+      "integrity": "sha512-aZpJJL/j6T3D+5TmhG4D0ylR3mN6UzmqmBjyb/p+zEAaouG6GpfHiUNUzKR3vKCEoJt/Z2L15XPDCVPuFJIQhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/lightningcss": {
       "version": "1.32.0",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
@@ -11341,6 +11350,7 @@
         "fastest-levenshtein": "^1.0.16",
         "fs-extra": "^11.3.4",
         "humanize-duration": "^3.33.2",
+        "libxml2-wasm": "^0.7.1",
         "listr2": "^9.0.5",
         "yauzl": "^3.3.0"
       },

--- a/reso-certification/package.json
+++ b/reso-certification/package.json
@@ -24,7 +24,11 @@
     "reso-cert": "./dist/cli/index.js"
   },
   "files": [
-    "dist"
+    "dist",
+    "xsd",
+    "xsd-validator/index.js",
+    "xsd-validator/package.json",
+    "schema-validation-settings.json"
   ],
   "publishConfig": {
     "access": "public"
@@ -55,6 +59,7 @@
     "fastest-levenshtein": "^1.0.16",
     "fs-extra": "^11.3.4",
     "humanize-duration": "^3.33.2",
+    "libxml2-wasm": "^0.7.1",
     "listr2": "^9.0.5",
     "yauzl": "^3.3.0"
   },

--- a/reso-reference-server/package.json
+++ b/reso-reference-server/package.json
@@ -26,6 +26,7 @@
   ],
   "scripts": {
     "build": "tsc",
+    "prepublishOnly": "npm run build",
     "dev": "tsc --watch",
     "start": "node dist/index.js",
     "test": "vitest run",


### PR DESCRIPTION
Phase 2 of the v1.0.0 publish/split — per-package Trusted-Publishing workflows for the public packages, plus a fix to what reso-certification publishes.

## Trusted-Publishing workflows

Tag-triggered npm publish workflows for the six public packages that lacked one (reso-common's is the template):
`publish-{odata-expression-parser,reso-metadata-utils,reso-validation,reso-client,reso-reference-server,reso-certification}.yml`.

Each publishes via **npm Trusted Publishing** (GitHub OIDC — no token), gated on a tag `<pkg>-v<version>` matching the package's version, with `workflow_dispatch` as a manual fallback. Deps-having packages install + build their `@reso-standards` dep tree in **topological order** via workspace-scoped `-w` flags (target + deps only — *not* the private/UI packages), then test and `npm publish -w` the target.

**Validated locally end to end** (install → build → test → publish dry-run): odata (180), reso-client (96), reso-reference-server (258, ships `seed-data/`), reso-certification (562). All YAML clean. Also adds a `prepublishOnly` build to reso-reference-server (the only package that lacked one).

## Fix: reso-certification's published XSD + schema-validation assets

A latent bug surfaced while verifying the cert publish: the Phase-1 `files:["dist"]` trim excluded **runtime** assets cert's own SDK/CLI compliance path needs, so the published tarball would silently fail XSD validation and DD schema validation for every consumer (CLI, SDK, and the desktop's bundled cert worker).

- `src/xsd/validate-csdl.ts` (used by dd/core/add-edit/entity-event) dynamically imports `xsd-validator/index.js` from the package root → needs the `xsd/` schemas and `libxml2-wasm`.
- `src/sdk/dd.ts` copies `schema-validation-settings.json` from the package root; only `dist/legacy` carried a copy, which that code doesn't look at.

Fix: `libxml2-wasm` becomes a direct cert dependency (the isolated `xsd-validator` resolves it by walking up to cert's `node_modules` — verified by running the XSD tests with the validator's own `node_modules` removed), and `files` ships `xsd/`, `xsd-validator/index.js` + `package.json`, `schema-validation-settings.json`. The validator's nested `node_modules` is deliberately not shipped (non-deterministic across CI checkouts + redundant). Tarball: 817 kB, 0 node_modules files, ~13 kB over dist-only.

## Publish process (you trigger — nothing publishes until you push tags)

Order, deps first:
1. **Tier 0** — reso-common *(published)*, odata-expression-parser, reso-metadata-utils, reso-validation
2. **Tier 1** — reso-client, reso-reference-server
3. **Tier 2** — reso-certification

Per brand-new package (the reso-common flow): one-time manual `npm publish` to create it → configure Trusted Publishing on the npm page → tag-triggered thereafter (`git tag <pkg>-v<version> && git push origin <pkg>-v<version>`).

Refs #220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
