### PR TITLE
find-variations over the v2 Variations Service + --from-server source (#251 deliv 4)

### DIFF
--- a/reso-certification/src/cli/index.ts
+++ b/reso-certification/src/cli/index.ts
@@ -27,46 +27,24 @@ import { startMockEntityEventServer, stopMockEntityEventServer } from '../entity
 import { loadConfigFile, configEntryToAddEdit, configEntryToEntityEvent } from '../sdk/config.js';
 import type { AddEditConfig, EntityEventConfig, CoreConfig, DDConfig, PipelineResult } from '../sdk/types.js';
 import { resolveCliAuth, mintOAuth2ClientCredentialsToken } from './auth.js';
-import { computeVariationsViaService, updateVariationsViaService, parseVariationsCsv } from '../variations/index.js';
+import {
+  computeVariationsViaService,
+  updateVariationsViaService,
+  parseVariationsCsv,
+  findVariations,
+  DEFAULT_FUZZINESS,
+  DEFAULT_DD_VERSION,
+  VARIATIONS_REPORT_FILENAME,
+  type VariationsServiceReport,
+} from '../variations/index.js';
 import { validateSchemaPayload, generateSchemaFromReport, loadSettings } from './schema-command.js';
 import { runMetadataStep } from './metadata-command.js';
+import { fetchMetadataReportFromServer } from '../sdk/metadata-source.js';
 import type { ODataVersion } from '../xsd/validate-csdl.js';
 import { runReplicate, REPLICATION_STRATEGY_VALUES } from './replicate-command.js';
 import { resolveAuthToken } from '../test-runner/auth.js';
 import { CURRENT_DD_VERSION, CERTIFIABLE_DD_VERSIONS, isCertifiableDDVersion, normalizeDDVersion } from '../sdk/dd-versions.js';
 import { resolveRenderMode, runWithProgress, runConfigEntries } from './render.js';
-
-// ── Legacy CJS bridge — lets us call the frozen v3.0.0 findVariations ──
-
-const createRequire = (await import('node:module')).createRequire;
-const requireLegacy = createRequire(import.meta.url);
-
-interface LegacyVariationsOptions {
-  readonly pathToMetadataReportJson: string;
-  readonly fuzziness?: number;
-  readonly version?: string;
-  readonly useSuggestions?: boolean;
-  readonly fromCli?: boolean;
-  readonly bearerToken?: string;
-}
-
-interface LegacyVariationsModule {
-  readonly findVariations: (opts: LegacyVariationsOptions) => Promise<unknown>;
-}
-
-const isLegacyVariationsModule = (m: unknown): m is LegacyVariationsModule =>
-  typeof m === 'object' &&
-  m !== null &&
-  typeof (m as Record<string, unknown>).findVariations === 'function';
-
-const legacyVariationsRaw: unknown = requireLegacy(
-  resolve(import.meta.dirname, '../legacy/lib/variations/index.js')
-);
-if (!isLegacyVariationsModule(legacyVariationsRaw)) {
-  throw new Error('Failed to load legacy variations module — findVariations export missing.');
-}
-const { findVariations: legacyFindVariations } = legacyVariationsRaw;
-
 
 /** Default port for mock OData servers when started via --mock. */
 const DEFAULT_MOCK_PORT = 8800;
@@ -524,120 +502,6 @@ ddCmd.action(
   },
 );
 
-// ── Find Variations Subcommand ──
-//
-// Mirrors `findVariations` from reso-certification-utils. Runs the frozen
-// v3.0.0 variations detection in `src/legacy/lib/variations/` against a
-// metadata-report.json. By default the cloud variations service is called
-// to fetch human-provided suggestions in addition to algorithmic ones;
-// pass --disable-variations-service-check to skip that call and use only
-// the local algorithmic suggestions.
-
-const DEFAULT_FUZZINESS = 0.25;
-const DEFAULT_DD_VERSION = '2.0';
-
-program
-  .command('find-variations')
-  .description('Find DD variations in a metadata report (frozen v3.0.0 detection)')
-  .requiredOption('-p, --metadata <path>', 'Path to metadata-report JSON file')
-  .option(
-    '-f, --fuzziness <float>',
-    `Fuzzy-match threshold (0–1, default ${DEFAULT_FUZZINESS})`,
-    String(DEFAULT_FUZZINESS)
-  )
-  .option(
-    '-v, --version <version>',
-    `Data Dictionary version (default ${DEFAULT_DD_VERSION})`,
-    DEFAULT_DD_VERSION
-  )
-  .option(
-    '--disable-variations-service-check',
-    'Skip the cloud variations service call (use algorithmic suggestions only)'
-  )
-  .action(
-    async (opts: {
-      metadata: string;
-      fuzziness: string;
-      version: string;
-      disableVariationsServiceCheck?: boolean;
-    }) => {
-      try {
-        const fuzziness = Number.parseFloat(opts.fuzziness);
-        if (!Number.isFinite(fuzziness) || fuzziness < 0 || fuzziness > 1) {
-          throw new Error(`--fuzziness must be a number in [0, 1], got '${opts.fuzziness}'`);
-        }
-
-        // Mint a fresh OAuth2 bearer token via client_credentials when the
-        // .env carries TOKEN_URI + CLIENT_ID + CLIENT_SECRET. This avoids
-        // operators having to maintain a long-lived static token. If the
-        // mint fails or env vars are missing, fall through to whatever
-        // findVariations does on its own (its fetchProviderToken path).
-        const bearerToken = opts.disableVariationsServiceCheck
-          ? undefined
-          : await mintOAuth2ClientCredentialsToken();
-
-        await legacyFindVariations({
-          pathToMetadataReportJson: resolve(opts.metadata),
-          fuzziness,
-          version: opts.version,
-          useSuggestions: !opts.disableVariationsServiceCheck,
-          fromCli: true,
-          ...(bearerToken ? { bearerToken } : {}),
-        });
-      } catch (error) {
-        console.error('Error:', error instanceof Error ? error.message : String(error));
-        process.exitCode = 2;
-      }
-    }
-  );
-
-// ── Compute Variations Subcommand ──
-//
-// Standalone variations check against the cloud /compute service for any
-// metadata-report.json — no full cert run. The matcher + the canonical /
-// in-review blend run server-side; this sends the report and prints the
-// variations. CLI auth: an OAuth2 client_credentials token from .env
-// (TOKEN_URI / CLIENT_ID / CLIENT_SECRET); if absent, the service falls back
-// to minting from CERT_AUTH_API_* creds, else it reports how to authenticate.
-
-program
-  .command('compute-variations')
-  .description('Compute DD variations for a metadata report via the cloud Variations Service')
-  .requiredOption('-p, --metadata <path>', 'Path to metadata-report JSON file')
-  .option('-v, --version <version>', `Data Dictionary version (default ${DEFAULT_DD_VERSION})`, DEFAULT_DD_VERSION)
-  .option('-f, --fuzziness <float>', `Fuzzy-match threshold (0–1, default ${DEFAULT_FUZZINESS})`, String(DEFAULT_FUZZINESS))
-  .option('-o, --output <path>', 'Write the variations report here (default: stdout)')
-  .action(async (opts: { metadata: string; version: string; fuzziness: string; output?: string }) => {
-    try {
-      const fuzziness = Number.parseFloat(opts.fuzziness);
-      if (!Number.isFinite(fuzziness) || fuzziness < 0 || fuzziness > 1) {
-        throw new Error(`--fuzziness must be a number in [0, 1], got '${opts.fuzziness}'`);
-      }
-
-      const metadataReportJson = JSON.parse(await readFile(resolve(opts.metadata), 'utf-8')) as unknown;
-      const bearerToken = await mintOAuth2ClientCredentialsToken();
-
-      const report = await computeVariationsViaService({
-        metadataReportJson,
-        version: opts.version,
-        fuzziness,
-        fromCli: true,
-        ...(bearerToken ? { bearerToken } : {}),
-      });
-
-      const out = JSON.stringify(report, null, 2);
-      if (opts.output) {
-        await writeFile(resolve(opts.output), out);
-        console.log(`Variations report written to ${resolve(opts.output)}`);
-      } else {
-        console.log(out);
-      }
-    } catch (error) {
-      console.error('Error:', error instanceof Error ? error.message : String(error));
-      process.exitCode = 2;
-    }
-  });
-
 // ── Update Variations Subcommand (Admin) ──
 //
 // Submit human-reviewed variation suggestions from a CSV to the v2 admin
@@ -978,6 +842,136 @@ program
         process.exitCode = 0;
       } catch (err) {
         process.stderr.write(`\nreplicate: ${err instanceof Error ? err.message : String(err)}\n`);
+        process.exitCode = 2;
+      }
+    },
+  );
+
+// ── Find Variations Subcommand (per-step util: DD variations review via the v2 Variations Service) ──
+//
+// The cert variations step: compute a metadata report's DD variations through the v2 Variations
+// Service (`/compute`) and emit the canonical data-dictionary-variations.json. The metadata source
+// is either a local report (--metadata, or "-" for stdin) or a live endpoint (--from-server --url,
+// whose $metadata is fetched + serialized in memory). `--output-dir -` prints the raw report to
+// stdout instead of writing the artifact. computeVariationsViaService is the engine; this command
+// is the cert wrapper around it (source resolution + canonical artifact + run summary).
+//
+// Two independent auth contexts: the provider-endpoint auth flags (--auth-token / --client-id …)
+// authenticate the --from-server $metadata fetch, while the /compute call authenticates to the
+// RESO Variations Service with .env service credentials (minted inside the service when omitted).
+
+/** Count non-empty variation categories in a service report, for the run summary. */
+const summarizeVariations = (report: VariationsServiceReport): { total: number; detail: string } => {
+  const counts = Object.entries(report.variations ?? {}).map(
+    ([key, value]) => [key, Array.isArray(value) ? value.length : 0] as const,
+  );
+  const total = counts.reduce((sum, [, n]) => sum + n, 0);
+  const detail = counts
+    .filter(([, n]) => n > 0)
+    .map(([key, n]) => `${key}: ${n}`)
+    .join(', ');
+  return { total, detail };
+};
+
+program
+  .command('find-variations')
+  .description('DD variations review for a metadata report via the v2 Variations Service')
+  .option('-m, --metadata <file>', 'Metadata report JSON (metadata-report.json), or "-" for stdin')
+  .option('--from-server', 'Fetch metadata from a live OData endpoint instead of a file (requires --url)')
+  .option('-u, --url <url>', 'OData service root URL (with --from-server)')
+  .option('-f, --fuzziness <float>', `Fuzzy-match threshold (0–1, default ${DEFAULT_FUZZINESS})`, String(DEFAULT_FUZZINESS))
+  .option('-v, --version <version>', `Data Dictionary version (default ${DEFAULT_DD_VERSION})`, DEFAULT_DD_VERSION)
+  .option('--output-dir <path>', 'Directory for data-dictionary-variations.json (created if missing); "-" for stdout', '.')
+  .option('--auth-token <token>', 'Bearer token for the --from-server endpoint')
+  .option('--client-id <id>', 'OAuth2 client_id for the --from-server endpoint (with --client-secret and --token-url)')
+  .option('--client-secret <secret>', 'OAuth2 client_secret for the --from-server endpoint')
+  .option('--token-url <url>', 'OAuth2 token endpoint URL for the --from-server endpoint')
+  .action(
+    async (opts: {
+      metadata?: string;
+      fromServer?: boolean;
+      url?: string;
+      fuzziness: string;
+      version: string;
+      outputDir: string;
+      authToken?: string;
+      clientId?: string;
+      clientSecret?: string;
+      tokenUrl?: string;
+    }) => {
+      try {
+        // Exactly one metadata source.
+        if (opts.fromServer && opts.metadata) {
+          throw new Error('--metadata and --from-server are mutually exclusive. Choose one metadata source.');
+        }
+        if (!opts.fromServer && !opts.metadata) {
+          throw new Error('Provide a metadata source: --metadata <file> (or "-" for stdin), or --from-server --url <url>.');
+        }
+
+        const fuzziness = Number.parseFloat(opts.fuzziness);
+        if (!Number.isFinite(fuzziness) || fuzziness < 0 || fuzziness > 1) {
+          throw new Error(`--fuzziness must be a number in [0, 1], got '${opts.fuzziness}'`);
+        }
+        const { version } = opts;
+
+        // Resolve the metadata report to an in-memory object. --from-server fetches the endpoint's
+        // $metadata (authenticated with the provider-endpoint auth flags) and serializes it;
+        // --metadata reads a local report (or stdin). No temporary file is written either way.
+        const resolveMetadataReport = async (): Promise<unknown> => {
+          if (opts.fromServer) {
+            const url = opts.url;
+            if (!url) throw new Error('--from-server requires --url <url> (the OData service root).');
+            const bearerToken = await resolveAuthToken(
+              resolveCliAuth({
+                authToken: opts.authToken,
+                clientId: opts.clientId,
+                clientSecret: opts.clientSecret,
+                tokenUrl: opts.tokenUrl,
+              }),
+            );
+            return fetchMetadataReportFromServer({ url, bearerToken, version });
+          }
+          const metadataPath = opts.metadata;
+          if (!metadataPath) {
+            throw new Error('Provide a metadata source: --metadata <file> (or "-" for stdin), or --from-server --url <url>.');
+          }
+          return readJsonInput(metadataPath);
+        };
+        const metadataReportJson = await resolveMetadataReport();
+
+        // The /compute token authenticates to the RESO Variations Service; minted from .env service
+        // credentials. When absent, the service mints its own (CERT_AUTH_API_*) or reports how to auth.
+        const computeToken = await mintOAuth2ClientCredentialsToken();
+
+        if (opts.outputDir === '-') {
+          // Raw report to stdout — no canonical artifact written.
+          const report = await computeVariationsViaService({
+            metadataReportJson,
+            version,
+            fuzziness,
+            fromCli: true,
+            ...(computeToken ? { bearerToken: computeToken } : {}),
+          });
+          process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+        } else {
+          const report = await findVariations({
+            metadataReportJson,
+            version,
+            fuzziness,
+            fromCli: true,
+            outputPath: resolve(opts.outputDir),
+            ...(computeToken ? { bearerToken: computeToken } : {}),
+          });
+          const { total, detail } = summarizeVariations(report);
+          process.stderr.write(
+            total > 0
+              ? `find-variations: ${total} variation(s) [${detail}] → ${resolve(opts.outputDir, VARIATIONS_REPORT_FILENAME)}\n`
+              : 'find-variations: no variations found\n',
+          );
+        }
+        process.exitCode = 0;
+      } catch (err) {
+        process.stderr.write(`find-variations: ${err instanceof Error ? err.message : String(err)}\n`);
         process.exitCode = 2;
       }
     },

--- a/reso-certification/src/index.ts
+++ b/reso-certification/src/index.ts
@@ -137,6 +137,11 @@ export type {
   FindVariationsInput,
 } from './variations/index.js';
 
+// ── Metadata source (--from-server: fetch $metadata from a live endpoint + serialize) ──
+
+export { fetchMetadataReportFromServer } from './sdk/metadata-source.js';
+export type { FetchMetadataReportFromServerInput } from './sdk/metadata-source.js';
+
 // ── Metadata Report ──
 // The serializer (serializeMetadataReport/generateMetadataReport + MetadataReport*) moved to
 // @reso-standards/reso-metadata-utils (reso-tools #221). Import from there directly.

--- a/reso-certification/src/sdk/metadata-source.ts
+++ b/reso-certification/src/sdk/metadata-source.ts
@@ -1,0 +1,38 @@
+/**
+ * Metadata source helpers — resolve a RESO Format metadata report from a live
+ * OData endpoint.
+ *
+ * The `--from-server` metadata source shared by the per-step CLI commands:
+ * fetch the CSDL/EDMX `$metadata` from a service root and serialize it to a
+ * metadata report, so a provider can run a single cert step (e.g. variations)
+ * straight against their server without first generating a report file. The
+ * `$metadata` fetch (and its OData-version detection) reuses the same wrapper
+ * the DD pipeline uses; serialization is `generateMetadataReport`.
+ */
+
+import { generateMetadataReport } from '@reso-standards/reso-metadata-utils';
+import type { MetadataReport } from '@reso-standards/reso-metadata-utils';
+import { fetchMetadataWithVersion } from '../test-runner/metadata.js';
+
+export interface FetchMetadataReportFromServerInput {
+  /** OData service root URL (no resource name or query). */
+  readonly url: string;
+  /** Bearer token for the endpoint — resolve from the CLI auth chain before calling. */
+  readonly bearerToken: string;
+  /** DD version stamped into the generated report. */
+  readonly version: string;
+}
+
+/**
+ * Fetch OData `$metadata` from a live endpoint and serialize it to an in-memory
+ * RESO Format metadata report. Throws when the fetch fails (non-OK response,
+ * propagated by {@link fetchMetadataWithVersion}) or the CSDL cannot be
+ * serialized (`generateMetadataReport`). No temporary file is written — the
+ * report is returned for a caller (e.g. the variations step) to consume directly.
+ */
+export const fetchMetadataReportFromServer = async (
+  input: FetchMetadataReportFromServerInput,
+): Promise<MetadataReport> => {
+  const { xml } = await fetchMetadataWithVersion(input.url, input.bearerToken);
+  return generateMetadataReport(xml, input.version);
+};

--- a/reso-certification/src/variations/find-variations.ts
+++ b/reso-certification/src/variations/find-variations.ts
@@ -2,10 +2,12 @@
  * findVariations — the thin-client replacement for the frozen v3.0.0 local
  * matcher.
  *
- * Reads a metadata report from disk, computes its DD variations via the backend
- * Variations Service (`computeVariationsViaService`), and writes the report to
- * an output directory when variations are found. The canonical + in-review
- * blend and the machine matching run server-side; this function is I/O glue.
+ * Takes a metadata report — from disk (`pathToMetadataReportJson`) or already
+ * in memory (`metadataReportJson`, e.g. fetched + serialized from a live server
+ * via `--from-server`) — computes its DD variations via the backend Variations
+ * Service (`computeVariationsViaService`), and writes the report to an output
+ * directory when variations are found. The canonical + in-review blend and the
+ * machine matching run server-side; this function is I/O glue.
  *
  * The input signature mirrors the legacy `findVariations` so existing call
  * sites (CLI, cert pipeline) swap over without changing their arguments. Unlike
@@ -14,14 +16,23 @@
  * `computeVariationsViaService`. Callers already wrap in try/catch.
  */
 
-import { readFile, writeFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
 import { computeVariationsViaService, type VariationsServiceReport } from './service.js';
 import { DEFAULT_DD_VERSION, DEFAULT_FUZZINESS, VARIATIONS_REPORT_FILENAME } from './constants.js';
 
 export interface FindVariationsInput {
-  /** Path to the metadata-report JSON on disk. */
-  readonly pathToMetadataReportJson: string;
+  /**
+   * Metadata source — provide exactly one of this or {@link metadataReportJson}.
+   * Path to the metadata-report JSON on disk; read + parsed by this function.
+   */
+  readonly pathToMetadataReportJson?: string;
+  /**
+   * Metadata source — provide exactly one of this or {@link pathToMetadataReportJson}.
+   * An already-in-memory metadata report, e.g. one fetched + serialized from a
+   * live server (`--from-server`), so no temporary file has to be written.
+   */
+  readonly metadataReportJson?: unknown;
   /** Fuzzy-match threshold (0–1). Defaults to {@link DEFAULT_FUZZINESS}. */
   readonly fuzziness?: number;
   /** Data Dictionary version. Defaults to {@link DEFAULT_DD_VERSION}. */
@@ -49,9 +60,32 @@ export interface FindVariationsInput {
 const hasVariations = (report: VariationsServiceReport): boolean =>
   Object.values(report.variations ?? {}).some((entries) => Array.isArray(entries) && entries.length > 0);
 
+/**
+ * Resolve the metadata report from exactly one source — an in-memory report or
+ * a file path. Mutually exclusive: both or neither is a caller error, surfaced
+ * as a thrown Error rather than silently preferring one.
+ */
+const loadMetadataReport = async (input: FindVariationsInput): Promise<unknown> => {
+  const inline = input.metadataReportJson;
+  const path = input.pathToMetadataReportJson;
+  const hasInline = inline !== undefined;
+  const hasPath = typeof path === 'string' && path.length > 0;
+  if (hasInline && hasPath) {
+    throw new Error(
+      'findVariations: metadataReportJson and pathToMetadataReportJson are mutually exclusive — provide one.',
+    );
+  }
+  if (hasInline) return inline;
+  if (typeof path === 'string' && path.length > 0) {
+    return JSON.parse(await readFile(path, { encoding: 'utf8' })) as unknown;
+  }
+  throw new Error(
+    'findVariations: provide a metadata source — metadataReportJson (in-memory) or pathToMetadataReportJson (file).',
+  );
+};
+
 export const findVariations = async (input: FindVariationsInput): Promise<VariationsServiceReport> => {
   const {
-    pathToMetadataReportJson,
     fuzziness = DEFAULT_FUZZINESS,
     version = DEFAULT_DD_VERSION,
     fromCli,
@@ -59,9 +93,7 @@ export const findVariations = async (input: FindVariationsInput): Promise<Variat
     bearerToken,
   } = input;
 
-  const metadataReportJson = JSON.parse(
-    await readFile(pathToMetadataReportJson, { encoding: 'utf8' }),
-  ) as unknown;
+  const metadataReportJson = await loadMetadataReport(input);
 
   const report = await computeVariationsViaService({
     metadataReportJson,
@@ -72,10 +104,12 @@ export const findVariations = async (input: FindVariationsInput): Promise<Variat
   });
 
   if (hasVariations(report)) {
-    await writeFile(
-      resolve(join(outputPath ?? '', VARIATIONS_REPORT_FILENAME)),
-      JSON.stringify(report, null, 2),
-    );
+    const reportPath = resolve(join(outputPath ?? '', VARIATIONS_REPORT_FILENAME));
+    // Honor the CLI's "created if missing" contract — and match every sibling writer
+    // (writeArtifact, the compliance reporters) — by creating the target directory before
+    // writing, so a per-run --output-dir like ./results/run1 works instead of ENOENT-ing.
+    await mkdir(dirname(reportPath), { recursive: true });
+    await writeFile(reportPath, JSON.stringify(report, null, 2));
   }
 
   return report;

--- a/reso-certification/tests/sdk/metadata-source.test.ts
+++ b/reso-certification/tests/sdk/metadata-source.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { readFile } from 'node:fs/promises';
+
+// Mock the $metadata fetcher so the test is offline + deterministic (no reso-client
+// HTTP path). metadata-source.ts only depends on fetchMetadataWithVersion from here.
+vi.mock('../../src/test-runner/metadata.js', () => ({
+  fetchMetadataWithVersion: vi.fn(),
+}));
+
+import { fetchMetadataWithVersion } from '../../src/test-runner/metadata.js';
+import { fetchMetadataReportFromServer } from '../../src/sdk/metadata-source.js';
+
+describe('fetchMetadataReportFromServer', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches $metadata from the endpoint (with the bearer) and serializes it to a report', async () => {
+    // good-edmx.xml carries an EntityContainer, which generateMetadataReport requires
+    // (sample-metadata.xml is deliberately the no-container negative case elsewhere).
+    const sampleEdmx = await readFile(new URL('../fixtures/commander/good-edmx.xml', import.meta.url), 'utf-8');
+    vi.mocked(fetchMetadataWithVersion).mockResolvedValue({ xml: sampleEdmx, odataVersion: '4.01' });
+
+    const report = await fetchMetadataReportFromServer({
+      url: 'https://server.example.org',
+      bearerToken: 'tok',
+      version: '2.0',
+    });
+
+    // The endpoint + bearer are passed straight through to the fetcher.
+    expect(fetchMetadataWithVersion).toHaveBeenCalledWith('https://server.example.org', 'tok');
+    // The serialized report carries fields — i.e. the CSDL was actually parsed, not passed through.
+    expect(report.fields.length).toBeGreaterThan(0);
+    expect(report.resources.length).toBeGreaterThan(0);
+  });
+
+  it('propagates a fetch failure rather than swallowing it', async () => {
+    vi.mocked(fetchMetadataWithVersion).mockRejectedValue(new Error('HTTP 401 Unauthorized'));
+
+    await expect(
+      fetchMetadataReportFromServer({ url: 'https://server.example.org', bearerToken: 'bad', version: '2.0' }),
+    ).rejects.toThrow('401');
+  });
+});

--- a/reso-certification/tests/variations/find-variations-source.test.ts
+++ b/reso-certification/tests/variations/find-variations-source.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { gzipSync } from 'node:zlib';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { findVariations } from '../../src/variations/find-variations.js';
+
+/** Encode a report the way the /compute handler does — gzip then base64. */
+const gzB64 = (obj: unknown): string => gzipSync(JSON.stringify(obj)).toString('base64');
+
+const serviceResponse = (report: unknown) => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  text: async () => gzB64(report),
+});
+
+describe('findVariations — metadata source resolution', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    delete process.env.RESO_SERVICES_URL;
+  });
+
+  it('throws when no metadata source is provided', async () => {
+    await expect(findVariations({})).rejects.toThrow(/provide a metadata source/i);
+  });
+
+  it('throws when both an in-memory report and a file path are provided', async () => {
+    await expect(
+      findVariations({ metadataReportJson: { fields: [] }, pathToMetadataReportJson: '/tmp/x.json' }),
+    ).rejects.toThrow(/mutually exclusive/i);
+  });
+
+  it('computes from an in-memory report and writes the artifact when variations exist', async () => {
+    process.env.RESO_SERVICES_URL = 'https://services.example.org';
+    const report = {
+      description: 'x',
+      version: '2.0',
+      fuzziness: 0.25,
+      variations: { fields: [{ resourceName: 'Property', suggestedFieldName: 'X' }] },
+    };
+    const fetchMock = vi.fn().mockResolvedValue(serviceResponse(report));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const dir = await mkdtemp(join(tmpdir(), 'find-variations-'));
+    try {
+      const result = await findVariations({
+        metadataReportJson: { fields: [] },
+        version: '2.0',
+        fuzziness: 0.25,
+        bearerToken: 'tok', // pass a token so the service client skips minting
+        outputPath: dir,
+      });
+
+      // The in-memory report went to /compute (not a file read), and the report came back.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toBe('https://services.example.org/v2/certification/variations/compute');
+      expect(result).toEqual(report);
+
+      // The canonical artifact was written because variations were present.
+      const written = JSON.parse(await readFile(join(dir, 'data-dictionary-variations.json'), 'utf-8'));
+      expect(written).toEqual(report);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates a nested, non-existent --output-dir before writing (honors "created if missing")', async () => {
+    process.env.RESO_SERVICES_URL = 'https://services.example.org';
+    const report = {
+      description: 'x',
+      version: '2.0',
+      fuzziness: 0.25,
+      variations: { fields: [{ resourceName: 'Property', suggestedFieldName: 'X' }] },
+    };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(serviceResponse(report)));
+
+    const base = await mkdtemp(join(tmpdir(), 'find-variations-'));
+    const nested = join(base, 'results', 'run1'); // does not exist yet
+    try {
+      await findVariations({
+        metadataReportJson: { fields: [] },
+        version: '2.0',
+        bearerToken: 'tok',
+        outputPath: nested,
+      });
+      const written = JSON.parse(await readFile(join(nested, 'data-dictionary-variations.json'), 'utf-8'));
+      expect(written).toEqual(report);
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  it('does not write an artifact when there are no variations', async () => {
+    process.env.RESO_SERVICES_URL = 'https://services.example.org';
+    const report = { description: 'x', version: '2.0', fuzziness: 0.25, variations: { fields: [] } };
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(serviceResponse(report)));
+
+    const dir = await mkdtemp(join(tmpdir(), 'find-variations-'));
+    try {
+      const result = await findVariations({
+        metadataReportJson: { fields: [] },
+        version: '2.0',
+        bearerToken: 'tok',
+        outputPath: dir,
+      });
+      expect(result).toEqual(report);
+      await expect(readFile(join(dir, 'data-dictionary-variations.json'), 'utf-8')).rejects.toThrow();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Deliverable 4 of the CLI epic (#251) — `find-variations` over the v2 service + `--from-server`

Rewires `reso-cert find-variations` off the frozen legacy v3.0.0 matcher onto the **v2 Variations Service** (`computeVariationsViaService` → `/compute`), and gives it a **metadata source**:

- `--metadata <file>` (or `-` for stdin) — a local metadata report (default).
- `--from-server --url <url>` (+ provider auth flags) — fetch the endpoint's `$metadata` and serialize it in memory (no temp file), so a provider can run just the variations step against their server.
- `--output-dir <path>` (default `.`, `-` = stdout) — writes the canonical `data-dictionary-variations.json` for the cert path, or prints the raw report to stdout.

Per direction: **one command**, backed by the compute engine (`computeVariations` is the engine; `find` is the cert wrapper). The redundant `compute-variations` command and the legacy CJS bridge are removed — both unreleased/internal, so nothing published breaks; the compute engine and its test suite are untouched.

### Changes
- **New** `src/sdk/metadata-source.ts` — `fetchMetadataReportFromServer` (the shared `--from-server` source: fetch `$metadata` → `generateMetadataReport`).
- **`src/variations/find-variations.ts`** — accept an in-memory `metadataReportJson` alongside the file path (exactly one of the two); `mkdir` the output dir before writing.
- **`src/cli/index.ts`** — the rewired `find-variations` command; `compute-variations` + the legacy bridge removed.
- **`src/index.ts`** — export the new SDK helper.
- **Tests** — `tests/sdk/metadata-source.test.ts`, `tests/variations/find-variations-source.test.ts` (+1 for the output-dir fix).

### Two auth contexts
- The `--from-server` `$metadata` fetch authenticates to the **provider endpoint** (`--auth-token` / `--client-id` …).
- The `/compute` call authenticates to the **RESO Variations Service** (`.env` service credentials; the service mints its own when omitted).

### Verification
- `tsc` clean; full suite **816 passed + 2 expected-fail**.
- Adversarial refute-by-default review over the diff (correctness / auth-security / back-compat / test-coverage). **One defect confirmed and fixed:** `--output-dir` didn't honor its documented "created if missing" (`writeFile` with no `mkdir` → ENOENT + lost report); now `mkdir`s recursively, with a fails-before/passes-after test. The **two-auth wiring was verified clean** (auth lens: zero findings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
