### PR TITLE
external tickets: Windows path fix (#175) + ref-server README reconciliation (#163)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This installs dependencies and builds all 8 packages in the correct order. Takes
 cd reso-reference-server
 docker compose up -d
 docker compose --profile seed up seed
-# Server: http://localhost:8080  UI: http://localhost:5173
+# Server: http://localhost:8080
 ```
 
 ### Desktop Certification App

--- a/reso-certification/src/sdk/dd.ts
+++ b/reso-certification/src/sdk/dd.ts
@@ -9,6 +9,7 @@
 import { writeFile, copyFile, readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { resolveAuthToken } from '../test-runner/auth.js';
 import { fetchMetadataWithVersion, persistMetadataXml } from '../test-runner/metadata.js';
 import { generateMetadataReport } from '@reso-standards/reso-metadata-utils';
@@ -385,7 +386,7 @@ const initReplicationState: TestFunction<DDContext> = async (ctx) => {
   if (!ctx.replicationStateService) {
     const settingsFile = 'schema-validation-settings.json';
     if (!existsSync(settingsFile)) {
-      const packageRoot = join(dirname(new URL(import.meta.url).pathname), '..', '..');
+      const packageRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
       const sourcePaths = [
         join(packageRoot, settingsFile),
         join(packageRoot, 'src', 'legacy', settingsFile),

--- a/reso-reference-server/README.md
+++ b/reso-reference-server/README.md
@@ -18,7 +18,6 @@ docker compose up -d
 ```
 
 This starts:
-- **UI** at `http://localhost:5173` (React SPA with nginx reverse proxy)
 - **Server** at `http://localhost:8080` (OData API, `DB_BACKEND=postgres`)
 - **PostgreSQL** at `localhost:5432`
 
@@ -32,11 +31,10 @@ docker compose --profile seed up seed
 
 ```bash
 cd reso-reference-server
-docker compose --profile mongodb up -d mongodb server-mongo ui-mongo
+docker compose --profile mongodb up -d mongodb server-mongo
 ```
 
 This starts:
-- **UI** at `http://localhost:5173`
 - **Server** at `http://localhost:8080` (OData API, `DB_BACKEND=mongodb`)
 - **MongoDB** at `localhost:27017`
 
@@ -50,11 +48,10 @@ docker compose --profile seed-mongo up seed-mongo
 
 ```bash
 cd reso-reference-server
-docker compose --profile sqlite up -d server-sqlite ui-sqlite
+docker compose --profile sqlite up -d server-sqlite
 ```
 
 This starts:
-- **UI** at `http://localhost:5173`
 - **Server** at `http://localhost:8080` (OData API, `DB_BACKEND=sqlite`)
 - No external database – SQLite file stored in a Docker volume
 
@@ -77,11 +74,11 @@ docker compose up -d
 docker compose --profile seed up seed
 
 # – or start with MongoDB – 
-docker compose --profile mongodb up -d mongodb server-mongo ui-mongo
+docker compose --profile mongodb up -d mongodb server-mongo
 docker compose --profile mongodb --profile seed-mongo up seed-mongo
 
 # – or start with SQLite – 
-docker compose --profile sqlite up -d server-sqlite ui-sqlite
+docker compose --profile sqlite up -d server-sqlite
 docker compose --profile sqlite --profile seed-sqlite up seed-sqlite
 ```
 
@@ -93,9 +90,6 @@ curl http://localhost:8080/health
 
 # OData metadata
 curl http://localhost:8080/\$metadata
-
-# Browse the UI
-open http://localhost:5173
 
 # Query Property records via the API
 curl -H 'Accept: application/json' 'http://localhost:8080/Property?\$top=5&\$select=ListPrice,City,StateOrProvince'
@@ -220,7 +214,7 @@ docker compose --profile seed up --exit-code-from seed
 docker compose --profile compliance-core up --build --exit-code-from compliance-core
 
 # MongoDB
-docker compose --profile mongodb up -d --build --wait mongodb server-mongo ui-mongo
+docker compose --profile mongodb up -d --build --wait mongodb server-mongo
 docker compose --profile mongodb --profile seed-mongo up seed-mongo
 docker compose --profile compliance-core-mongo up --build --exit-code-from compliance-core-mongo
 


### PR DESCRIPTION
## Summary

Two small public fixes from the external-ticket triage, off `v1.0.0-pre`.

## #175 — Windows package-root resolution (`reso-certification`)

`dd.ts` resolved its package root via `new URL(import.meta.url).pathname`, which produces a `/C:/…` string on Windows and breaks resolution of `schema-validation-settings.json` (the reporter's ESM-loader / "outside results root" error). Switched to `fileURLToPath` for a correct native path on all platforms.

## #163 — Reference-server README reconciliation

Post-split, the browser UI moved to the private repo and the `ui`/`ui-mongo`/`ui-sqlite` docker services were removed, but the READMEs still advertised a UI at `localhost:5173` and named the removed services in docker commands that would now fail. Removed the stale UI references and service names across the root and reference-server READMEs so the documented setup matches the public OData-API-only server.

## Testing

Full `precommit` green.
