### PR TITLE
feat(cert): `reso-cert metadata` CLI command + require EntityContainer in validation

### DIFF
--- a/reso-certification/src/cli/index.ts
+++ b/reso-certification/src/cli/index.ts
@@ -29,6 +29,8 @@ import type { AddEditConfig, EntityEventConfig, CoreConfig, DDConfig, PipelineRe
 import { resolveCliAuth, mintOAuth2ClientCredentialsToken } from './auth.js';
 import { computeVariationsViaService, updateVariationsViaService, parseVariationsCsv } from '../variations/index.js';
 import { validateSchemaPayload, generateSchemaFromReport, loadSettings } from './schema-command.js';
+import { runMetadataStep } from './metadata-command.js';
+import type { ODataVersion } from '../xsd/validate-csdl.js';
 import { CURRENT_DD_VERSION, CERTIFIABLE_DD_VERSIONS, isCertifiableDDVersion, normalizeDDVersion } from '../sdk/dd-versions.js';
 import { resolveRenderMode, runWithProgress, runConfigEntries } from './render.js';
 
@@ -757,15 +759,18 @@ metadataReportCmd
 
 // ── Schema Subcommand (per-step util: generate a JSON Schema / validate a payload against it) ──
 
-/** Read a JSON value from a file path, or from stdin when the path is "-". */
-const readJsonInput = async (path: string): Promise<unknown> => {
+/** Read raw text from a file path, or from stdin when the path is "-". */
+const readTextInput = async (path: string): Promise<string> => {
   if (path === '-') {
     const chunks: Buffer[] = [];
     for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
-    return JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+    return Buffer.concat(chunks).toString('utf-8');
   }
-  return JSON.parse(await readFile(resolve(path), 'utf-8'));
+  return readFile(resolve(path), 'utf-8');
 };
+
+/** Read a JSON value from a file path, or from stdin when the path is "-". */
+const readJsonInput = async (path: string): Promise<unknown> => JSON.parse(await readTextInput(path));
 
 /** Write a JSON artifact to stdout when outputDir is "-", else to <outputDir>/<filename> (created if missing). */
 const writeArtifact = async (outputDir: string, filename: string, data: unknown): Promise<string> => {
@@ -834,6 +839,44 @@ schemaCmd
       process.exitCode = 0;
     } catch (err) {
       process.stderr.write(`schema generate: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exitCode = 2;
+    }
+  });
+
+// ── Metadata Subcommand (per-step util: validate OData CSDL + convert it to a RESO Format metadata report) ──
+// The first cert step, and the one that gates the rest: the metadata defines the OData entities and structure,
+// so if it is invalid nothing downstream (schema, variations, sampling) is meaningful. Exit code carries the
+// verdict (0 valid / 1 invalid / 2 IO); the report goes to the artifact, the human summary to stderr.
+
+program
+  .command('metadata')
+  .description('Metadata step — validate OData CSDL/EDMX (XSD + semantic) and convert it to a RESO Format metadata report')
+  .requiredOption('-m, --metadata <path>', 'Path to the CSDL/EDMX XML metadata file, or "-" for stdin')
+  .option('-v, --version <ddVersion>', 'DD version stamped into the generated report', '2.0')
+  .option('--odata-version <version>', 'OData version override for validation (4.0 | 4.01); auto-detected when omitted')
+  .option('--output-dir <path>', 'Directory for metadata-report.json (created if missing); "-" for stdout', '.')
+  .option('--no-report', 'Validate only; do not generate the metadata report')
+  .action(async (opts: { metadata: string; version: string; odataVersion?: string; outputDir: string; report: boolean }) => {
+    try {
+      const metadataXml = await readTextInput(opts.metadata);
+      const result = await runMetadataStep({
+        metadataXml,
+        ddVersion: opts.version,
+        odataVersion: opts.odataVersion as ODataVersion | undefined,
+        emitReport: opts.report,
+      });
+      process.stderr.write(`metadata: ${result.summary}\n`);
+      for (const err of result.errors) process.stderr.write(`  - ${err}\n`);
+      if (opts.report && result.report) {
+        const dest = await writeArtifact(opts.outputDir, 'metadata-report.json', result.report);
+        const { resources, fields, lookups } = result.report;
+        process.stderr.write(
+          `metadata: report → ${dest} (${resources.length} resources, ${fields.length.toLocaleString()} fields, ${lookups.length.toLocaleString()} lookups)\n`,
+        );
+      }
+      process.exitCode = result.passed ? 0 : 1;
+    } catch (err) {
+      process.stderr.write(`metadata: ${err instanceof Error ? err.message : String(err)}\n`);
       process.exitCode = 2;
     }
   });

--- a/reso-certification/src/cli/metadata-command.ts
+++ b/reso-certification/src/cli/metadata-command.ts
@@ -1,0 +1,79 @@
+/**
+ * Testable core for the `reso-cert metadata` command — the metadata cert step.
+ *
+ * Combines the two operations the step performs: validate the OData CSDL/EDMX (XSD structural + CSDL semantic,
+ * via `src/sdk/metadata-validation`) and serialize it to a RESO Format metadata report (`generateMetadataReport`).
+ * Validation gates the step; the report is the artifact the downstream steps (schema, variations) consume. IO,
+ * output routing and exit codes live in the command action (`index.ts`); this module is pure over its inputs.
+ */
+
+import { generateMetadataReport } from '@reso-standards/reso-metadata-utils';
+import type { MetadataReport } from '@reso-standards/reso-metadata-utils';
+import {
+  validateMetadata,
+  formatValidationSummary,
+  collectValidationErrors,
+} from '../sdk/metadata-validation.js';
+import type { MetadataValidationResult } from '../sdk/metadata-validation.js';
+import type { ODataVersion } from '../xsd/validate-csdl.js';
+
+/** DD version stamped into the generated report when the caller does not specify one. */
+export const DEFAULT_DD_VERSION = '2.0';
+
+export interface MetadataStepResult {
+  /** The step passes iff the metadata validates (XSD + semantic) AND — when a report was requested — it
+   *  serialized to a RESO Format report. Validation and serialization are distinct checks with distinct
+   *  strictness, so a document can validate yet fail to serialize; the step fails in that case too. */
+  readonly passed: boolean;
+  readonly validation: MetadataValidationResult;
+  /** One-line human summary of the validation outcome. */
+  readonly summary: string;
+  /** Flattened validation errors, plus a `[report]` line when serialization was requested but failed. */
+  readonly errors: ReadonlyArray<string>;
+  /** The serialized RESO Format metadata report — present when it serialized and a report was requested;
+   *  absent when generation was skipped (`emitReport: false`) or serialization failed (see {@link reportError}). */
+  readonly report?: MetadataReport;
+  /** Set when report serialization was requested but threw (e.g. the CSDL lacks the required EntityContainer).
+   *  The serializer imposes service-document requirements the XSD/semantic validators do not, so this can fire
+   *  even when {@link validation} passes — and when it does, the step fails: downstream has no report to read. */
+  readonly reportError?: string;
+}
+
+/**
+ * Run the metadata step over raw CSDL/EDMX XML: validate, then (unless suppressed) serialize to a RESO Format
+ * report. `ddVersion` stamps the report's version; `odataVersion` overrides OData-version auto-detection for
+ * validation. Serialization is attempted independently of the RESO verdict — a semantically invalid but
+ * serializable document still yields a report — and a serialization failure is surfaced (never thrown out of
+ * this function) so the step returns a determinate verdict rather than crashing on malformed metadata.
+ */
+export const runMetadataStep = async (opts: {
+  readonly metadataXml: string;
+  readonly ddVersion?: string;
+  readonly odataVersion?: ODataVersion;
+  readonly emitReport?: boolean;
+}): Promise<MetadataStepResult> => {
+  const validation = await validateMetadata(opts.metadataXml, opts.odataVersion);
+  const emit = opts.emitReport !== false;
+  const { report, reportError } = emit
+    ? tryGenerateReport(opts.metadataXml, opts.ddVersion ?? DEFAULT_DD_VERSION)
+    : { report: undefined, reportError: undefined };
+  const validationValid = validation.xsdValid && validation.semanticValid;
+  const passed = validationValid && (!emit || report !== undefined);
+  const errors = reportError
+    ? [...collectValidationErrors(validation), `[report] ${reportError}`]
+    : collectValidationErrors(validation);
+  return { passed, validation, summary: formatValidationSummary(validation), errors, report, reportError };
+};
+
+/** Serialize the report, capturing (rather than throwing) a serializer failure so the step reports a verdict
+ *  instead of crashing on malformed CSDL. The failure reason is surfaced in {@link MetadataStepResult.reportError}. */
+const tryGenerateReport = (
+  metadataXml: string,
+  ddVersion: string,
+): { readonly report?: MetadataReport; readonly reportError?: string } => {
+  try {
+    return { report: generateMetadataReport(metadataXml, ddVersion) };
+  } catch (err) {
+    return { reportError: err instanceof Error ? err.message : String(err) };
+  }
+};

--- a/reso-certification/tests/cli-metadata-command.test.ts
+++ b/reso-certification/tests/cli-metadata-command.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { runMetadataStep } from '../src/cli/metadata-command.js';
+
+const readFixture = (p: string): Promise<string> => readFile(resolve(import.meta.dirname, p), 'utf-8');
+
+describe('runMetadataStep — the metadata cert step (validate + serialize)', () => {
+  it('a valid CSDL passes the verdict and serializes a RESO Format report', async () => {
+    const xml = await readFixture('fixtures/commander/good-edmx.xml');
+    const result = await runMetadataStep({ metadataXml: xml, ddVersion: '2.0' });
+    expect(result.passed).toBe(true);
+    expect(result.errors).toHaveLength(0);
+    expect(result.report?.resources.length).toBeGreaterThan(0);
+    expect(result.report?.fields.length).toBeGreaterThan(0);
+  });
+
+  it('fails the verdict on structurally broken CSDL (XSD catches the stray character)', async () => {
+    const xml = await readFixture('fixtures/commander/bad-edmx-unparsable-xml.xml');
+    const result = await runMetadataStep({ metadataXml: xml, ddVersion: '2.0' });
+    expect(result.passed).toBe(false);
+    expect(result.validation.xsdValid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('fails the verdict on a semantically invalid CSDL (missing entity key)', async () => {
+    const xml = await readFixture('fixtures/commander/bad-edmx-no-keyfield.xml');
+    const result = await runMetadataStep({ metadataXml: xml, ddVersion: '2.0' });
+    expect(result.passed).toBe(false);
+    expect(result.validation.semanticValid).toBe(false);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  it('--no-report (emitReport: false) validates without serializing', async () => {
+    const xml = await readFixture('fixtures/commander/good-edmx.xml');
+    const result = await runMetadataStep({ metadataXml: xml, ddVersion: '2.0', emitReport: false });
+    expect(result.passed).toBe(true);
+    expect(result.report).toBeUndefined();
+  });
+
+  // A metadata document with no EntityContainer is caught at the semantic layer (the new validator check) and
+  // also can't serialize — the step fails with both signals, each pointing at the missing container.
+  it('fails when the metadata declares no EntityContainer, surfacing a report error too', async () => {
+    const xml = await readFixture('../sample-metadata.xml');
+    const result = await runMetadataStep({ metadataXml: xml, ddVersion: '2.0' });
+    expect(result.passed).toBe(false);
+    expect(result.validation.semanticValid).toBe(false);
+    expect(result.errors.some(e => e.includes('EntityContainer'))).toBe(true);
+    expect(result.reportError).toContain('EntityContainer');
+  });
+});

--- a/reso-certification/tests/fixtures/commander/good-edmx.xml
+++ b/reso-certification/tests/fixtures/commander/good-edmx.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="org.reso.metadata.Resources">
+      <EntityType Name="Property">
+        <Key>
+          <PropertyRef Name="ListingKey"/>
+        </Key>
+        <Property Name="ListingKey" Type="Edm.String" MaxLength="255" Nullable="false"/>
+        <Property Name="ListingId" Type="Edm.String" MaxLength="255"/>
+      </EntityType>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Default">
+      <EntityContainer Name="Container">
+        <EntitySet Name="Property" EntityType="org.reso.metadata.Resources.Property"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/reso-metadata-utils/src/csdl/validator.ts
+++ b/reso-metadata-utils/src/csdl/validator.ts
@@ -57,6 +57,7 @@ const unwrapCollection = (type: string): string => type.slice('Collection('.leng
 
 const SPEC = {
   v4: {
+    entityContainer: 'https://docs.oasis-open.org/odata/odata/v4.0/csd01/part3-csdl/odata-v4.0-csd01-part3-csdl.html#_Toc355092911',
     entityTypeKey: 'https://docs.oasis-open.org/odata/odata/v4.0/csd01/part3-csdl/odata-v4.0-csd01-part3-csdl.html#_Toc355092870',
     entityTypeBaseType: 'https://docs.oasis-open.org/odata/odata/v4.0/csd01/part3-csdl/odata-v4.0-csd01-part3-csdl.html#_Toc355092866',
     complexTypeBaseType: 'https://docs.oasis-open.org/odata/odata/v4.0/csd01/part3-csdl/odata-v4.0-csd01-part3-csdl.html#_Toc355092877',
@@ -67,6 +68,7 @@ const SPEC = {
     referentialConstraint: 'https://docs.oasis-open.org/odata/odata/v4.0/csd01/part3-csdl/odata-v4.0-csd01-part3-csdl.html#_Toc355092861',
   },
   v401: {
+    entityContainer: 'https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_EntityContainer',
     entityTypeKey: 'https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_Key',
     entityTypeBaseType: 'https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_DerivedEntityType',
     complexTypeBaseType: 'https://docs.oasis-open.org/odata/odata-csdl-xml/v4.01/odata-csdl-xml-v4.01.html#sec_DerivedComplexType',
@@ -79,6 +81,7 @@ const SPEC = {
 } as const;
 
 interface SpecUrls {
+  readonly entityContainer: string;
   readonly entityTypeKey: string;
   readonly entityTypeBaseType: string;
   readonly complexTypeBaseType: string;
@@ -93,6 +96,7 @@ interface SpecUrls {
  * Validate a parsed CSDL schema for semantic correctness.
  *
  * Checks (ported from Apache Olingo CsdlTypeValidator):
+ * 0. A single entity container is present (a service metadata document must expose one)
  * 1. Entity types have at least one key property (unless abstract or derived)
  * 2. Entity type BaseType references are resolvable
  * 3. Complex type BaseType references are resolvable
@@ -115,6 +119,21 @@ export const validateCsdl = (schema: CsdlSchema, odataVersion: '4.0' | '4.01' = 
     errors.push({
       path: 'Schema',
       message: 'Schema namespace is missing or empty',
+    });
+  }
+
+  // Require an entity container. A metadata document that describes an OData service must define one (commonly
+  // named "Default") — it declares the entity sets a client can query, so a service without one exposes no
+  // resources. The serializer enforces the same requirement downstream; catching it here gives the provider a
+  // clear reason at the validation step instead of an opaque serialization failure later.
+  if (!schema.entityContainer) {
+    errors.push({
+      path: 'EntityContainer',
+      message:
+        'No EntityContainer was found in the metadata. An OData service metadata document must contain a single ' +
+        'entity container (commonly named "Default") that defines the resources the service exposes. Add a ' +
+        '<Schema> containing an <EntityContainer> whose <EntitySet> entries list your resources (Property, Member, …).',
+      specUrl: spec.entityContainer,
     });
   }
 

--- a/reso-metadata-utils/tests/csdl-validator.test.ts
+++ b/reso-metadata-utils/tests/csdl-validator.test.ts
@@ -44,6 +44,21 @@ describe('validateCsdl', () => {
     expect(result.errors).toHaveLength(0);
   });
 
+  it('requires an entity container and links the OData spec', () => {
+    const schema: CsdlSchema = { ...validSchema, entityContainer: undefined };
+    const result = validateCsdl(schema);
+    expect(result.valid).toBe(false);
+    const containerError = result.errors.find(e => e.path === 'EntityContainer');
+    expect(containerError?.message).toContain('EntityContainer');
+    expect(containerError?.specUrl).toContain('oasis-open.org');
+  });
+
+  it('links the 4.01 EntityContainer section when validating as 4.01', () => {
+    const schema: CsdlSchema = { ...validSchema, entityContainer: undefined };
+    const result = validateCsdl(schema, '4.01');
+    expect(result.errors.find(e => e.path === 'EntityContainer')?.specUrl).toContain('sec_EntityContainer');
+  });
+
   it('detects missing namespace', () => {
     const schema: CsdlSchema = { ...validSchema, namespace: '' };
     const result = validateCsdl(schema);


### PR DESCRIPTION
Second deliverable of the per-step cert CLI epic (#251). **Stacked on #252** (reuses that PR's `readTextInput`/`writeArtifact` helpers) — review after #252, or merge #252 first and this retargets to `v1.0.0-pre`.

## `reso-cert metadata` — the metadata step (validate + convert)
The first cert step and the one that gates the rest: the metadata defines the OData entities and structure, so if it is invalid nothing downstream (schema, variations, sampling) is meaningful. One command does both operations the step performs:

- **Validate** the CSDL/EDMX — XSD structural + CSDL semantic (`validateMetadata`).
- **Convert** it to a RESO Format metadata report (`generateMetadataReport`).

Interface matches `schema`: metadata from a **file or stdin (`-`)**; report to **`--output-dir`** (created if missing; current dir default) or **`-`/stdout**; **exit 0** valid / **1** invalid / **2** IO; human summary + errors to **stderr**, machine artifact to the output target.

Validation and serialization are distinct checks with distinct strictness, so a document can validate yet fail to serialize. The step surfaces a report-generation failure honestly (`reportError`, factored into the verdict) rather than silently succeeding with no artifact. Testable core in `src/cli/metadata-command.ts`; fixture `good-edmx.xml` added.

## Validator gap this surfaced: require an EntityContainer
Building the step turned up a real semantic gap. `validateCsdl` only checked entity sets **inside** `if (schema.entityContainer)`, so a metadata document with **no** `EntityContainer` passed validation vacuously — even though an OData service metadata document must define one (OData 4.01 §3: *"The metadata document contains a single entity container that defines the resources exposed by this service"*). The serializer already enforced it downstream by throwing; now the validation step catches it with a clear message and an OData spec link:

```
[EntityContainer] No EntityContainer was found in the metadata. An OData service metadata document must
contain a single entity container (commonly named "Default") that defines the resources the service exposes.
Add a <Schema> containing an <EntityContainer> whose <EntitySet> entries list your resources (Property, …).
— https://docs.oasis-open.org/odata/odata/v4.0/csd01/part3-csdl/odata-v4.0-csd01-part3-csdl.html#_Toc355092911
```

v4.0 cites `#_Toc355092911`, v4.01 cites `#sec_EntityContainer` (the same anchor the serializer's existing error uses, so both point at one canonical URL). Real server captures all carry exactly one container, so no conformant server regresses.

## Tests
- `csdl-validator.test.ts` — container required + the 4.01 spec link (23 pass).
- `cli-metadata-command.test.ts` — valid passes + serializes; XSD-broken and semantically-invalid fail; `--no-report`; and the missing-container case caught at the semantic layer with a report error too (5 pass).
- `npm run precommit` green across all packages.

Part of #251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
