### PR TITLE
feat(cert): `reso-cert replicate` command + timestamp-collision & --strict fixes

### DIFF
--- a/reso-certification/src/cli/index.ts
+++ b/reso-certification/src/cli/index.ts
@@ -31,6 +31,8 @@ import { computeVariationsViaService, updateVariationsViaService, parseVariation
 import { validateSchemaPayload, generateSchemaFromReport, loadSettings } from './schema-command.js';
 import { runMetadataStep } from './metadata-command.js';
 import type { ODataVersion } from '../xsd/validate-csdl.js';
+import { runReplicate, REPLICATION_STRATEGY_VALUES } from './replicate-command.js';
+import { resolveAuthToken } from '../test-runner/auth.js';
 import { CURRENT_DD_VERSION, CERTIFIABLE_DD_VERSIONS, isCertifiableDDVersion, normalizeDDVersion } from '../sdk/dd-versions.js';
 import { resolveRenderMode, runWithProgress, runConfigEntries } from './render.js';
 
@@ -880,5 +882,105 @@ program
       process.exitCode = 2;
     }
   });
+
+// ── Replicate Subcommand (per-step util: pull data from a live endpoint using a replication strategy) ──
+// Wraps the legacy replication engine. Four strategies (TopAndSkip / TimestampAsc / TimestampDesc / NextLink);
+// single-resource (--resource) or report-driven (--metadata) scope; writes a data-availability report (and,
+// with --save-results, the raw pages) under --output-dir. Auth is pre-resolved to a bearer token here (the
+// engine's own OAuth path hard-exits on failure), and the run uses throwOnError so a failure is our exit code.
+
+program
+  .command('replicate')
+  .description('Replicate data from a resource (or a whole metadata report) using an OData replication strategy')
+  .requiredOption('-u, --url <uri>', 'OData service root URI (no resource name or query)')
+  .requiredOption('-s, --strategy <strategy>', `Replication strategy: ${REPLICATION_STRATEGY_VALUES.join(' | ')}`)
+  .option('-r, --resource <name>', 'Resource to replicate (single-resource mode)')
+  .option('-m, --metadata <path>', 'Metadata report JSON — replicate every resource in it (report-driven mode)')
+  .option('-x, --expansions <list>', 'Comma-separated expansions, e.g. Media,OpenHouse (single-resource mode)')
+  .option('-f, --filter <expr>', 'OData $filter expression')
+  .option('-t, --top <n>', 'OData $top page size')
+  .option('--orderby <expr>', 'OData $orderby expression')
+  .option('--max-page-size <n>', 'odata.maxpagesize preference (NextLink strategy)')
+  .option('-l, --limit <n>', 'Stop after this many total records')
+  .option('--output-dir <dir>', 'Directory for the report and any saved pages (created if missing)', '.')
+  .option('-v, --version <ddVersion>', 'Data Dictionary version', '2.0')
+  .option('--save-results', 'Also write every raw response page to disk')
+  .option('--json-schema-validation', 'Validate each payload against a schema generated from the metadata')
+  .option('--strict', 'Fail on schema-validation errors')
+  .option('--originating-system-name <v>', 'Append OriginatingSystemName eq <v> to every query')
+  .option('--originating-system-id <v>', 'Append OriginatingSystemID eq <v> to every query')
+  .option('--auth-token <token>', 'Bearer token for authorization')
+  .option('--client-id <id>', 'OAuth2 client_id (with --client-secret and --token-url)')
+  .option('--client-secret <secret>', 'OAuth2 client_secret')
+  .option('--token-url <url>', 'OAuth2 token endpoint URL')
+  .action(
+    async (opts: {
+      url: string;
+      strategy: string;
+      resource?: string;
+      metadata?: string;
+      expansions?: string;
+      filter?: string;
+      top?: string;
+      orderby?: string;
+      maxPageSize?: string;
+      limit?: string;
+      outputDir: string;
+      version: string;
+      saveResults?: boolean;
+      jsonSchemaValidation?: boolean;
+      strict?: boolean;
+      originatingSystemName?: string;
+      originatingSystemId?: string;
+      authToken?: string;
+      clientId?: string;
+      clientSecret?: string;
+      tokenUrl?: string;
+    }) => {
+      const toInt = (v?: string): number | undefined => (v == null ? undefined : Number.parseInt(v, 10));
+      try {
+        const auth = resolveCliAuth({
+          authToken: opts.authToken,
+          clientId: opts.clientId,
+          clientSecret: opts.clientSecret,
+          tokenUrl: opts.tokenUrl,
+        });
+        const bearerToken = await resolveAuthToken(auth);
+        const result = await runReplicate({
+          serviceRootUri: opts.url,
+          strategy: opts.strategy,
+          bearerToken,
+          resourceName: opts.resource,
+          expansions: opts.expansions,
+          metadataReportPath: opts.metadata ? resolve(opts.metadata) : undefined,
+          filter: opts.filter,
+          top: toInt(opts.top),
+          orderby: opts.orderby,
+          maxPageSize: toInt(opts.maxPageSize),
+          limit: toInt(opts.limit),
+          outputPath: opts.outputDir,
+          version: opts.version,
+          shouldGenerateReports: !!opts.metadata,
+          jsonSchemaValidation: opts.jsonSchemaValidation || opts.strict,
+          strictMode: opts.strict,
+          shouldSaveResults: opts.saveResults,
+          originatingSystemName: opts.originatingSystemName,
+          originatingSystemId: opts.originatingSystemId,
+          onProgress: (info: Record<string, unknown>) => {
+            const n = Number(info.totalRecordsFetched ?? 0);
+            process.stderr.write(`replicate ${opts.strategy}: ${n.toLocaleString()} records\r`);
+          },
+        });
+        process.stderr.write(
+          `\nreplicate: ${result.strategy} complete — ${result.stats.totalRecordsFetched.toLocaleString()} records, ` +
+            `${result.stats.totalRequests.toLocaleString()} requests → ${result.outputDir}\n`,
+        );
+        process.exitCode = 0;
+      } catch (err) {
+        process.stderr.write(`\nreplicate: ${err instanceof Error ? err.message : String(err)}\n`);
+        process.exitCode = 2;
+      }
+    },
+  );
 
 program.parse();

--- a/reso-certification/src/cli/replicate-command.ts
+++ b/reso-certification/src/cli/replicate-command.ts
@@ -1,0 +1,152 @@
+/**
+ * Testable core for the `reso-cert replicate` command — the sampling / replication cert step.
+ *
+ * Pulls OData records from a live endpoint using one of the four replication strategies and writes a
+ * data-availability report (and, optionally, the raw pages) to an output directory. Wraps the carried legacy
+ * replication engine (`src/legacy/lib/replication`) the same way the `dd` pipeline does (`src/sdk/dd.ts`):
+ * a pre-resolved bearer token, one fresh replication-state instance, and `throwOnError: true` so failures
+ * surface as a rejected promise (→ CLI exit code) instead of the engine's default `process.exit(1)`.
+ *
+ * The legacy `replicate` returns nothing — all results are side effects (files on disk, a mutated state
+ * singleton, an `onProgress` callback). This core captures the final `onProgress` payload so the command can
+ * report record counts and throughput, and validates the strategy up front (the engine only rejects an unknown
+ * strategy per-page, deep inside the run).
+ */
+
+import { resolve } from 'node:path';
+
+// Legacy CJS engine, imported exactly as src/sdk/dd.ts does (default import + destructure, no createRequire).
+// @ts-expect-error — legacy CJS, no type declarations
+import certUtils from '../legacy/index.js';
+// @ts-expect-error — legacy CJS
+import certUtilsCommon from '../legacy/common.js';
+// @ts-expect-error — legacy CJS
+import certUtilsReplicationUtils from '../legacy/lib/replication/utils.js';
+
+const { replicate } = certUtils as {
+  replicate: (opts: Record<string, unknown>) => Promise<void>;
+};
+const { createReplicationStateServiceInstance } = certUtilsCommon as {
+  createReplicationStateServiceInstance: () => unknown;
+};
+const { REPLICATION_STRATEGIES } = certUtilsReplicationUtils as {
+  REPLICATION_STRATEGIES: Readonly<Record<string, string>>;
+};
+
+/** The four accepted replication strategies, sourced from the legacy engine (never hardcoded). */
+export const REPLICATION_STRATEGY_VALUES: ReadonlyArray<string> = Object.values(REPLICATION_STRATEGIES);
+
+const DEFAULT_DD_VERSION = '2.0';
+
+export interface ReplicationStats {
+  readonly totalRecordsFetched: number;
+  readonly meanResponseMs: number;
+  readonly throughput: number;
+  readonly totalRequests: number;
+}
+
+export interface ReplicateResult {
+  readonly strategy: string;
+  readonly stats: ReplicationStats;
+  /** Absolute directory the report(s) and any raw pages were written to. */
+  readonly outputDir: string;
+}
+
+const toNumber = (v: unknown): number => (v == null ? 0 : Number(v));
+
+// The legacy engine only emits onProgress past a 500ms throttle with no final flush, so the captured stats
+// reflect the last throttled tick — accurate for a real run (seconds long), but empty for a sub-500ms run.
+// The authoritative record counts live in the written report / saved pages; these stats are the CLI summary.
+const extractStats = (info: Record<string, unknown>): ReplicationStats => ({
+  totalRecordsFetched: toNumber(info.totalRecordsFetched),
+  meanResponseMs: toNumber(info.meanResponseMs),
+  throughput: toNumber(info.throughput),
+  totalRequests: toNumber(info.totalRequests),
+});
+
+export interface ReplicateOptions {
+  readonly serviceRootUri: string;
+  readonly strategy: string;
+  readonly bearerToken: string;
+  /** Single-resource mode: replicate this resource (with optional expansions). */
+  readonly resourceName?: string;
+  readonly expansions?: string;
+  /** Report-driven mode: replicate every resource in this metadata report. Takes precedence over resourceName. */
+  readonly metadataReportPath?: string;
+  readonly filter?: string;
+  readonly top?: number;
+  readonly orderby?: string;
+  readonly maxPageSize?: number;
+  readonly limit?: number;
+  readonly outputPath: string;
+  readonly version?: string;
+  readonly jsonSchemaValidation?: boolean;
+  readonly strictMode?: boolean;
+  /** Write every raw response page to <outputPath>/reso-replication-output/… (default false). */
+  readonly shouldSaveResults?: boolean;
+  /** Write the data-availability report(s) (default true). */
+  readonly shouldGenerateReports?: boolean;
+  readonly originatingSystemName?: string;
+  readonly originatingSystemId?: string;
+  readonly secondsDelayBetweenRequests?: number;
+  readonly onProgress?: (info: Record<string, unknown>) => void;
+}
+
+/**
+ * Run one replication pass. Validates the strategy, then invokes the legacy engine with a fresh state instance
+ * and `throwOnError: true`. Resolves with the captured final stats and the resolved output directory; rejects
+ * (rather than exiting the process) when the engine errors.
+ */
+export const runReplicate = async (opts: ReplicateOptions): Promise<ReplicateResult> => {
+  if (!REPLICATION_STRATEGY_VALUES.includes(opts.strategy)) {
+    throw new Error(
+      `Unknown strategy '${opts.strategy}'. Must be one of: ${REPLICATION_STRATEGY_VALUES.join(', ')}.`,
+    );
+  }
+  if (!opts.metadataReportPath && !opts.resourceName) {
+    throw new Error('Provide either --resource <name> (single-resource) or --metadata <path> (report-driven).');
+  }
+  // Schema validation (and the data-availability report) need the metadata to generate the schema and know
+  // every resource's fields, so they are report-driven-mode only.
+  if (opts.jsonSchemaValidation && !opts.metadataReportPath) {
+    throw new Error('Schema validation (--json-schema-validation / --strict) requires a metadata report (--metadata) — the schema is generated from it.');
+  }
+
+  const replicationStateService = createReplicationStateServiceInstance();
+  let lastInfo: Record<string, unknown> = {};
+
+  await replicate({
+    serviceRootUri: opts.serviceRootUri,
+    strategy: opts.strategy,
+    bearerToken: opts.bearerToken,
+    // Report-driven mode wins (legacy enumerates every resource in the report); otherwise single-resource params.
+    pathToMetadataReportJson: opts.metadataReportPath ?? '',
+    resourceName: opts.resourceName,
+    expansions: opts.expansions,
+    filter: opts.filter,
+    top: opts.top,
+    orderby: opts.orderby,
+    maxPageSize: opts.maxPageSize,
+    limit: opts.limit,
+    outputPath: opts.outputPath,
+    version: opts.version ?? DEFAULT_DD_VERSION,
+    jsonSchemaValidation: opts.jsonSchemaValidation ?? false,
+    strictMode: opts.strictMode ?? false,
+    shouldSaveResults: opts.shouldSaveResults ?? false,
+    shouldGenerateReports: opts.shouldGenerateReports ?? true,
+    originatingSystemName: opts.originatingSystemName,
+    originatingSystemId: opts.originatingSystemId,
+    secondsDelayBetweenRequests: opts.secondsDelayBetweenRequests ?? 1,
+    REPLICATION_STATE_SERVICE: replicationStateService,
+    // Reject instead of process.exit(1) so the CLI action controls the exit code; keep the top-level loggers
+    // quiet (fromCli: false) and surface our own summary.
+    throwOnError: true,
+    fromCli: false,
+    onProgress: (info: Record<string, unknown>) => {
+      lastInfo = info;
+      opts.onProgress?.(info);
+    },
+  });
+
+  return { strategy: opts.strategy, stats: extractStats(lastInfo), outputDir: resolve(opts.outputPath) };
+};

--- a/reso-certification/src/legacy/lib/replication/index.js
+++ b/reso-certification/src/legacy/lib/replication/index.js
@@ -374,11 +374,17 @@ const replicate = async ({
               break;
             }
           } catch (err) {
+            // With throwOnError, propagate a mid-run error (a strictMode schema-validation throw, or a
+            // parse/scoring failure) to the top-level catch so the caller's exit code reflects it — instead of
+            // the bare `return` that silently ended the run and resolved as success (which defeated --strict).
+            // Log only when swallowing (throwOnError false); on a rethrow the top-level catch logs it once.
+            if (throwOnError) throw err;
             LOG_ERROR(err);
             return;
           }
         }
       } catch (err) {
+        if (throwOnError) throw err;
         LOG_ERROR(err);
         return;
       }

--- a/reso-certification/src/legacy/lib/replication/utils.js
+++ b/reso-certification/src/legacy/lib/replication/utils.js
@@ -148,8 +148,10 @@ const computeLastIsoTimestamp = ({ jsonData = {}, lastIsoTimestamp, strategy, ti
 
   if (strategy === REPLICATION_STRATEGIES.TIMESTAMP_ASC) {
     if (lastIsoTimestamp === maxIsoTimestamp) {
-      //timestamp collision - add a little time to the timestamp
-      return new Date(new Date(maxIsoTimestamp) + 1).toISOString();
+      // Timestamp collision (a whole page shares this timestamp): nudge forward 1ms so the next `ge` page
+      // doesn't re-fetch it. Use getTime() for explicit numeric math — `new Date(dateObj + 1)` coerces the
+      // Date to a string and yields Invalid Date, so .toISOString() throws (the bug this replaced).
+      return new Date(new Date(maxIsoTimestamp).getTime() + 1).toISOString();
     } else {
       return maxIsoTimestamp;
     }
@@ -157,8 +159,8 @@ const computeLastIsoTimestamp = ({ jsonData = {}, lastIsoTimestamp, strategy, ti
 
   if (strategy === REPLICATION_STRATEGIES.TIMESTAMP_DESC) {
     if (lastIsoTimestamp === minIsoTimestamp) {
-      // timestamp collision - subtract a little time from the timestamp
-      return new Date(new Date(minIsoTimestamp) - 1).toISOString();
+      // Timestamp collision: nudge backward 1ms (symmetric to ASC; explicit getTime() for the same reason).
+      return new Date(new Date(minIsoTimestamp).getTime() - 1).toISOString();
     } else {
       return minIsoTimestamp;
     }
@@ -1346,8 +1348,12 @@ const buildRequestUrlString = ({
             .join(' and ')
           : null;
 
+    // `le` (inclusive), symmetric to TimestampAsc's `ge`: re-fetch the boundary record and let scorePayload's
+    // hash dedup drop the repeat, rather than `lt` (exclusive) which silently dropped every record sharing the
+    // page-boundary timestamp when a collision straddled a page. The -1ms nudge in computeLastIsoTimestamp
+    // breaks the stall when a whole page shares the min timestamp.
     return new URL(
-      `?$top=${$top}&$filter=${timestampField} lt ${timestamp}${preparedFilter?.length ? ` and ${preparedFilter}` : ''}${
+      `?$top=${$top}&$filter=${timestampField} le ${timestamp}${preparedFilter?.length ? ` and ${preparedFilter}` : ''}${
         $expand?.length ? `&$expand=${$expand}` : ''
       }&$orderby=${timestampField} desc`,
       baseUri

--- a/reso-certification/tests/legacy/replicate-command.test.ts
+++ b/reso-certification/tests/legacy/replicate-command.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtemp, rm, readdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runReplicate, REPLICATION_STRATEGY_VALUES } from '../../src/cli/replicate-command.js';
+import { startReplicationMockServer } from './replication-mock-server.js';
+
+const RESOURCE = 'Property';
+
+// Distinct timestamps → every strategy (incl. the exclusive-lt Desc walk) traverses cleanly with a tiny page.
+const distinctRecords = [
+  { ListingKey: 'P1', ModificationTimestamp: '2024-01-01T00:00:00.000Z' },
+  { ListingKey: 'P2', ModificationTimestamp: '2024-02-01T00:00:00.000Z' },
+  { ListingKey: 'P3', ModificationTimestamp: '2024-03-01T00:00:00.000Z' },
+  { ListingKey: 'P4', ModificationTimestamp: '2024-04-01T00:00:00.000Z' },
+  { ListingKey: 'P5', ModificationTimestamp: '2024-05-01T00:00:00.000Z' },
+];
+
+/** Collect the ListingKeys across every saved page — the proof each strategy fetched all rows and terminated. */
+const savedKeys = async (outputPath: string, resource: string): Promise<ReadonlyArray<string>> => {
+  const base = join(outputPath, 'reso-replication-output', resource);
+  const keys = new Set<string>();
+  for (const runDir of await readdir(base)) {
+    const pageDir = join(base, runDir);
+    for (const file of await readdir(pageDir)) {
+      if (!file.endsWith('.json')) continue;
+      const body = JSON.parse(await readFile(join(pageDir, file), 'utf-8')) as { value?: ReadonlyArray<{ ListingKey?: unknown }> };
+      for (const record of body.value ?? []) keys.add(String(record.ListingKey));
+    }
+  }
+  return [...keys].sort();
+};
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) await cleanup();
+});
+
+// Returns the distinct ListingKeys the run actually pulled and saved — the ground truth for full traversal +
+// termination. (We assert on WHICH records, not the run's record-count stat: that stat comes from the legacy
+// engine's 500ms-throttled onProgress, which never fires on a sub-500ms test run — see replicate-command.ts.)
+const replicateAgainst = async (
+  records: ReadonlyArray<Record<string, unknown>>,
+  strategy: string,
+): Promise<ReadonlyArray<string>> => {
+  const server = await startReplicationMockServer({ resource: RESOURCE, records });
+  cleanups.push(server.close);
+  const outputPath = await mkdtemp(join(tmpdir(), 'replicate-'));
+  cleanups.push(() => rm(outputPath, { recursive: true, force: true }));
+
+  await runReplicate({
+    serviceRootUri: server.url,
+    strategy,
+    bearerToken: 'test-token',
+    resourceName: RESOURCE,
+    top: 2, // tiny pages force multi-page pagination across all strategies
+    maxPageSize: 2, // NextLink's odata.maxpagesize
+    outputPath,
+    shouldSaveResults: true, // raw pages are what savedKeys reads back
+    shouldGenerateReports: false, // single-resource mode has no metadata to score against
+    secondsDelayBetweenRequests: 0, // no inter-request sleep in tests
+  });
+
+  return savedKeys(outputPath, RESOURCE);
+};
+
+// Build-and-check EVERY strategy, including the two the dd pipeline never exercises (TopAndSkip, TimestampAsc).
+describe('runReplicate — each strategy paginates, terminates, and fetches every record', () => {
+  it.each(REPLICATION_STRATEGY_VALUES)('strategy %s traverses the whole resource via 2-record pages', async strategy => {
+    expect(await replicateAgainst(distinctRecords, strategy)).toEqual(['P1', 'P2', 'P3', 'P4', 'P5']);
+  });
+});
+
+// Both timestamp strategies must survive a duplicate timestamp that straddles a page boundary. Pre-fix:
+// TimestampAsc CRASHED (Invalid Date) and TimestampDesc SILENTLY DROPPED the tied record (exclusive `lt`).
+// C3 and C4 share a timestamp and, at page size 2, land across the boundary — the exact hazard.
+describe('runReplicate — timestamp strategies across a boundary-straddling collision', () => {
+  const collisionRecords = [
+    { ListingKey: 'C1', ModificationTimestamp: '2024-01-01T00:00:00.000Z' },
+    { ListingKey: 'C2', ModificationTimestamp: '2024-02-01T00:00:00.000Z' },
+    { ListingKey: 'C3', ModificationTimestamp: '2024-03-01T00:00:00.000Z' },
+    { ListingKey: 'C4', ModificationTimestamp: '2024-03-01T00:00:00.000Z' }, // shares C3's timestamp
+    { ListingKey: 'C5', ModificationTimestamp: '2024-04-01T00:00:00.000Z' },
+  ];
+
+  it.each(['TimestampAsc', 'TimestampDesc'])('%s reaches every record across the collision', async strategy => {
+    expect(await replicateAgainst(collisionRecords, strategy)).toEqual(['C1', 'C2', 'C3', 'C4', 'C5']);
+  });
+});
+
+// --strict must FAIL the run on a schema violation. Pre-fix the strictMode throw was swallowed by a bare-return
+// catch in the replication loop, so the run resolved as success (exit 0) — a false pass in a cert tool.
+describe('runReplicate — --strict propagates a schema-validation failure (no false pass)', () => {
+  const minimalReport = {
+    description: 'strict-test',
+    version: '2.0',
+    generatedOn: '2024-01-01T00:00:00.000Z',
+    resources: [{ resourceName: RESOURCE }],
+    fields: [
+      { resourceName: RESOURCE, fieldName: 'ListingKey', type: 'Edm.String', annotations: [] },
+      { resourceName: RESOURCE, fieldName: 'ModificationTimestamp', type: 'Edm.DateTimeOffset', annotations: [] },
+    ],
+    lookups: [],
+    actions: [],
+    functions: [],
+  };
+  // additionalProperties:false in the generated schema → an unknown field is a validation error.
+  const violatingRecord = { ListingKey: 'X1', ModificationTimestamp: '2024-01-01T00:00:00.000Z', BogusExtraField: 'nope' };
+
+  it('rejects instead of resolving when a record fails the schema under strictMode', async () => {
+    const server = await startReplicationMockServer({ resource: RESOURCE, records: [violatingRecord] });
+    cleanups.push(server.close);
+    const outputPath = await mkdtemp(join(tmpdir(), 'replicate-strict-'));
+    cleanups.push(() => rm(outputPath, { recursive: true, force: true }));
+    const reportPath = join(outputPath, 'metadata-report.json');
+    await writeFile(reportPath, JSON.stringify(minimalReport));
+
+    await expect(
+      runReplicate({
+        serviceRootUri: server.url,
+        strategy: 'TopAndSkip',
+        bearerToken: 'test-token',
+        metadataReportPath: reportPath,
+        outputPath,
+        version: '2.0',
+        jsonSchemaValidation: true,
+        strictMode: true,
+        secondsDelayBetweenRequests: 0,
+      }),
+    ).rejects.toThrow(/[Ss]chema validation/);
+  });
+
+  it('rejects up front when schema validation is requested without a metadata report', async () => {
+    await expect(
+      runReplicate({
+        serviceRootUri: 'http://localhost',
+        strategy: 'TopAndSkip',
+        bearerToken: 'test-token',
+        resourceName: RESOURCE, // single-resource, no metadata
+        outputPath: '.',
+        jsonSchemaValidation: true,
+      }),
+    ).rejects.toThrow(/requires a metadata report/);
+  });
+});

--- a/reso-certification/tests/legacy/replication-mock-server.ts
+++ b/reso-certification/tests/legacy/replication-mock-server.ts
@@ -1,0 +1,116 @@
+/**
+ * Minimal in-process OData collection endpoint for testing the replication strategies offline.
+ *
+ * Answers what the legacy replication iterator actually sends, per strategy:
+ *   - count probe        GET /{Resource}?$count=true                → { @odata.count }
+ *   - TopAndSkip         GET /{Resource}?$top=N&$skip=M             → records [M, M+N)
+ *   - TimestampAsc/Desc  GET /{Resource}?$top=N&$filter=<ts op iso>&$orderby=<ts asc|desc>
+ *   - NextLink           GET /{Resource} (+ Prefer: odata.maxpagesize=N), then follows @odata.nextLink
+ *
+ * Every non-empty page advertises an `@odata.nextLink` when more rows remain — the NextLink strategy follows
+ * it; the others ignore it and page by $skip / boundary filter. A page past the end returns `{ value: [] }` and
+ * no nextLink, which is how each strategy terminates. Uses an OS-assigned port (listen(0)) for tests.
+ */
+
+import type { Server } from 'node:http';
+import express from 'express';
+
+export interface ReplicationMockOptions {
+  readonly resource: string;
+  readonly records: ReadonlyArray<Record<string, unknown>>;
+  /** Timestamp field the strategies filter/order on (the engine hardcodes ModificationTimestamp). */
+  readonly timestampField?: string;
+}
+
+export interface ReplicationMockServer {
+  readonly url: string;
+  readonly close: () => Promise<void>;
+}
+
+const toInt = (v?: string): number | undefined => (v == null ? undefined : Number.parseInt(v, 10));
+
+/** Apply the timestamp boundary clause the timestamp strategies emit (ignoring any trailing `and …` clause). */
+const applyFilter = (
+  records: ReadonlyArray<Record<string, unknown>>,
+  filter: string | undefined,
+  tsField: string,
+): ReadonlyArray<Record<string, unknown>> => {
+  if (!filter) return records;
+  const match = filter.match(new RegExp(`${tsField}\\s+(ge|gt|le|lt)\\s+(\\S+)`));
+  if (!match) return records;
+  const [, op, iso] = match;
+  const bound = new Date(iso).getTime();
+  return records.filter(r => {
+    const t = new Date(String(r[tsField])).getTime();
+    if (op === 'ge') return t >= bound;
+    if (op === 'gt') return t > bound;
+    if (op === 'le') return t <= bound;
+    return t < bound; // lt
+  });
+};
+
+/**
+ * Order the rows the way a real server would. With NO `$orderby` (what TopAndSkip sends) rows stay in
+ * insertion order — we do NOT impose a sort the client didn't ask for, so the test can't hide TopAndSkip's
+ * reliance on a stable server default order. With `$orderby <ts> asc|desc` (the timestamp strategies) sort by
+ * the timestamp field, tie-broken by ListingKey so equal-timestamp paging is deterministic.
+ */
+const applyOrderby = (
+  records: ReadonlyArray<Record<string, unknown>>,
+  orderby: string | undefined,
+  tsField: string,
+): ReadonlyArray<Record<string, unknown>> => {
+  if (!orderby) return records; // insertion order — the server's default; TopAndSkip depends on it being stable
+  const desc = orderby.toLowerCase().includes('desc');
+  return [...records].sort((a, b) => {
+    const ta = new Date(String(a[tsField])).getTime();
+    const tb = new Date(String(b[tsField])).getTime();
+    if (ta !== tb) return desc ? tb - ta : ta - tb;
+    const ka = String(a.ListingKey ?? '');
+    const kb = String(b.ListingKey ?? '');
+    return desc ? kb.localeCompare(ka) : ka.localeCompare(kb);
+  });
+};
+
+const parseMaxPageSize = (prefer: string | undefined): number | undefined => {
+  const match = prefer?.match(/odata\.maxpagesize\s*=\s*(\d+)/i);
+  return match ? Number.parseInt(match[1], 10) : undefined;
+};
+
+export const startReplicationMockServer = async (opts: ReplicationMockOptions): Promise<ReplicationMockServer> => {
+  const tsField = opts.timestampField ?? 'ModificationTimestamp';
+  const app = express();
+
+  app.get(`/${opts.resource}`, (req, res) => {
+    const q = req.query as Record<string, string | undefined>;
+    const base = `${req.protocol}://${req.get('host')}`;
+
+    // Count probe — the iterator reads @odata.count and pages separately.
+    if (q['$count'] === 'true' && q['$top'] == null && q['$skip'] == null && q['$filter'] == null) {
+      res.json({ '@odata.count': opts.records.length, value: [] });
+      return;
+    }
+
+    const ordered = applyOrderby(applyFilter(opts.records, q['$filter'], tsField), q['$orderby'], tsField);
+    const pageSize = toInt(q['$top']) ?? parseMaxPageSize(req.get('prefer')) ?? 100;
+    const skip = toInt(q['$skip']) ?? 0;
+    const page = ordered.slice(skip, skip + pageSize);
+
+    const body: Record<string, unknown> = { '@odata.context': `${base}/$metadata#${opts.resource}`, value: page };
+    if (skip + pageSize < ordered.length) {
+      body['@odata.nextLink'] = `${base}/${opts.resource}?$skip=${skip + pageSize}`;
+    }
+    res.json(body);
+  });
+
+  return new Promise<ReplicationMockServer>(resolve => {
+    const server: Server = app.listen(0, () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      resolve({
+        url: `http://127.0.0.1:${port}`,
+        close: () => new Promise<void>(done => server.close(() => done())),
+      });
+    });
+  });
+};

--- a/reso-certification/tests/legacy/replication.test.ts
+++ b/reso-certification/tests/legacy/replication.test.ts
@@ -5,7 +5,9 @@ import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
 const { getMetadata } = require(resolve(import.meta.dirname, '../../src/etl/common.cjs'));
 const { createReplicationStateServiceInstance } = require(resolve(import.meta.dirname, '../../src/legacy/common.js'));
-const { scorePayload } = require(resolve(import.meta.dirname, '../../src/legacy/lib/replication/utils.js'));
+const { scorePayload, computeLastIsoTimestamp, REPLICATION_STRATEGIES } = require(
+  resolve(import.meta.dirname, '../../src/legacy/lib/replication/utils.js')
+);
 
 describe('Replication related tests', () => {
   it('Should not throw error is non-string non-array value is present', async () => {
@@ -32,5 +34,38 @@ describe('Replication related tests', () => {
         resourceName: 'Property'
       });
     }).not.toThrow();
+  });
+});
+
+// The timestamp strategies advance a `ge`/`lt` boundary between pages. When an entire page shares one
+// timestamp the boundary doesn't move, so the collision branch nudges it by 1ms. Regression: the ASC branch
+// used `new Date(dateObj + 1)`, which coerces the Date to a string → Invalid Date → toISOString() throws.
+describe('computeLastIsoTimestamp — timestamp-collision boundary (TimestampAsc/Desc)', () => {
+  const TS = '2024-06-15T10:00:00.000Z';
+  const collidingPage = { value: [{ ModificationTimestamp: TS }, { ModificationTimestamp: TS }] };
+  const args = (strategy: string, lastIsoTimestamp: string) => ({
+    jsonData: collidingPage,
+    lastIsoTimestamp,
+    strategy,
+    timestampFieldName: 'ModificationTimestamp'
+  });
+
+  it('ASC nudges the boundary forward 1ms on a collision (no Invalid Date throw)', () => {
+    let result: string;
+    expect(() => {
+      result = computeLastIsoTimestamp(args(REPLICATION_STRATEGIES.TIMESTAMP_ASC, TS));
+    }).not.toThrow();
+    expect(new Date(result!).getTime()).toBe(new Date(TS).getTime() + 1);
+  });
+
+  it('DESC nudges the boundary backward 1ms on a collision', () => {
+    const result = computeLastIsoTimestamp(args(REPLICATION_STRATEGIES.TIMESTAMP_DESC, TS));
+    expect(new Date(result).getTime()).toBe(new Date(TS).getTime() - 1);
+  });
+
+  it('returns the page max/min unchanged when the boundary advances (no collision)', () => {
+    const earlier = '2024-06-15T09:00:00.000Z';
+    expect(computeLastIsoTimestamp(args(REPLICATION_STRATEGIES.TIMESTAMP_ASC, earlier))).toBe(TS);
+    expect(computeLastIsoTimestamp(args(REPLICATION_STRATEGIES.TIMESTAMP_DESC, '2024-06-15T11:00:00.000Z'))).toBe(TS);
   });
 });


### PR DESCRIPTION
Third deliverable of the per-step cert CLI epic (#251): `reso-cert replicate` exposes the replication / sampling step so a vendor can pull data (or replicate in a loop) from the CLI, wrapping the carried legacy engine the way the `dd` pipeline does.

Building it turned up — and this PR fixes — **two silent cert-correctness bugs in the shared replication engine** that the DD pipeline also runs. Both were caught by an adversarial review pass and are locked by regression tests that provably fail without the fix. Full DD regression stays green (808 passed).

## `reso-cert replicate`
- **Four strategies**, each verified end-to-end against an in-process OData mock (paginates, terminates, fetches every record): `TopAndSkip`, `TimestampAsc`, `TimestampDesc`, `NextLink`.
- Single-resource (`--resource` [+ `--expansions`]) or report-driven (`--metadata`, replicates every resource in the report) scope; `--filter`/`--top`/`--orderby`/`--max-page-size`/`--limit`; `--output-dir` (default cwd), `--save-results` for raw pages.
- Auth pre-resolved to a bearer token here (`--auth-token` or `--client-id/-secret/--token-url`) — the engine's own OAuth path hard-exits on failure, so we resolve up front.
- Exit `0` success / `2` error; human summary to stderr; report + pages under the output dir.
- Testable core in `src/cli/replicate-command.ts`; `throwOnError` + a fresh replication-state instance per run.

## Cert-engine fixes (shared with the DD pipeline)
1. **`TimestampAsc` crash → fixed.** The collision branch did `new Date(new Date(x) + 1)` — string coercion → `Invalid Date` → `toISOString()` threw whenever a whole page shared one `ModificationTimestamp` (routine with bulk-loaded MLS data). Now `new Date(new Date(x).getTime() + 1)`; the `Desc` branch made symmetric to kill the asymmetry that caused it.
2. **`TimestampDesc` silent data-loss → fixed.** `lt <cursor>` (exclusive) dropped every record sharing the page-boundary timestamp. Changed to `le` (inclusive) + the existing hash dedup + `-1ms` nudge — symmetric to `Asc`'s `ge`. Regression test proves it (pre-fix drops a tied record silently).
3. **`--strict` false-pass → fixed.** A strict-mode schema-validation failure threw, but a bare-return catch in the replication loop swallowed it, so `replicate --strict` exited **0** with a "complete" summary on a failing run. The two inner catches now re-raise when `throwOnError`, so the failure reaches the caller's exit code. Regression test proves it (pre-fix resolves as success).

## Scope / correctness notes
- Reports (`shouldGenerateReports`) and schema validation are report-driven-mode only (they need the metadata); this also sidesteps a params-mode `--expansions` scoring quirk. The CLI rejects `--strict`/`--json-schema-validation` without `--metadata`.
- Two adversarial passes (find + re-verify the fixes). Confirmed-LOW residuals are ticketed, not shipped broken:
  - **#254** — keyset paging for *more than a page* of records sharing one exact-ms timestamp (the nudge's residual limitation; also the `--limit` raw-count note).
  - **#255** — forward `timestampFieldName` to the URL builder (latent; unreachable from the CLI today).
  - **#256** — single-resource `--expansions` `modelName` (latent; neutralized by the report-mode change above).

Part of #251.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
