### PR TITLE
fix(cert): Core F1 — ground now() timestamp scenarios on ModificationTimestamp

### DIFF
--- a/reso-certification/src/web-api-core/sampling.ts
+++ b/reso-certification/src/web-api-core/sampling.ts
@@ -140,6 +140,11 @@ const DECIMAL_TYPES = ['Edm.Decimal', 'Edm.Double'];
 const DATE_TYPES = ['Edm.Date'];
 const DATETIME_TYPES = ['Edm.DateTimeOffset'];
 
+// The RESO-required modification timestamp — always <= now, so the safe field to ground the `lt/le now()`
+// scenarios on. Fields ending in this suffix are system modification/event timestamps (likewise always past).
+const MODIFICATION_TIMESTAMP_FIELD = 'ModificationTimestamp';
+const TIMESTAMP_FIELD_SUFFIX = 'Timestamp';
+
 const isIntegerType = (type: string): boolean => INTEGER_TYPES.includes(type);
 const isDecimalType = (type: string): boolean => DECIMAL_TYPES.includes(type);
 const isDateType = (type: string): boolean => DATE_TYPES.includes(type);
@@ -260,14 +265,15 @@ export const selectTimestampField = (
   datetimeFields: ReadonlyArray<string>,
   records: ReadonlyArray<Record<string, unknown>>,
 ): string | undefined => {
-  const isStandardTimestamp = (f: string): boolean => f.endsWith('Timestamp');
+  const isPopulated = (f: string): boolean => records.some(r => r[f] != null);
+  const isStandardTimestamp = (f: string): boolean => f.endsWith(TIMESTAMP_FIELD_SUFFIX);
   return (
-    (datetimeFields.includes('ModificationTimestamp') && records.some(r => r['ModificationTimestamp'] != null)
-      ? 'ModificationTimestamp'
+    (datetimeFields.includes(MODIFICATION_TIMESTAMP_FIELD) && isPopulated(MODIFICATION_TIMESTAMP_FIELD)
+      ? MODIFICATION_TIMESTAMP_FIELD
       : undefined)
-    ?? datetimeFields.filter(isStandardTimestamp).find(f => records.some(r => r[f] != null))
+    ?? datetimeFields.filter(isStandardTimestamp).find(isPopulated)
     ?? findFullyPopulatedTimestamp(datetimeFields, records)
-    ?? datetimeFields.find(f => records.some(r => r[f] != null))
+    ?? datetimeFields.find(isPopulated)
   );
 };
 

--- a/reso-certification/src/web-api-core/sampling.ts
+++ b/reso-certification/src/web-api-core/sampling.ts
@@ -251,6 +251,26 @@ const findFullyPopulatedTimestamp = (
   return undefined;
 };
 
+/** Choose the field for the timestamp scenarios. The `lt/le now()` scenarios need a field guaranteed to be
+ *  <= now, or a future-dated datetime (OpenHouse start times, Showing appointments) legitimately returns empty
+ *  for `lt now()` and would false-fail a compliant server. Prefer ModificationTimestamp (RESO-required, always
+ *  past); else another standard `*Timestamp` field (system modification/event timestamps, likewise always past);
+ *  else a generic populated datetime (last resort — a resource with no timestamp field is a DD-gate failure). */
+export const selectTimestampField = (
+  datetimeFields: ReadonlyArray<string>,
+  records: ReadonlyArray<Record<string, unknown>>,
+): string | undefined => {
+  const isStandardTimestamp = (f: string): boolean => f.endsWith('Timestamp');
+  return (
+    (datetimeFields.includes('ModificationTimestamp') && records.some(r => r['ModificationTimestamp'] != null)
+      ? 'ModificationTimestamp'
+      : undefined)
+    ?? datetimeFields.filter(isStandardTimestamp).find(f => records.some(r => r[f] != null))
+    ?? findFullyPopulatedTimestamp(datetimeFields, records)
+    ?? datetimeFields.find(f => records.some(r => r[f] != null))
+  );
+};
+
 // ── Main resolver ──
 
 /**
@@ -337,9 +357,7 @@ export const resolveTestParams = async (
 
   // Resolve timestamp field + value (prefer fully populated for orderby). datetimeValue = sampled MIN (feeds
   // gt/ge); the previous first-seen value was the global MAX under a `…DESC` default sort → `gt max` false-fail.
-  const timestampField = findFullyPopulatedTimestamp(datetimeFields, records)
-    ?? datetimeFields.find(f => records.some(r => r[f] != null))
-    ?? (datetimeFields.includes('ModificationTimestamp') ? 'ModificationTimestamp' : undefined);
+  const timestampField = selectTimestampField(datetimeFields, records);
   const tsStats = timestampField ? timestampStats(collectValues(records, timestampField)) : undefined;
   const datetimeValue = tsStats?.min;
   const datetimeDistinctCount = tsStats?.distinct;

--- a/reso-certification/tests/web-api-core-empty-verdict.test.ts
+++ b/reso-certification/tests/web-api-core-empty-verdict.test.ts
@@ -51,8 +51,9 @@ describe('emptyVerdict — legitimately-empty operators skip', () => {
   it('enum has A and has B (two values) → skip', () => {
     expect(emptyVerdict(enumS('has', { valueParam2: 'multiLookupValue2' }), NONE)).toBe('skip');
   });
-  it('compound filter (gt X and lt Y) → skip (two conditions, legitimately often empty)', () => {
+  it('compound filter (gt X and/or lt Y) → skip (two conditions, legitimately often empty)', () => {
     expect(emptyVerdict(filter('gt', { compound: { op2: 'lt', valueParam2: 'integerValueHigh', logical: 'and' } }), NONE)).toBe('skip');
+    expect(emptyVerdict(filter('gt', { compound: { op2: 'lt', valueParam2: 'integerValueHigh', logical: 'or' } }), NONE)).toBe('skip'); // same branch — keys on scenario.compound, not the connector
   });
   it('non-filter scenarios (structural, etc.) → skip', () => {
     expect(emptyVerdict(structural(), NONE)).toBe('skip');

--- a/reso-certification/tests/web-api-core-sampling.test.ts
+++ b/reso-certification/tests/web-api-core-sampling.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { dateStats, integerNotSentinelFor, isSampleComplete, numericStats } from '../src/web-api-core/sampling.js';
+import { dateStats, integerNotSentinelFor, isSampleComplete, numericStats, selectTimestampField } from '../src/web-api-core/sampling.js';
 
 // The `ne` empty-verdict may only rule "empty is correct / pass" when the sample WAS the whole resource.
 // Core 2.1.0 signals "more results exist" with a forward @odata.nextLink, so its absence is our completeness proof.
@@ -73,5 +73,40 @@ describe('dateStats — chronological min / max and date-only dedup', () => {
     expect(s.min).toBe('2024-01-01');
     expect(s.max).toBe('2024-12-31');
     expect(s.distinct).toBe(3); // 2024-01-01, 2024-06-15 (both forms collapse), 2024-12-31
+  });
+});
+
+describe('selectTimestampField — grounds the now() scenarios on an always-<=-now field (F1)', () => {
+  it('prefers ModificationTimestamp even when a future-dated datetime is populated first', () => {
+    // OpenHouse-style: a future-dated field leads the datetime list; picking it would false-fail `lt now()`.
+    const datetimeFields = ['OpenHouseStartTime', 'OpenHouseEndTime', 'ModificationTimestamp'];
+    const records = [
+      { OpenHouseStartTime: '2099-06-01T10:00:00Z', OpenHouseEndTime: '2099-06-01T12:00:00Z', ModificationTimestamp: '2026-01-01T00:00:00Z' },
+      { OpenHouseStartTime: '2099-07-01T10:00:00Z', OpenHouseEndTime: '2099-07-01T12:00:00Z', ModificationTimestamp: '2026-02-01T00:00:00Z' },
+    ];
+    expect(selectTimestampField(datetimeFields, records)).toBe('ModificationTimestamp');
+  });
+
+  it('falls back to another standard *Timestamp field when ModificationTimestamp is absent', () => {
+    // ShowingStartTime is future-dated (ends in "Time", not "Timestamp") → excluded; OriginalEntryTimestamp wins.
+    const datetimeFields = ['ShowingStartTime', 'OriginalEntryTimestamp'];
+    const records = [{ ShowingStartTime: '2099-06-01T10:00:00Z', OriginalEntryTimestamp: '2026-01-01T00:00:00Z' }];
+    expect(selectTimestampField(datetimeFields, records)).toBe('OriginalEntryTimestamp');
+  });
+
+  it('falls back to another *Timestamp when ModificationTimestamp is present but unpopulated', () => {
+    const datetimeFields = ['ModificationTimestamp', 'PhotosChangeTimestamp'];
+    const records = [{ ModificationTimestamp: null, PhotosChangeTimestamp: '2026-01-01T00:00:00Z' }];
+    expect(selectTimestampField(datetimeFields, records)).toBe('PhotosChangeTimestamp');
+  });
+
+  it('last resort: a generic populated datetime when the resource has no *Timestamp field', () => {
+    const datetimeFields = ['SomeLocalDateTime'];
+    const records = [{ SomeLocalDateTime: '2026-01-01T00:00:00Z' }];
+    expect(selectTimestampField(datetimeFields, records)).toBe('SomeLocalDateTime');
+  });
+
+  it('returns undefined when no datetime field is populated', () => {
+    expect(selectTimestampField(['ModificationTimestamp'], [{ ModificationTimestamp: null }])).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Core F1 — `lt/le now()` false-fail on future-dated timestamp fields

### The bug (live in `v1.0.0-pre`)

The Web API Core `lt/le/ne now()` timestamp scenarios run on `timestampField`, which `sampling.ts` resolved as *the first fully-populated datetime field*, with `ModificationTimestamp` only as a last-resort fallback:

```js
const timestampField = findFullyPopulatedTimestamp(datetimeFields, records)   // first fully-populated *any* datetime
  ?? datetimeFields.find(f => records.some(r => r[f] != null))
  ?? (datetimeFields.includes('ModificationTimestamp') ? 'ModificationTimestamp' : undefined);
```

On a resource like **OpenHouse** or **Showing**, that can pick a **future-dated** field (upcoming start/end times). `field lt now()` then legitimately returns **empty** (no past records), and `emptyVerdict` — which correctly treats a guaranteed-match empty as a defect — **fails a compliant server**.

`ModificationTimestamp` is RESO-required and always `<= now`, so it's the field these scenarios were meant to use. The verdict logic was fine; the field selection wasn't grounded.

### The fix

Extract `selectTimestampField` (exported, pure) and ground it:

1. **`ModificationTimestamp`** if present + populated (required, always `<= now`).
2. else another standard **`*Timestamp`** field (system modification/event timestamps, also always past).
3. else a generic populated datetime (last resort — a resource with no timestamp field is already a DD-gate failure).

`empty-verdict.ts` is **unchanged** — its `now() → fail` is correct once the field is guaranteed past.

### Tests

5 regression tests for `selectTimestampField`, including the headline case: a future-dated field leading the datetime list still resolves to `ModificationTimestamp`.

Full precommit green.
