### PR TITLE
docs(ref-server): note package/SDK usage + link #238

### DIFF
--- a/reso-reference-server/README.md
+++ b/reso-reference-server/README.md
@@ -4,6 +4,8 @@ A metadata-driven OData 4.01 reference server for the [RESO Data Dictionary](htt
 
 > **[User Guide](doc/GUIDE.md)** – a task-oriented walkthrough with realistic examples.
 
+> **Use it as a package.** Also published to npm as `@reso-standards/reso-reference-server` — import `createApp`, `startServer` and `loadConfig` to embed a RESO OData server in your own Node process (handy for test harnesses). Running the server directly from the package (`npx`, no clone or Docker) is tracked in [#238](https://github.com/RESOStandards/reso-tools/issues/238).
+
 ## Quick Start (Docker)
 
 The server supports three database backends: **PostgreSQL** (default), **MongoDB**, and **SQLite**. Each has its own Docker Compose profile.


### PR DESCRIPTION
Adds a top-of-README callout to `reso-reference-server`: it's published to npm and usable as an **SDK** (`createApp`/`startServer`/`loadConfig` — handy for test harnesses), and the **runnable-from-package** path (`npx`, no clone or Docker) is tracked in #238.

Small, docs-only, independent of the stacked split/docker PRs (#236/#237).

🤖 Generated with [Claude Code](https://claude.com/claude-code)