### PR TITLE
feat(cert): `reso-cert schema` CLI command (validate / generate)

### DIFF
--- a/reso-certification/src/cli/index.ts
+++ b/reso-certification/src/cli/index.ts
@@ -17,7 +17,7 @@
 // like RESO_SERVICES_URL populated when they destructure process.env.
 import './env-bootstrap.js';
 
-import { readFile, writeFile } from 'node:fs/promises';
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { Command } from 'commander';
 import { synthesizeResourcesFromFields } from '../metadata/index.js';
@@ -28,6 +28,7 @@ import { loadConfigFile, configEntryToAddEdit, configEntryToEntityEvent } from '
 import type { AddEditConfig, EntityEventConfig, CoreConfig, DDConfig, PipelineResult } from '../sdk/types.js';
 import { resolveCliAuth, mintOAuth2ClientCredentialsToken } from './auth.js';
 import { computeVariationsViaService, updateVariationsViaService, parseVariationsCsv } from '../variations/index.js';
+import { validateSchemaPayload, generateSchemaFromReport, loadSettings } from './schema-command.js';
 import { CURRENT_DD_VERSION, CERTIFIABLE_DD_VERSIONS, isCertifiableDDVersion, normalizeDDVersion } from '../sdk/dd-versions.js';
 import { resolveRenderMode, runWithProgress, runConfigEntries } from './render.js';
 
@@ -750,6 +751,89 @@ metadataReportCmd
       );
     } catch (error) {
       console.error('Error:', error instanceof Error ? error.message : String(error));
+      process.exitCode = 2;
+    }
+  });
+
+// ── Schema Subcommand (per-step util: generate a JSON Schema / validate a payload against it) ──
+
+/** Read a JSON value from a file path, or from stdin when the path is "-". */
+const readJsonInput = async (path: string): Promise<unknown> => {
+  if (path === '-') {
+    const chunks: Buffer[] = [];
+    for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+    return JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+  }
+  return JSON.parse(await readFile(resolve(path), 'utf-8'));
+};
+
+/** Write a JSON artifact to stdout when outputDir is "-", else to <outputDir>/<filename> (created if missing). */
+const writeArtifact = async (outputDir: string, filename: string, data: unknown): Promise<string> => {
+  const json = JSON.stringify(data, null, 2);
+  if (outputDir === '-') {
+    process.stdout.write(`${json}\n`);
+    return '(stdout)';
+  }
+  const dir = resolve(outputDir);
+  await mkdir(dir, { recursive: true });
+  const file = resolve(dir, filename);
+  await writeFile(file, json);
+  return file;
+};
+
+const schemaCmd = program.command('schema').description('Data Dictionary / RESO Common Format JSON Schema tools');
+
+schemaCmd
+  .command('validate')
+  .description("Validate a payload against a metadata report's JSON Schema")
+  .requiredOption('-m, --metadata <file>', 'Metadata report JSON (metadata-report.json), or "-" for stdin')
+  .requiredOption('-p, --payload <file>', 'Payload JSON — an OData collection { value: [...] } or a single record, or "-" for stdin')
+  .option('-v, --version <version>', 'DD version for the schema context (e.g. 2.0)')
+  .option('-r, --resource <name>', 'Resource name (else inferred from the payload @odata.context)')
+  .option('-s, --settings <file>', 'schema-validation-settings.json (else ./ then the pre-baked copy)')
+  .option('-a, --additional-properties', 'Allow fields not present in the metadata (default: reject them)')
+  .option('--output-dir <path>', 'Directory for the report (created if missing); "-" for stdout', '.')
+  .action(async (opts: { metadata: string; payload: string; version?: string; resource?: string; settings?: string; additionalProperties?: boolean; outputDir: string }) => {
+    try {
+      const validationConfig = await loadSettings(opts.settings);
+      const metadataReportJson = await readJsonInput(opts.metadata);
+      const jsonPayload = await readJsonInput(opts.payload);
+      const { totalErrors, report } = await validateSchemaPayload({
+        metadataReportJson,
+        jsonPayload,
+        resourceName: opts.resource,
+        version: opts.version,
+        validationConfig,
+        additionalProperties: opts.additionalProperties,
+      });
+      const dest = await writeArtifact(opts.outputDir, 'schema-validation-report.json', report);
+      process.stderr.write(
+        totalErrors === 0
+          ? `PASS — 0 schema validation errors (report: ${dest})\n`
+          : `FAIL — ${totalErrors} schema validation error(s) (report: ${dest})\n`
+      );
+      process.exitCode = totalErrors > 0 ? 1 : 0;
+    } catch (err) {
+      process.stderr.write(`schema validate: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exitCode = 2;
+    }
+  });
+
+schemaCmd
+  .command('generate')
+  .description('Generate a JSON Schema from a metadata report')
+  .requiredOption('-m, --metadata <file>', 'Metadata report JSON, or "-" for stdin')
+  .option('-a, --additional-properties', 'Allow fields not present in the metadata')
+  .option('--output-dir <path>', 'Directory for the schema (created if missing); "-" for stdout', '.')
+  .action(async (opts: { metadata: string; additionalProperties?: boolean; outputDir: string }) => {
+    try {
+      const metadataReportJson = await readJsonInput(opts.metadata);
+      const schema = await generateSchemaFromReport({ metadataReportJson, additionalProperties: opts.additionalProperties });
+      const dest = await writeArtifact(opts.outputDir, 'schema.json', schema);
+      process.stderr.write(`Schema generated (${dest})\n`);
+      process.exitCode = 0;
+    } catch (err) {
+      process.stderr.write(`schema generate: ${err instanceof Error ? err.message : String(err)}\n`);
       process.exitCode = 2;
     }
   });

--- a/reso-certification/src/cli/schema-command.ts
+++ b/reso-certification/src/cli/schema-command.ts
@@ -1,0 +1,114 @@
+/**
+ * Testable core for the `reso-cert schema` command (validate / generate).
+ *
+ * Wraps the carried JSON-schema validator (`src/legacy/lib/schema`) — `generateJsonSchema`, `validate`,
+ * `combineErrors` — and resolves the schema-validation-settings (exemptions) so the CLI verdict matches the
+ * in-run cert verdict. IO, output routing and exit codes live in the command action (index.ts); this module is
+ * pure over its inputs so it can be unit-tested without a process.
+ */
+
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const requireLegacy = createRequire(import.meta.url);
+
+const SETTINGS_FILE = 'schema-validation-settings.json';
+
+interface SchemaModule {
+  readonly generateJsonSchema: (opts: { metadataReportJson: unknown; additionalProperties?: boolean }) => Promise<unknown>;
+  readonly validate: (opts: {
+    readonly jsonSchema: unknown;
+    readonly jsonPayload: unknown;
+    readonly resourceName?: string;
+    readonly version?: string;
+    readonly validationConfig?: unknown;
+    readonly isResoDataDictionarySchema?: boolean;
+    readonly errorMap?: Record<string, unknown>;
+  }) => Record<string, unknown>;
+  readonly combineErrors: (errorMap: Record<string, unknown>) => { readonly totalErrors?: number; readonly [k: string]: unknown };
+}
+
+const isSchemaModule = (m: unknown): m is SchemaModule =>
+  typeof m === 'object' &&
+  m !== null &&
+  typeof (m as Record<string, unknown>).generateJsonSchema === 'function' &&
+  typeof (m as Record<string, unknown>).validate === 'function' &&
+  typeof (m as Record<string, unknown>).combineErrors === 'function';
+
+const loadSchemaModule = (): SchemaModule => {
+  const raw: unknown = requireLegacy(resolve(dirname(fileURLToPath(import.meta.url)), '../legacy/lib/schema/index.js'));
+  if (!isSchemaModule(raw)) {
+    throw new Error('Failed to load the schema module — expected generateJsonSchema / validate / combineErrors exports.');
+  }
+  return raw;
+};
+
+/**
+ * Resolve the schema-validation-settings file. Precedence: an explicit path, then one in the current run
+ * directory, then the pre-baked copy shipped at the package root. `import.meta.url` lands in `src/cli/` (dev)
+ * or `dist/cli/` (packaged) — both two levels below the package root — so the pre-baked path is the same for
+ * each. `fileURLToPath` (not `new URL().pathname`) keeps it correct on Windows (cf. #175).
+ */
+export const resolveSettingsPath = (explicit?: string): string | undefined => {
+  if (explicit) return resolve(explicit);
+  const cwdSettings = resolve(process.cwd(), SETTINGS_FILE);
+  if (existsSync(cwdSettings)) return cwdSettings;
+  const prebaked = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', SETTINGS_FILE);
+  return existsSync(prebaked) ? prebaked : undefined;
+};
+
+/** Load the exemptions/validation config from a resolved settings path; `{}` (no exemptions) when absent. */
+export const loadSettings = async (settingsPath?: string): Promise<Record<string, unknown>> => {
+  const path = resolveSettingsPath(settingsPath);
+  if (!path) return {};
+  return JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
+};
+
+export interface SchemaValidationResult {
+  readonly totalErrors: number;
+  readonly report: Record<string, unknown>;
+}
+
+/**
+ * Generate a JSON Schema from a metadata report and validate a payload against it. `validate` infers the
+ * resource/version from the payload's `@odata.context` when `resourceName`/`version` are omitted, applies the
+ * exemptions in `validationConfig`, and handles both a collection (`{ value: [...] }`) and a single record.
+ */
+export const validateSchemaPayload = async (opts: {
+  readonly metadataReportJson: unknown;
+  readonly jsonPayload: unknown;
+  readonly resourceName?: string;
+  readonly version?: string;
+  readonly validationConfig?: unknown;
+  readonly additionalProperties?: boolean;
+}): Promise<SchemaValidationResult> => {
+  const mod = loadSchemaModule();
+  const jsonSchema = await mod.generateJsonSchema({
+    metadataReportJson: opts.metadataReportJson,
+    additionalProperties: opts.additionalProperties ?? false,
+  });
+  // A single generated schema (not a version Map), so `isResoDataDictionarySchema` stays false (validate's default).
+  const errorMap = mod.validate({
+    jsonSchema,
+    jsonPayload: opts.jsonPayload,
+    resourceName: opts.resourceName,
+    version: opts.version,
+    validationConfig: opts.validationConfig ?? {},
+    errorMap: {},
+  });
+  const combined = mod.combineErrors(errorMap);
+  return { totalErrors: combined.totalErrors ?? 0, report: combined };
+};
+
+/** Generate a JSON Schema from a metadata report (the `schema generate` verb). */
+export const generateSchemaFromReport = async (opts: {
+  readonly metadataReportJson: unknown;
+  readonly additionalProperties?: boolean;
+}): Promise<unknown> =>
+  loadSchemaModule().generateJsonSchema({
+    metadataReportJson: opts.metadataReportJson,
+    additionalProperties: opts.additionalProperties ?? false,
+  });

--- a/reso-certification/tests/cli-schema-command.test.ts
+++ b/reso-certification/tests/cli-schema-command.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { basename, resolve } from 'node:path';
+import { createRequire } from 'node:module';
+import { validateSchemaPayload, resolveSettingsPath, loadSettings } from '../src/cli/schema-command.js';
+
+const require = createRequire(import.meta.url);
+const { getReferenceMetadata } = require(resolve(import.meta.dirname, '../src/etl/index.cjs'));
+const { valuePayload, enumMismatchPayload } = require(resolve(import.meta.dirname, './legacy/fixtures/payload-samples.cjs'));
+
+// A conforming provider advertises the Open-lookup values it serves; the valid sample payloads carry a City
+// value, so advertise it (same setup as the ported schema-validation suite) — otherwise City is an incidental
+// unadvertised error and the "valid" case would report > 0.
+const CITY = 'org.reso.metadata.enums.City';
+const advertise = (meta: { lookups: unknown[] }, entries: ReadonlyArray<readonly [string, string]>) => ({
+  ...meta,
+  lookups: [...meta.lookups, ...entries.map(([lookupName, lookupValue]) => ({ lookupName, lookupValue, type: 'Edm.String' }))],
+});
+const metadata = advertise(getReferenceMetadata('2.0'), [[CITY, 'SampleCityEnumValue']]);
+
+describe('validateSchemaPayload — the schema command verdict core', () => {
+  it('a conforming payload → 0 errors (exit 0)', async () => {
+    const { totalErrors } = await validateSchemaPayload({
+      metadataReportJson: metadata,
+      jsonPayload: valuePayload,
+      resourceName: 'Property',
+      version: '2.0',
+    });
+    expect(totalErrors).toBe(0);
+  });
+
+  it('an unadvertised enum value → > 0 errors (exit 1 — the verdict the CLI reflects)', async () => {
+    const { totalErrors, report } = await validateSchemaPayload({
+      metadataReportJson: metadata,
+      jsonPayload: enumMismatchPayload,
+      resourceName: 'Property',
+      version: '2.0',
+    });
+    expect(totalErrors).toBeGreaterThan(0);
+    expect(report).toBeDefined();
+  });
+});
+
+describe('resolveSettingsPath — explicit → CWD → pre-baked precedence', () => {
+  it('honors an explicit path', () => {
+    expect(resolveSettingsPath('/tmp/my-settings.json')).toBe(resolve('/tmp/my-settings.json'));
+  });
+
+  it('falls back to the pre-baked package settings when nothing else is given', () => {
+    const p = resolveSettingsPath();
+    expect(p).toBeDefined();
+    expect(basename(p as string)).toBe('schema-validation-settings.json');
+  });
+});
+
+describe('loadSettings — the exemptions config', () => {
+  it('loads the pre-baked settings (carries the 2.0 and 2.1 stanzas)', async () => {
+    const cfg = await loadSettings();
+    expect(Object.keys(cfg)).toEqual(expect.arrayContaining(['2.0', '2.1']));
+  });
+});


### PR DESCRIPTION
First deliverable of the per-step cert CLI epic (#251). Vendors have hooked into each cert step and run it independently in their CI, so v1.0.0 needs CLI parity for every step — the CLI is a first-class testing citizen.

## What
- **`reso-cert schema validate`** — generate a JSON Schema from a metadata report and validate a payload against it. Exit `0` pass / `1` verdict failure / `2` IO error.
- **`reso-cert schema generate`** — emit the generated JSON Schema.

## Interface (per the epic contract)
- Metadata report and payload come from a **file path or stdin (`-`)**.
- Output goes to `--output-dir` (created if missing; current dir default) or `-`/**stdout**.
- Machine artifact (the report JSON) to the output target; a **human summary to stderr**; **exit code** carries the verdict — so CI can branch on it.
- Settings resolution: `--settings` → **CWD** `schema-validation-settings.json` → **pre-baked** package copy (`fileURLToPath`, per the #175 Windows-path lesson), so exemptions load and the CLI verdict matches an in-run cert verdict. The pre-baked copy carries both the `2.0` and `2.1` stanzas.

## How
Wraps the carried validator (`generateJsonSchema` / `validate` / `combineErrors`) behind a pure, testable core (`src/cli/schema-command.ts`); IO, output routing and exit codes stay in the command action (`src/cli/index.ts`). A single generated schema (not a version Map), so `isResoDataDictionarySchema` stays at validate's default.

## Tests
`tests/cli-schema-command.test.ts` — verdict core over the ported schema fixtures (valid payload → 0, unadvertised enum → > 0), settings-path precedence (explicit + pre-baked), and the exemptions config carrying both DD stanzas. `npm run precommit` green.

Closes #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
