### PR TITLE
chore(dd-reference): sync DD refs from transport after #227 (Field/Type single)

### DIFF
--- a/reso-certification/reference-metadata/dd-1.7.json
+++ b/reso-certification/reference-metadata/dd-1.7.json
@@ -1,7 +1,7 @@
 {
   "description": "RESO Data Dictionary 1.7 Reference Metadata",
   "version": "1.7",
-  "generatedOn": "2026-06-22T17:49:26.000Z",
+  "generatedOn": "2026-07-27T19:16:14.000Z",
   "resources": [
     "ContactListingNotes",
     "ContactListings",

--- a/reso-certification/reference-metadata/dd-2.0.json
+++ b/reso-certification/reference-metadata/dd-2.0.json
@@ -1,7 +1,7 @@
 {
   "description": "RESO Data Dictionary 2.0 Reference Metadata",
   "version": "2.0",
-  "generatedOn": "2026-06-22T17:49:26.000Z",
+  "generatedOn": "2026-07-27T19:16:14.000Z",
   "resources": [
     "Association",
     "Caravan",

--- a/reso-certification/reference-metadata/dd-2.1.json
+++ b/reso-certification/reference-metadata/dd-2.1.json
@@ -1,7 +1,7 @@
 {
   "description": "RESO Data Dictionary 2.1 Reference Metadata",
   "version": "2.1",
-  "generatedOn": "2026-06-22T17:49:26.000Z",
+  "generatedOn": "2026-07-27T19:16:14.000Z",
   "resources": [
     "Association",
     "Building",
@@ -30543,7 +30543,6 @@
         }
       ],
       "maxLength": 100,
-      "isCollection": true,
       "lookupStatus": "Open with Enumerations"
     },
     {

--- a/reso-common/reference-metadata/dd-1.7.json
+++ b/reso-common/reference-metadata/dd-1.7.json
@@ -1,7 +1,7 @@
 {
   "description": "RESO Data Dictionary 1.7 Reference Metadata",
   "version": "1.7",
-  "generatedOn": "2026-06-22T17:49:26.000Z",
+  "generatedOn": "2026-07-27T19:16:14.000Z",
   "resources": [
     "ContactListingNotes",
     "ContactListings",

--- a/reso-common/reference-metadata/dd-2.0.json
+++ b/reso-common/reference-metadata/dd-2.0.json
@@ -1,7 +1,7 @@
 {
   "description": "RESO Data Dictionary 2.0 Reference Metadata",
   "version": "2.0",
-  "generatedOn": "2026-06-22T17:49:26.000Z",
+  "generatedOn": "2026-07-27T19:16:14.000Z",
   "resources": [
     "Association",
     "Caravan",

--- a/reso-common/reference-metadata/dd-2.1.json
+++ b/reso-common/reference-metadata/dd-2.1.json
@@ -1,7 +1,7 @@
 {
   "description": "RESO Data Dictionary 2.1 Reference Metadata",
   "version": "2.1",
-  "generatedOn": "2026-06-22T17:49:26.000Z",
+  "generatedOn": "2026-07-27T19:16:14.000Z",
   "resources": [
     "Association",
     "Building",
@@ -30543,7 +30543,6 @@
         }
       ],
       "maxLength": 100,
-      "isCollection": true,
       "lookupStatus": "Open with Enumerations"
     },
     {


### PR DESCRIPTION
## Summary

Syncs the reso-tools DD reference metadata from transport `main` via `npm run update:dd-reference`, following the merge of RESOStandards/transport#227.

The only **data** change is `Field/Type` in DD 2.1: it drops `isCollection` and now resolves to a single `org.reso.metadata.enums.FieldDataTypes` enum rather than `Collection(FieldDataTypes)`. A field has exactly one transport data type; `FieldDataTypes` values are mutually exclusive primitives and collection cardinality is modeled separately by `Field/CollectionYN` (see transport RESOStandards/reso-tools#225 / RESOStandards/reso-tools-private#52).

The remaining diffs across `dd-1.7.json` / `dd-2.0.json` / `dd-2.1.json` (both the reso-common source and the reso-certification synced copy) are the shared `generatedOn` timestamp from transport's regeneration build – no other field, lookup, or count changed.

## Verification

- Per-file diff confirmed: the only non-`generatedOn` change is `- "isCollection": true` on `Field` / `Type` in the two dd-2.1 copies; 1.7 and 2.0 are `generatedOn`-only.
- `npm run test:certification`: full suite green against the refreshed refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
