### PR TITLE
RCF schema-inference module — data → DD-2.0 metadata report (#251 deliv 5, PR-A)

### DIFF
--- a/reso-certification/src/rcf/aggregate.ts
+++ b/reso-certification/src/rcf/aggregate.ts
@@ -1,0 +1,91 @@
+/**
+ * Local-field type aggregation for RCF schema inference (C3).
+ *
+ * A local (non-DD) field is observed across many sampled records; `inferType`
+ * types each value. This folds those per-value types into ONE field descriptor:
+ * widen integers to the largest observed width, take the max Decimal
+ * scale/precision and the max string length, mark nullable when any value was
+ * null/blank, and detect collections and expansions. When observations disagree
+ * irreconcilably, `Edm.String` is the safe container.
+ *
+ * DD (reference) fields never come here — their types come from reference
+ * metadata (ground truth). This is only for fields absent from the reference.
+ */
+
+import { inferType } from './infer-type.js';
+import { isValidValue } from './values.js';
+
+export interface AggregatedFieldType {
+  readonly type: string;
+  readonly isCollection?: boolean;
+  readonly isExpansion?: boolean;
+  readonly nullable?: boolean;
+  readonly maxLength?: number;
+  readonly scale?: number;
+  readonly precision?: number;
+}
+
+/** Edm integer widths, smallest → largest, for widening. */
+const INT_WIDTH: Readonly<Record<string, number>> = { 'Edm.Int16': 1, 'Edm.Int32': 2, 'Edm.Int64': 3 };
+
+const widestInt = (types: ReadonlyArray<string>): string =>
+  types.reduce((widest, t) => ((INT_WIDTH[t] ?? 0) > (INT_WIDTH[widest] ?? 0) ? t : widest), 'Edm.Int16');
+
+const withNullable = (base: AggregatedFieldType, nullable: boolean): AggregatedFieldType =>
+  nullable ? { ...base, nullable: true } : base;
+
+/**
+ * Fold a local field's raw sampled values into a single type descriptor.
+ * Recurses element-wise for collections. `nullable` reflects the whole field
+ * (any null/blank observation), independent of collection depth.
+ */
+export const aggregateFieldType = (values: ReadonlyArray<unknown>): AggregatedFieldType => {
+  const nullable = values.some(v => !isValidValue(v));
+  const valid = values.filter(isValidValue);
+  if (valid.length === 0) return withNullable({ type: 'Edm.String' }, nullable);
+
+  // Collection: any observation is an array → aggregate the flattened element values.
+  const arrays = valid.filter(Array.isArray);
+  if (arrays.length > 0) {
+    const elementAgg = aggregateFieldType(arrays.flat());
+    return { ...elementAgg, isCollection: true, ...(nullable ? { nullable: true } : {}) };
+  }
+
+  // Nested object → an expansion / custom complex type.
+  if (valid.some(v => typeof v === 'object')) {
+    return withNullable({ type: 'Custom Type', isExpansion: true }, nullable);
+  }
+
+  const inferred = valid.map(inferType);
+  const types = [...new Set(inferred.map(t => t.type).filter((t): t is string => typeof t === 'string'))];
+
+  // Numeric: all integers → widest; any decimal in the mix → Decimal with max scale/precision.
+  if (types.every(t => t in INT_WIDTH)) {
+    return withNullable({ type: widestInt(types) }, nullable);
+  }
+  if (types.every(t => t in INT_WIDTH || t === 'Edm.Decimal')) {
+    const scale = Math.max(0, ...inferred.map(t => t.scale ?? 0));
+    // precision must cover the widest integer part PLUS the deepest fractional part — taking
+    // independent maxes (and letting integers contribute 0) under-counts, e.g. [12345, 1.5]
+    // would give precision 2, which cannot hold 12345.
+    const intDigits = Math.max(0, ...valid.map(v => (typeof v === 'number' ? Math.abs(Math.trunc(v)).toString().length : 0)));
+    const precision = intDigits + scale;
+    return withNullable(
+      { type: 'Edm.Decimal', ...(scale ? { scale } : {}), ...(precision ? { precision } : {}) },
+      nullable,
+    );
+  }
+
+  // A single homogeneous temporal type is kept; strings (or any string/temporal mix) → Edm.String
+  // with the max observed length.
+  if (types.length === 1 && (types[0] === 'Edm.Date' || types[0] === 'Edm.DateTimeOffset' || types[0] === 'Edm.Boolean')) {
+    return withNullable({ type: types[0] }, nullable);
+  }
+  if (types.every(t => t === 'Edm.String' || t === 'Edm.Date' || t === 'Edm.DateTimeOffset')) {
+    const maxLength = Math.max(0, ...valid.map(v => (typeof v === 'string' ? v.length : 0)));
+    return withNullable({ type: 'Edm.String', ...(maxLength ? { maxLength } : {}) }, nullable);
+  }
+
+  // Anything else (genuinely mixed incompatible types) → Edm.String is the safe container.
+  return withNullable({ type: 'Edm.String' }, nullable);
+};

--- a/reso-certification/src/rcf/aggregate.ts
+++ b/reso-certification/src/rcf/aggregate.ts
@@ -31,6 +31,10 @@ const INT_WIDTH: Readonly<Record<string, number>> = { 'Edm.Int16': 1, 'Edm.Int32
 const widestInt = (types: ReadonlyArray<string>): string =>
   types.reduce((widest, t) => ((INT_WIDTH[t] ?? 0) > (INT_WIDTH[widest] ?? 0) ? t : widest), 'Edm.Int16');
 
+// Max of a numeric list by reduction, NOT `Math.max(0, ...nums)`: a collection field flattens to its
+// element values, which can exceed the argument-count limit (~125k in V8) and overflow the call stack.
+const maxOf = (nums: ReadonlyArray<number>): number => nums.reduce((m, n) => (n > m ? n : m), 0);
+
 const withNullable = (base: AggregatedFieldType, nullable: boolean): AggregatedFieldType =>
   nullable ? { ...base, nullable: true } : base;
 
@@ -64,11 +68,11 @@ export const aggregateFieldType = (values: ReadonlyArray<unknown>): AggregatedFi
     return withNullable({ type: widestInt(types) }, nullable);
   }
   if (types.every(t => t in INT_WIDTH || t === 'Edm.Decimal')) {
-    const scale = Math.max(0, ...inferred.map(t => t.scale ?? 0));
+    const scale = maxOf(inferred.map(t => t.scale ?? 0));
     // precision must cover the widest integer part PLUS the deepest fractional part — taking
     // independent maxes (and letting integers contribute 0) under-counts, e.g. [12345, 1.5]
     // would give precision 2, which cannot hold 12345.
-    const intDigits = Math.max(0, ...valid.map(v => (typeof v === 'number' ? Math.abs(Math.trunc(v)).toString().length : 0)));
+    const intDigits = maxOf(valid.map(v => (typeof v === 'number' ? Math.abs(Math.trunc(v)).toString().length : 0)));
     const precision = intDigits + scale;
     return withNullable(
       { type: 'Edm.Decimal', ...(scale ? { scale } : {}), ...(precision ? { precision } : {}) },
@@ -82,7 +86,7 @@ export const aggregateFieldType = (values: ReadonlyArray<unknown>): AggregatedFi
     return withNullable({ type: types[0] }, nullable);
   }
   if (types.every(t => t === 'Edm.String' || t === 'Edm.Date' || t === 'Edm.DateTimeOffset')) {
-    const maxLength = Math.max(0, ...valid.map(v => (typeof v === 'string' ? v.length : 0)));
+    const maxLength = maxOf(valid.map(v => (typeof v === 'string' ? v.length : 0)));
     return withNullable({ type: 'Edm.String', ...(maxLength ? { maxLength } : {}) }, nullable);
   }
 

--- a/reso-certification/src/rcf/assemble-report.ts
+++ b/reso-certification/src/rcf/assemble-report.ts
@@ -1,0 +1,259 @@
+/**
+ * Assemble an inferred DD-2.0 metadata report from sampled RCF records (C5 + assembly).
+ *
+ * Ties the inference pieces together. For each observed (resource, field):
+ *   - DD field (present in the injected reference map) → carry the reference
+ *     TYPE and shape (ground truth, never inferred). If it is a lookup field,
+ *     emit its observed values as lookups, annotating the ones that match the
+ *     reference StandardName (`lookupValues`) / LegacyOData (`legacyODataValues`)
+ *     sets with their `RESO.DDWikiUrl`.
+ *   - Local field (absent from the reference) → infer the type by aggregation;
+ *     an all-`Edm.String` field that reads as an enumeration (bounded, repeating)
+ *     emits local lookups (`Edm.String`), otherwise it is a plain string field.
+ *
+ * The reference map is injected (built from `buildMetadataMap(getReferenceMetadata(version))`
+ * by the caller) so this module stays pure and unit-testable with fixtures.
+ *
+ * OPEN (validate in the e2e against the variations service): for a DD lookup
+ * field we emit ALL observed distinct values — the reference-matching ones for
+ * context and the NON-matching ones so the variations service can flag them as
+ * value variations. If the service expects only matching values, restrict the
+ * emission in the command layer; it is a one-line filter here.
+ */
+
+import type { MetadataReport, MetadataReportField, MetadataReportLookup } from '@reso-standards/reso-metadata-utils';
+import { aggregateFieldType } from './aggregate.js';
+import { classifyStringField, stringFieldStats } from './local-enum-detection.js';
+import { isValidValue } from './values.js';
+
+const DD_WIKI_URL_TERM = 'RESO.DDWikiUrl';
+
+/** A reference lookup value entry, as produced by `buildMetadataMap`. */
+export interface ReferenceLookupEntry {
+  readonly type: string;
+  readonly lookupName: string;
+  readonly lookupValue?: string;
+  readonly legacyODataValue?: string;
+  readonly ddWikiUrl?: string;
+  readonly standardLookupValue?: string;
+  readonly isStringEnumeration?: boolean;
+}
+
+/** A reference field entry, as produced by `buildMetadataMap` (`map[resource][field]`). */
+export interface ReferenceField {
+  readonly type: string;
+  readonly typeName?: string;
+  readonly nullable?: boolean;
+  readonly isExpansion?: boolean;
+  readonly isCollection?: boolean;
+  readonly isLookupField?: boolean;
+  readonly isComplexType?: boolean;
+  readonly ddWikiUrl?: string;
+  readonly lookupValues?: Readonly<Record<string, ReferenceLookupEntry>>;
+  readonly legacyODataValues?: Readonly<Record<string, ReferenceLookupEntry>>;
+}
+
+export type ReferenceMap = Readonly<Record<string, Readonly<Record<string, ReferenceField>>>>;
+
+/** Accumulated observed values per resource → field. */
+export type PayloadCache = Record<string, Record<string, unknown[]>>;
+
+export interface InferMetadataReportInput {
+  /** Sampled records grouped by (root) resource name. Expansions are discovered by recursion. */
+  readonly recordsByResource: Readonly<Record<string, ReadonlyArray<unknown>>>;
+  /** Reference DD metadata map (`buildMetadataMap(getReferenceMetadata(version))`). */
+  readonly referenceMap: ReferenceMap;
+  readonly version: string;
+  /** ISO timestamp for the report; injected so this function stays deterministic. */
+  readonly generatedOn: string;
+  readonly description?: string;
+}
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+const push = (cache: PayloadCache, resource: string, field: string, value: unknown): void => {
+  (cache[resource] ??= {})[field] ??= [];
+  cache[resource][field].push(value);
+};
+
+/**
+ * Accumulate observed values per (resource, field), recursing into nested objects
+ * as expansions. A DD expansion's target resource comes from the reference
+ * `typeName`; a local nested object recurses under the field name. OData/RESO
+ * annotation keys (`@…`) are skipped.
+ */
+export const buildPayloadCache = (
+  records: ReadonlyArray<unknown>,
+  resourceName: string,
+  referenceMap: ReferenceMap,
+  cache: PayloadCache = {},
+  // Records seen per resource — a field observed fewer times than its resource's record count
+  // was absent from some records (jagged data), which the assembler treats as nullable.
+  recordCounts: Record<string, number> = {},
+): PayloadCache => {
+  for (const record of records) {
+    if (!isPlainObject(record)) continue;
+    recordCounts[resourceName] = (recordCounts[resourceName] ?? 0) + 1;
+    for (const [field, value] of Object.entries(record)) {
+      if (field.startsWith('@')) continue; // OData/RESO annotations, not data fields
+      push(cache, resourceName, field, value);
+
+      const ref = referenceMap[resourceName]?.[field];
+      const target = ref?.isExpansion ? ref.typeName || field : field;
+      if (Array.isArray(value) && value.some(isPlainObject)) {
+        buildPayloadCache(value.filter(isPlainObject), target, referenceMap, cache, recordCounts);
+      } else if (isPlainObject(value)) {
+        buildPayloadCache([value], target, referenceMap, cache, recordCounts);
+      }
+    }
+  }
+  return cache;
+};
+
+const ddFieldFromReference = (
+  resource: string,
+  field: string,
+  ref: ReferenceField,
+  isEnumeration: boolean,
+  nullableByAbsence: boolean,
+): MetadataReportField => {
+  const nullable = nullableByAbsence || ref.nullable === true;
+  return {
+    resourceName: resource,
+    fieldName: field,
+    type: ref.type,
+    ...(ref.typeName ? { typeName: ref.typeName } : {}),
+    ...(nullable ? { nullable: true } : ref.nullable === false ? { nullable: false } : {}),
+    ...(ref.isCollection ? { isCollection: true } : {}),
+    ...(ref.isExpansion ? { isExpansion: true } : {}),
+    // Only when the field actually emitted observed lookups — a DD enum field whose values were all
+    // null/blank in the sample carries no lookups, so claiming isEnumeration would be inconsistent
+    // (nothing to re-read, an empty enum downstream). Keep isEnumeration ⟺ has-lookups.
+    ...(isEnumeration ? { isEnumeration: true } : {}),
+    annotations: ref.ddWikiUrl ? [{ term: DD_WIKI_URL_TERM, value: ref.ddWikiUrl }] : [],
+  };
+};
+
+/**
+ * Distinct non-blank string observations of a field, preserving first-seen order.
+ * Multi-value (collection) observations are arrays, so they are flattened first —
+ * otherwise every value of a DD collection lookup (Appliances, ExteriorFeatures, …)
+ * would be dropped and the field would emit no lookups.
+ */
+const distinctStrings = (values: ReadonlyArray<unknown>): ReadonlyArray<string> => [
+  ...new Set(
+    values
+      .flatMap(v => (Array.isArray(v) ? v : [v]))
+      .filter((v): v is string => typeof v === 'string' && isValidValue(v)),
+  ),
+];
+
+/**
+ * Emit lookups for a DD lookup field: every observed value, annotated when it
+ * matches the reference. `lookupName` is the enum FQDN (= the field's `type`) so
+ * the field↔lookup link re-serializes correctly — a re-read via `buildMetadataMap`
+ * recovers `isLookupField` off `field.type === lookup.lookupName`.
+ *
+ * `type` is `Edm.String`: RCF gives us observed *string* values (not machine
+ * ordinals + display annotations like the canonical serializer), so a string
+ * enumeration is both correct for validation and the shape `buildMetadataMap`
+ * re-reads back into `lookupValues` (keyed by the observed value).
+ */
+const ddLookups = (ref: ReferenceField, values: ReadonlyArray<unknown>): MetadataReportLookup[] =>
+  distinctStrings(values).map(value => {
+    const matched = ref.lookupValues?.[value] ?? ref.legacyODataValues?.[value];
+    return {
+      lookupName: ref.type,
+      lookupValue: value,
+      type: 'Edm.String',
+      ...(matched?.ddWikiUrl ? { annotations: [{ term: DD_WIKI_URL_TERM, value: matched.ddWikiUrl }] } : {}),
+    };
+  });
+
+const localScalarField = (resource: string, field: string, type: string, extra: Partial<MetadataReportField>): MetadataReportField => ({
+  resourceName: resource,
+  fieldName: field,
+  type,
+  ...extra,
+  annotations: [],
+});
+
+/**
+ * Build the field + any lookups for a LOCAL (non-DD) field. A repeating,
+ * bounded all-string field becomes a local enumeration (field type = the local
+ * lookup name `Resource.Field`, one `Edm.String` lookup per distinct value);
+ * otherwise it is a plain field of the aggregated type.
+ */
+const localFieldAndLookups = (
+  resource: string,
+  field: string,
+  values: ReadonlyArray<unknown>,
+  nullableByAbsence: boolean,
+): { readonly field: MetadataReportField; readonly lookups: ReadonlyArray<MetadataReportLookup> } => {
+  const agg = aggregateFieldType(values);
+  const extra: Partial<MetadataReportField> = {
+    ...(agg.isCollection ? { isCollection: true } : {}),
+    // A local nested object recurses under the field name in buildPayloadCache, so its
+    // typeName must be that same field name for the schema $ref (#/definitions/<typeName>) to resolve.
+    ...(agg.isExpansion ? { isExpansion: true, typeName: field } : {}),
+    ...(agg.nullable || nullableByAbsence ? { nullable: true } : {}),
+    ...(agg.maxLength ? { maxLength: agg.maxLength } : {}),
+    ...(agg.scale ? { scale: agg.scale } : {}),
+    ...(agg.precision ? { precision: agg.precision } : {}),
+  };
+
+  if (agg.type === 'Edm.String' && !agg.isExpansion && classifyStringField(stringFieldStats(values)) === 'enum') {
+    const lookupName = `${resource}.${field}`;
+    const lookups = distinctStrings(values)
+      .filter(v => Number.isNaN(Number(v)))
+      .map(value => ({ lookupName, lookupValue: value, type: 'Edm.String' }));
+    return { field: localScalarField(resource, field, lookupName, extra), lookups };
+  }
+  return { field: localScalarField(resource, field, agg.type, extra), lookups: [] };
+};
+
+/** Assemble the DD-2.0 metadata report from an accumulated payload cache. */
+export const assembleReport = (
+  cache: PayloadCache,
+  referenceMap: ReferenceMap,
+  version: string,
+  generatedOn: string,
+  description = 'RESO Data Dictionary Metadata Report (inferred from RESO Common Format samples)',
+  recordCounts: Record<string, number> = {},
+): MetadataReport => {
+  const fields: MetadataReportField[] = [];
+  const lookups: MetadataReportLookup[] = [];
+
+  for (const [resource, fieldMap] of Object.entries(cache)) {
+    const total = recordCounts[resource] ?? 0;
+    for (const [field, values] of Object.entries(fieldMap)) {
+      // Jagged data: a field observed fewer times than the resource's record count was absent
+      // from some records → nullable. (total 0 = counts not supplied; fall back to value-based only.)
+      const nullableByAbsence = total > 0 && values.length < total;
+      const ref = referenceMap[resource]?.[field];
+      if (ref) {
+        const fieldLookups = ref.isLookupField ? ddLookups(ref, values) : [];
+        fields.push(ddFieldFromReference(resource, field, ref, fieldLookups.length > 0, nullableByAbsence));
+        lookups.push(...fieldLookups);
+      } else {
+        const built = localFieldAndLookups(resource, field, values, nullableByAbsence);
+        fields.push(built.field);
+        lookups.push(...built.lookups);
+      }
+    }
+  }
+
+  const resources = Object.keys(cache).map(resourceName => ({ resourceName }));
+  return { description, version, generatedOn, resources, fields, lookups, actions: [], functions: [] };
+};
+
+/** Infer a DD-2.0 metadata report from sampled RCF records grouped by resource. */
+export const inferMetadataReport = (input: InferMetadataReportInput): MetadataReport => {
+  const cache: PayloadCache = {};
+  const recordCounts: Record<string, number> = {};
+  for (const [resource, records] of Object.entries(input.recordsByResource)) {
+    buildPayloadCache(records, resource, input.referenceMap, cache, recordCounts);
+  }
+  return assembleReport(cache, input.referenceMap, input.version, input.generatedOn, input.description, recordCounts);
+};

--- a/reso-certification/src/rcf/assemble-report.ts
+++ b/reso-certification/src/rcf/assemble-report.ts
@@ -235,11 +235,13 @@ export const assembleReport = (
       if (ref) {
         const fieldLookups = ref.isLookupField ? ddLookups(ref, values) : [];
         fields.push(ddFieldFromReference(resource, field, ref, fieldLookups.length > 0, nullableByAbsence));
-        lookups.push(...fieldLookups);
+        // Append element-wise, not `push(...fieldLookups)`: a spread of a very large distinct-value
+        // set would overflow the argument-count limit (cf. `maxOf` in aggregate.ts).
+        for (const l of fieldLookups) lookups.push(l);
       } else {
         const built = localFieldAndLookups(resource, field, values, nullableByAbsence);
         fields.push(built.field);
-        lookups.push(...built.lookups);
+        for (const l of built.lookups) lookups.push(l);
       }
     }
   }

--- a/reso-certification/src/rcf/index.ts
+++ b/reso-certification/src/rcf/index.ts
@@ -1,0 +1,33 @@
+/**
+ * RCF (RESO Common Format) schema inference.
+ *
+ * RCF payloads carry values, not a schema. To run the DD-2.0 machinery (schema
+ * validation + variations) against RCF data, this package INFERS a DD-2.0
+ * metadata report from sampled records: per-value typing, local-field
+ * aggregation, and — the only genuinely-hard call — enum-vs-free-text detection
+ * for local string fields. DD fields take their types from reference metadata
+ * (ground truth); only local fields are inferred. `inferMetadataReport` is the
+ * entry point.
+ */
+
+export { inferType, analyzeNumber, isValidIsoDate, isValidIsoDateTimeOffset, type InferredType } from './infer-type.js';
+export { isValidValue } from './values.js';
+export {
+  stringFieldStats,
+  classifyStringField,
+  ENUM_MIN_SAMPLE,
+  ENUM_MAX_DISTINCT_RATIO,
+  ENUM_MAX_DISTINCT,
+  type StringFieldStats,
+} from './local-enum-detection.js';
+export { aggregateFieldType, type AggregatedFieldType } from './aggregate.js';
+export {
+  inferMetadataReport,
+  assembleReport,
+  buildPayloadCache,
+  type ReferenceMap,
+  type ReferenceField,
+  type ReferenceLookupEntry,
+  type PayloadCache,
+  type InferMetadataReportInput,
+} from './assemble-report.js';

--- a/reso-certification/src/rcf/infer-type.ts
+++ b/reso-certification/src/rcf/infer-type.ts
@@ -1,0 +1,103 @@
+/**
+ * Per-value DD type inference for RESO Common Format (RCF) schema inference.
+ *
+ * RCF payloads carry values, not a schema. To run the DD-2.0 machinery (schema
+ * validation + variations) against RCF data we must INFER a DD-2.0 metadata
+ * report from the sampled records. This module is the leaf: turn a single
+ * sampled JSON value into an OData/DD `Edm.*` type descriptor, purely
+ * structurally (no reference metadata). The aggregation layer combines many of
+ * these across a field's sampled values.
+ *
+ * Clean-room reimplementation from the RESO Common Format reference behavior;
+ * the rules (integer width by range, Decimal scale/precision by digit count,
+ * ISO date/datetime probing) are chosen so an inferred report matches what the
+ * reference tooling produced, which is what downstream schema/variations expect.
+ */
+
+/** A structural type descriptor inferred from one or more sampled values. */
+export interface InferredType {
+  /** The Edm.* type for a scalar, or the sentinel `'null'` / `'object'`. Absent for a collection. */
+  readonly type?: string;
+  /** Element type descriptors, present when the value was an array. */
+  readonly types?: ReadonlyArray<InferredType>;
+  readonly isCollection?: boolean;
+  /** True when the value is (or contains) a nested object — a candidate expansion. */
+  readonly isExpansion?: boolean;
+  readonly nullable?: boolean;
+  /** Fractional-digit count for `Edm.Decimal`. */
+  readonly scale?: number;
+  /** Total-digit count (dot removed) for `Edm.Decimal`. */
+  readonly precision?: number;
+}
+
+const INT16_MIN = -32768;
+const INT16_MAX = 32767;
+const INT32_MIN = -2147483648;
+const INT32_MAX = 2147483647;
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+// ISO 8601 date-time with a required timezone offset (Z or ±HH:MM); fractional seconds optional.
+const ISO_DATETIME_OFFSET = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
+
+/** A strict `YYYY-MM-DD` that is also a real calendar date (round-trips through UTC). */
+export const isValidIsoDate = (value: string): boolean => {
+  if (!ISO_DATE.test(value)) return false;
+  const [y, m, d] = value.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  return dt.getUTCFullYear() === y && dt.getUTCMonth() === m - 1 && dt.getUTCDate() === d;
+};
+
+/** A strict ISO 8601 date-time with a timezone offset that is also a real instant. */
+export const isValidIsoDateTimeOffset = (value: string): boolean =>
+  ISO_DATETIME_OFFSET.test(value) && !Number.isNaN(Date.parse(value));
+
+/**
+ * Classify a JS number: integers narrow to the smallest Edm integer that holds
+ * them (Int16 → Int32 → Int64); non-integers become Edm.Decimal with scale =
+ * fractional-digit count and precision = total-digit count (dot removed).
+ */
+export const analyzeNumber = (n: number): InferredType => {
+  if (Number.isInteger(n)) {
+    if (n >= INT16_MIN && n <= INT16_MAX) return { type: 'Edm.Int16' };
+    if (n >= INT32_MIN && n <= INT32_MAX) return { type: 'Edm.Int32' };
+    return { type: 'Edm.Int64' };
+  }
+  const str = Math.abs(n).toString();
+  // Exponential notation (very small/large magnitudes) has no meaningful fixed
+  // digit count — still Edm.Decimal, but without asserting scale/precision.
+  if (str.includes('e') || str.includes('E')) return { type: 'Edm.Decimal' };
+  const [intPart, fracPart = ''] = str.split('.');
+  return { type: 'Edm.Decimal', scale: fracPart.length, precision: intPart.length + fracPart.length };
+};
+
+/**
+ * Infer a type descriptor from one sampled JSON value.
+ * - array   → `{ isCollection, types: [...], isExpansion: any element is }`
+ * - null    → `{ type: 'null', nullable: true }`
+ * - object  → `{ type: 'object', isExpansion: true }`
+ * - boolean → `Edm.Boolean`; number → {@link analyzeNumber}
+ * - string  → `Edm.Date` / `Edm.DateTimeOffset` (ISO probe) else `Edm.String`
+ */
+export const inferType = (value: unknown): InferredType => {
+  if (Array.isArray(value)) {
+    const types = value.map(inferType);
+    return { isCollection: true, types, isExpansion: types.some(t => t.isExpansion === true) };
+  }
+  if (value === null) return { type: 'null', nullable: true };
+  switch (typeof value) {
+    case 'boolean':
+      return { type: 'Edm.Boolean' };
+    case 'number':
+      return analyzeNumber(value);
+    case 'string':
+      if (isValidIsoDate(value)) return { type: 'Edm.Date' };
+      if (isValidIsoDateTimeOffset(value)) return { type: 'Edm.DateTimeOffset' };
+      return { type: 'Edm.String' };
+    case 'object':
+      // typeof null is 'object' but null is handled above; this is a real nested object.
+      return { type: 'object', isExpansion: true };
+    default:
+      // undefined/function/symbol cannot appear in parsed JSON; treat as a string leaf.
+      return { type: 'Edm.String' };
+  }
+};

--- a/reso-certification/src/rcf/local-enum-detection.ts
+++ b/reso-certification/src/rcf/local-enum-detection.ts
@@ -1,0 +1,59 @@
+/**
+ * Local-field enum-vs-free-text detection for RCF schema inference.
+ *
+ * The one genuinely-hard inference call. A local (non-DD) string field's values
+ * are all `Edm.String`, but the field is either an *enumeration* (a bounded,
+ * repeating set of values → emit local lookups) or *free text* (Remarks, Address
+ * → a plain string field, no lookups). The only signal is repetition: an enum's
+ * distinct value set is bounded and repeats as records accumulate; free text's
+ * distinct set grows ~linearly with the sample.
+ *
+ * DD fields never reach here — their lookup-ness is known from reference
+ * metadata. This applies ONLY to local fields, and the cost is asymmetric:
+ * mis-flagging high-cardinality free text (Remarks) as an enum dumps thousands
+ * of "lookup values" into the report and the /compute payload, while missing a
+ * real local enum only costs a few variation suggestions. So the bias is
+ * deliberately conservative — return 'enum' only on clear evidence, else 'free-text'.
+ *
+ * Thresholds are tunable constants with defaults chosen to be safe; they are
+ * meant to be calibrated against real RCF samples during the e2e phase.
+ */
+
+import { isValidValue } from './values.js';
+
+/** Minimum observed values before a verdict is trustworthy — never decide on a tiny sample. */
+export const ENUM_MIN_SAMPLE = 30;
+/** distinct / total at or below this reads as a bounded, repeating (enum) set. */
+export const ENUM_MAX_DISTINCT_RATIO = 0.5;
+/** A local enum's value set is bounded; beyond this many distinct values it is free text. */
+export const ENUM_MAX_DISTINCT = 250;
+
+export interface StringFieldStats {
+  /** Count of usable (non-blank, non-numeric-looking) string observations. */
+  readonly total: number;
+  /** Distinct usable values among them. */
+  readonly distinct: number;
+}
+
+/**
+ * Reduce a field's raw sampled values to enum-detection stats: keep non-blank
+ * strings, drop numeric-looking strings (those are numbers-as-strings, not enum
+ * members), and count total vs distinct.
+ */
+export const stringFieldStats = (values: ReadonlyArray<unknown>): StringFieldStats => {
+  const usable = values.filter(
+    (v): v is string => typeof v === 'string' && isValidValue(v) && Number.isNaN(Number(v)),
+  );
+  return { total: usable.length, distinct: new Set(usable).size };
+};
+
+/**
+ * Decide whether a local string field reads as an enumeration or free text.
+ * Conservative — every gate must pass to return 'enum', otherwise 'free-text'.
+ */
+export const classifyStringField = (stats: StringFieldStats): 'enum' | 'free-text' => {
+  if (stats.total < ENUM_MIN_SAMPLE) return 'free-text'; // not enough evidence
+  if (stats.distinct <= 1) return 'free-text'; // a constant is not a useful enumeration
+  if (stats.distinct > ENUM_MAX_DISTINCT) return 'free-text'; // unbounded → free text
+  return stats.distinct / stats.total <= ENUM_MAX_DISTINCT_RATIO ? 'enum' : 'free-text';
+};

--- a/reso-certification/src/rcf/values.ts
+++ b/reso-certification/src/rcf/values.ts
@@ -1,0 +1,11 @@
+/**
+ * Shared value predicates for RCF schema inference.
+ */
+
+/**
+ * True when a value should count toward inference — not null/undefined, and, for
+ * a string, not blank (empty or whitespace-only). Used to filter observations
+ * before typing and enum detection.
+ */
+export const isValidValue = (value: unknown): boolean =>
+  value !== null && value !== undefined && (typeof value !== 'string' || value.trim().length > 0);

--- a/reso-certification/tests/rcf/aggregate.test.ts
+++ b/reso-certification/tests/rcf/aggregate.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { aggregateFieldType } from '../../src/rcf/aggregate.js';
+
+describe('aggregateFieldType', () => {
+  it('widens integers to the largest observed width', () => {
+    expect(aggregateFieldType([1, 2, 40000])).toEqual({ type: 'Edm.Int32' });
+    expect(aggregateFieldType([1, 5_000_000_000])).toEqual({ type: 'Edm.Int64' });
+    expect(aggregateFieldType([1, 2, 3])).toEqual({ type: 'Edm.Int16' });
+  });
+
+  it('promotes an int + decimal mix to a Decimal spanning the widest int + deepest fraction', () => {
+    // 12.5 has the widest integer part (2 digits); 3.456 the deepest scale (3) ⇒ precision 2+3 = 5.
+    expect(aggregateFieldType([1, 12.5, 3.456])).toEqual({ type: 'Edm.Decimal', scale: 3, precision: 5 });
+    // 12345 (5 integer digits) with 1.5 (scale 1) ⇒ precision 6 — independent maxes would give 2.
+    expect(aggregateFieldType([12345, 1.5])).toEqual({ type: 'Edm.Decimal', scale: 1, precision: 6 });
+  });
+
+  it('takes the max length for strings', () => {
+    expect(aggregateFieldType(['ab', 'abcd', 'a'])).toEqual({ type: 'Edm.String', maxLength: 4 });
+  });
+
+  it('keeps a homogeneous temporal type', () => {
+    expect(aggregateFieldType(['2023-01-01', '2024-06-15'])).toEqual({ type: 'Edm.Date' });
+    expect(aggregateFieldType(['2023-01-01T00:00:00Z'])).toEqual({ type: 'Edm.DateTimeOffset' });
+  });
+
+  it('boolean stays boolean', () => {
+    expect(aggregateFieldType([true, false, true])).toEqual({ type: 'Edm.Boolean' });
+  });
+
+  it('marks nullable when any value is null or blank', () => {
+    expect(aggregateFieldType(['a', null, 'bb'])).toEqual({ type: 'Edm.String', maxLength: 2, nullable: true });
+    expect(aggregateFieldType([1, 2, ''])).toEqual({ type: 'Edm.Int16', nullable: true });
+  });
+
+  it('detects a collection and aggregates its elements', () => {
+    expect(aggregateFieldType([['A', 'BB'], ['CCC']])).toEqual({ type: 'Edm.String', maxLength: 3, isCollection: true });
+  });
+
+  it('detects nested objects as an expansion / custom type', () => {
+    expect(aggregateFieldType([{ a: 1 }, { a: 2 }])).toEqual({ type: 'Custom Type', isExpansion: true });
+  });
+
+  it('a temporal + free-text mix falls back to Edm.String', () => {
+    expect(aggregateFieldType(['2023-01-01', 'sometime last week'])).toEqual({ type: 'Edm.String', maxLength: 18 });
+  });
+
+  it('genuinely mixed incompatible types fall back to Edm.String', () => {
+    expect(aggregateFieldType([1, 'text', true])).toEqual({ type: 'Edm.String' });
+  });
+
+  it('all-null/blank observations default to a nullable Edm.String', () => {
+    expect(aggregateFieldType([null, '', '   '])).toEqual({ type: 'Edm.String', nullable: true });
+  });
+});

--- a/reso-certification/tests/rcf/aggregate.test.ts
+++ b/reso-certification/tests/rcf/aggregate.test.ts
@@ -37,6 +37,13 @@ describe('aggregateFieldType', () => {
     expect(aggregateFieldType([['A', 'BB'], ['CCC']])).toEqual({ type: 'Edm.String', maxLength: 3, isCollection: true });
   });
 
+  it('handles a large collection without overflowing the call stack (regression)', () => {
+    // A collection whose flattened element count exceeds V8's argument-count limit (~125k):
+    // `Math.max(0, ...elements)` overflowed here on a real 58k-record payload; `maxOf` reduces instead.
+    const bigCollection = [Array.from({ length: 200_000 }, (_, i) => (i === 0 ? 'longeststring' : 'x'))];
+    expect(aggregateFieldType(bigCollection)).toEqual({ type: 'Edm.String', maxLength: 13, isCollection: true });
+  });
+
   it('detects nested objects as an expansion / custom type', () => {
     expect(aggregateFieldType([{ a: 1 }, { a: 2 }])).toEqual({ type: 'Custom Type', isExpansion: true });
   });

--- a/reso-certification/tests/rcf/assemble-report.test.ts
+++ b/reso-certification/tests/rcf/assemble-report.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { inferMetadataReport, buildPayloadCache, type ReferenceMap } from '../../src/rcf/assemble-report.js';
+import type { MetadataReportField, MetadataReportLookup } from '@reso-standards/reso-metadata-utils';
+
+// The variations service re-reads a report via the legacy buildMetadataMap; use it to prove the
+// inferred report's field↔lookup serialization round-trips (isLookupField recovered off field.type).
+const requireLegacy = createRequire(import.meta.url);
+const { buildMetadataMap } = requireLegacy(
+  resolve(dirname(fileURLToPath(import.meta.url)), '../../src/legacy/common.js'),
+) as {
+  buildMetadataMap: (report: unknown) => {
+    metadataMap: Record<string, Record<string, { isLookupField?: boolean; lookupValues?: Record<string, unknown> }>>;
+  };
+};
+
+const referenceMap: ReferenceMap = {
+  Property: {
+    ListPrice: { type: 'Edm.Decimal', nullable: true, ddWikiUrl: 'https://ddwiki.reso.org/ListPrice' },
+    PropertyType: {
+      type: 'org.reso.metadata.enums.PropertyType',
+      isLookupField: true,
+      ddWikiUrl: 'https://ddwiki.reso.org/PropertyType',
+      lookupValues: {
+        Residential: {
+          type: 'org.reso.metadata.enums.PropertyType',
+          lookupName: 'PropertyType',
+          lookupValue: 'Residential',
+          ddWikiUrl: 'https://ddwiki.reso.org/PropertyType/Residential',
+        },
+      },
+      legacyODataValues: {},
+    },
+    Media: { type: 'Collection(org.reso.metadata.Media)', isExpansion: true, isCollection: true, typeName: 'Media' },
+  },
+  Media: {
+    MediaKey: { type: 'Edm.String', nullable: false, ddWikiUrl: 'https://ddwiki.reso.org/MediaKey' },
+  },
+};
+
+// 40 records — above the enum min-sample. PropertyType is a DD lookup with a
+// matched value + a variation; LocalStatus is a repeating local enum;
+// LocalRemarks is unique-per-record free text; Media is a DD expansion.
+const records = Array.from({ length: 40 }, (_, i) => ({
+  '@reso.context': 'urn:reso:metadata:2.0:resource:property',
+  ListPrice: i === 0 ? 100000 : 250000.5,
+  PropertyType: i % 5 === 0 ? 'Residentail' : 'Residential',
+  LocalStatus: ['Active', 'Pending', 'Closed'][i % 3],
+  LocalRemarks: `Unique remark number ${i}`,
+  Media: [{ MediaKey: `m${i}` }],
+}));
+
+const field = (fields: ReadonlyArray<MetadataReportField>, resource: string, name: string): MetadataReportField | undefined =>
+  fields.find(f => f.resourceName === resource && f.fieldName === name);
+const lookupsFor = (lookups: ReadonlyArray<MetadataReportLookup>, name: string): ReadonlyArray<MetadataReportLookup> =>
+  lookups.filter(l => l.lookupName === name);
+
+describe('inferMetadataReport', () => {
+  const report = inferMetadataReport({
+    recordsByResource: { Property: records },
+    referenceMap,
+    version: '2.0',
+    generatedOn: '2026-01-01T00:00:00.000Z',
+  });
+
+  it('stamps version + generatedOn and lists the root + expanded resources', () => {
+    expect(report.version).toBe('2.0');
+    expect(report.generatedOn).toBe('2026-01-01T00:00:00.000Z');
+    expect(report.resources.map(r => r.resourceName).sort()).toEqual(['Media', 'Property']);
+  });
+
+  it('skips @-prefixed OData/RESO annotation keys', () => {
+    expect(field(report.fields, 'Property', '@reso.context')).toBeUndefined();
+  });
+
+  it('carries a DD field type from reference ground truth, not from the values', () => {
+    // ListPrice is observed as an integer (100000) in one record, but the reference says Decimal.
+    const listPrice = field(report.fields, 'Property', 'ListPrice');
+    expect(listPrice?.type).toBe('Edm.Decimal');
+    expect(listPrice?.annotations).toContainEqual({ term: 'RESO.DDWikiUrl', value: 'https://ddwiki.reso.org/ListPrice' });
+  });
+
+  it('serializes a DD lookup field on the enum FQDN (= field.type) and marks it isEnumeration', () => {
+    const propTypeField = field(report.fields, 'Property', 'PropertyType');
+    expect(propTypeField?.type).toBe('org.reso.metadata.enums.PropertyType');
+    expect(propTypeField?.isEnumeration).toBe(true);
+
+    // lookupName === field.type (the FQDN) so a re-read reconstructs the field↔lookup link.
+    const propTypeLookups = lookupsFor(report.lookups, 'org.reso.metadata.enums.PropertyType');
+    const residential = propTypeLookups.find(l => l.lookupValue === 'Residential');
+    const variation = propTypeLookups.find(l => l.lookupValue === 'Residentail');
+
+    // lookup.type is the underlying Edm type (a string enumeration for observed values), not the FQDN.
+    expect(propTypeLookups.every(l => l.type === 'Edm.String')).toBe(true);
+    expect(residential?.annotations).toContainEqual({
+      term: 'RESO.DDWikiUrl',
+      value: 'https://ddwiki.reso.org/PropertyType/Residential',
+    });
+    // The variation is still emitted (so the variations service can flag it) but carries no DD annotation.
+    expect(variation).toBeDefined();
+    expect(variation?.annotations).toBeUndefined();
+  });
+
+  it('round-trips: buildMetadataMap recovers the DD lookup field from the serialized report', () => {
+    const { metadataMap } = buildMetadataMap(report);
+    const pt = metadataMap.Property?.PropertyType;
+    expect(pt?.isLookupField).toBe(true);
+    expect(Object.keys(pt?.lookupValues ?? {})).toContain('Residential');
+  });
+
+  it('detects a repeating local string field as a local enumeration', () => {
+    const status = field(report.fields, 'Property', 'LocalStatus');
+    expect(status?.type).toBe('Property.LocalStatus');
+    const statusLookups = lookupsFor(report.lookups, 'Property.LocalStatus');
+    expect(statusLookups.map(l => l.lookupValue).sort()).toEqual(['Active', 'Closed', 'Pending']);
+    expect(statusLookups.every(l => l.type === 'Edm.String')).toBe(true);
+  });
+
+  it('leaves a unique-per-record local string field as free text (no lookups)', () => {
+    const remarks = field(report.fields, 'Property', 'LocalRemarks');
+    expect(remarks?.type).toBe('Edm.String');
+    expect(lookupsFor(report.lookups, 'Property.LocalRemarks')).toHaveLength(0);
+  });
+
+  it('recurses expansions into their reference target resource', () => {
+    const mediaKey = field(report.fields, 'Media', 'MediaKey');
+    expect(mediaKey?.type).toBe('Edm.String');
+  });
+});
+
+describe('buildPayloadCache', () => {
+  it('accumulates values per field and recurses nested objects', () => {
+    const cache = buildPayloadCache(
+      [{ '@odata.id': 'x', A: 1, Nested: { B: 'y' } }],
+      'Root',
+      { Root: { Nested: { type: 'Edm.ComplexType', isExpansion: true, typeName: 'NestedType' } } },
+    );
+    expect(cache.Root.A).toEqual([1]);
+    expect(cache.Root['@odata.id']).toBeUndefined(); // annotation skipped
+    expect(cache.NestedType.B).toEqual(['y']); // recursed under the reference typeName
+  });
+});
+
+describe('inferMetadataReport — DD collection (multi-value) lookup fields', () => {
+  const refMap: ReferenceMap = {
+    Property: {
+      Appliances: {
+        type: 'org.reso.metadata.enums.Appliances',
+        isLookupField: true,
+        isCollection: true,
+        ddWikiUrl: 'https://ddwiki.reso.org/Appliances',
+        lookupValues: {
+          Dishwasher: {
+            type: 'org.reso.metadata.enums.Appliances',
+            lookupName: 'Appliances',
+            lookupValue: 'Dishwasher',
+            ddWikiUrl: 'https://ddwiki.reso.org/Appliances/Dishwasher',
+          },
+          Dryer: { type: 'org.reso.metadata.enums.Appliances', lookupName: 'Appliances', lookupValue: 'Dryer' },
+        },
+        legacyODataValues: {},
+      },
+    },
+  };
+
+  it('flattens array observations and emits each distinct element (match annotated, variation bare)', () => {
+    const report = inferMetadataReport({
+      recordsByResource: {
+        Property: [{ Appliances: ['Dishwasher', 'Dryer'] }, { Appliances: ['Dishwasher', 'MicrowaveXYZ'] }],
+      },
+      referenceMap: refMap,
+      version: '2.0',
+      generatedOn: '2026-01-01T00:00:00.000Z',
+    });
+    const lookups = report.lookups.filter(l => l.lookupName === 'org.reso.metadata.enums.Appliances');
+    expect(lookups.map(l => l.lookupValue).sort()).toEqual(['Dishwasher', 'Dryer', 'MicrowaveXYZ']);
+    expect(lookups.find(l => l.lookupValue === 'Dishwasher')?.annotations).toBeDefined(); // matched → annotated
+    expect(lookups.find(l => l.lookupValue === 'MicrowaveXYZ')?.annotations).toBeUndefined(); // variation → bare
+  });
+});
+
+describe('inferMetadataReport — DD enum field with no observed values', () => {
+  it('does not mark isEnumeration or emit lookups when all values are null/blank', () => {
+    const refMap: ReferenceMap = {
+      Property: {
+        StandardStatus: {
+          type: 'org.reso.metadata.enums.StandardStatus',
+          isLookupField: true,
+          nullable: true,
+          ddWikiUrl: 'https://ddwiki.reso.org/StandardStatus',
+          lookupValues: {
+            Active: { type: 'org.reso.metadata.enums.StandardStatus', lookupName: 'StandardStatus', lookupValue: 'Active' },
+          },
+          legacyODataValues: {},
+        },
+      },
+    };
+    const report = inferMetadataReport({
+      recordsByResource: { Property: [{ StandardStatus: null }, { StandardStatus: '' }, { StandardStatus: null }] },
+      referenceMap: refMap,
+      version: '2.0',
+      generatedOn: '2026-01-01T00:00:00.000Z',
+    });
+    const f = report.fields.find(x => x.fieldName === 'StandardStatus');
+    expect(f?.type).toBe('org.reso.metadata.enums.StandardStatus'); // still the DD field
+    expect(f?.isEnumeration).toBeUndefined(); // but not an enumeration — no observed values
+    expect(report.lookups.filter(l => l.lookupName === 'org.reso.metadata.enums.StandardStatus')).toHaveLength(0);
+  });
+});
+
+describe('inferMetadataReport — local nested-object field', () => {
+  it('emits a local expansion with typeName = field name so its schema $ref resolves', () => {
+    const report = inferMetadataReport({
+      recordsByResource: { Property: [{ LocalDetails: { Foo: 'a', Num: 1 } }, { LocalDetails: { Foo: 'b', Num: 2 } }] },
+      referenceMap: {},
+      version: '2.0',
+      generatedOn: '2026-01-01T00:00:00.000Z',
+    });
+    const local = report.fields.find(f => f.resourceName === 'Property' && f.fieldName === 'LocalDetails');
+    expect(local?.isExpansion).toBe(true);
+    expect(local?.typeName).toBe('LocalDetails'); // matches the buildPayloadCache recursion target
+    expect(report.resources.map(r => r.resourceName)).toContain('LocalDetails');
+    expect(report.fields.some(f => f.resourceName === 'LocalDetails' && f.fieldName === 'Foo')).toBe(true);
+  });
+});
+
+describe('inferMetadataReport — presence → nullable (jagged data)', () => {
+  it('marks a field nullable when it is absent from some records, not when present in all', () => {
+    const report = inferMetadataReport({
+      recordsByResource: {
+        Property: [
+          { AlwaysHere: 'a', SometimesHere: 'x' },
+          { AlwaysHere: 'b' }, // SometimesHere absent
+          { AlwaysHere: 'c' },
+        ],
+      },
+      referenceMap: {},
+      version: '2.0',
+      generatedOn: '2026-01-01T00:00:00.000Z',
+    });
+    expect(report.fields.find(f => f.fieldName === 'AlwaysHere')?.nullable).toBeUndefined(); // present in all 3
+    expect(report.fields.find(f => f.fieldName === 'SometimesHere')?.nullable).toBe(true); // absent from 2 of 3
+  });
+});

--- a/reso-certification/tests/rcf/infer-type.test.ts
+++ b/reso-certification/tests/rcf/infer-type.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import { inferType, analyzeNumber, isValidIsoDate, isValidIsoDateTimeOffset } from '../../src/rcf/infer-type.js';
+
+describe('analyzeNumber — integer width by range', () => {
+  const cases: ReadonlyArray<readonly [number, string]> = [
+    [0, 'Edm.Int16'],
+    [32767, 'Edm.Int16'],
+    [-32768, 'Edm.Int16'],
+    [32768, 'Edm.Int32'],
+    [-32769, 'Edm.Int32'],
+    [2147483647, 'Edm.Int32'],
+    [-2147483648, 'Edm.Int32'],
+    [2147483648, 'Edm.Int64'],
+    [-2147483649, 'Edm.Int64'],
+    [5_000_000_000, 'Edm.Int64'],
+  ];
+  it.each(cases)('%d → %s', (n, expected) => {
+    expect(analyzeNumber(n)).toEqual({ type: expected });
+  });
+});
+
+describe('analyzeNumber — decimals carry scale + precision', () => {
+  it('123.45 → Decimal scale 2 precision 5', () => {
+    expect(analyzeNumber(123.45)).toEqual({ type: 'Edm.Decimal', scale: 2, precision: 5 });
+  });
+  it('0.5 → Decimal scale 1 precision 2 (dot-removed digit count)', () => {
+    expect(analyzeNumber(0.5)).toEqual({ type: 'Edm.Decimal', scale: 1, precision: 2 });
+  });
+  it('-12.5 → Decimal scale 1 precision 3 (sign ignored)', () => {
+    expect(analyzeNumber(-12.5)).toEqual({ type: 'Edm.Decimal', scale: 1, precision: 3 });
+  });
+});
+
+describe('isValidIsoDate', () => {
+  it.each(['2023-01-15', '2000-02-29', '1999-12-31'])('accepts real date %s', d => {
+    expect(isValidIsoDate(d)).toBe(true);
+  });
+  it.each([
+    '2023-02-30', // not a real calendar day
+    '2023-13-01', // month 13
+    '2023-1-5', // not zero-padded
+    '2023/01/15', // wrong separators
+    '2023-01-15T00:00:00Z', // a datetime, not a date
+    'Residential', // plain string
+  ])('rejects %s', s => {
+    expect(isValidIsoDate(s)).toBe(false);
+  });
+});
+
+describe('isValidIsoDateTimeOffset', () => {
+  it.each(['2023-01-15T10:30:00Z', '2023-01-15T10:30:00.123Z', '2023-01-15T10:30:00+05:00', '2023-01-15T10:30:00-08:00'])(
+    'accepts %s',
+    s => {
+      expect(isValidIsoDateTimeOffset(s)).toBe(true);
+    },
+  );
+  it.each([
+    '2023-01-15T10:30:00', // no offset
+    '2023-01-15', // date only
+    '2023-13-15T10:30:00Z', // invalid month → NaN
+    'not-a-date',
+  ])('rejects %s', s => {
+    expect(isValidIsoDateTimeOffset(s)).toBe(false);
+  });
+});
+
+describe('inferType — scalars', () => {
+  it('boolean → Edm.Boolean', () => expect(inferType(true)).toEqual({ type: 'Edm.Boolean' }));
+  it('integer → Edm.Int16', () => expect(inferType(42)).toEqual({ type: 'Edm.Int16' }));
+  it('decimal → Edm.Decimal', () => expect(inferType(1.25)).toEqual({ type: 'Edm.Decimal', scale: 2, precision: 3 }));
+  it('ISO date string → Edm.Date', () => expect(inferType('2023-01-15')).toEqual({ type: 'Edm.Date' }));
+  it('ISO datetime string → Edm.DateTimeOffset', () =>
+    expect(inferType('2023-01-15T10:30:00Z')).toEqual({ type: 'Edm.DateTimeOffset' }));
+  it('plain string → Edm.String', () => expect(inferType('Residential')).toEqual({ type: 'Edm.String' }));
+  it('null → nullable null sentinel', () => expect(inferType(null)).toEqual({ type: 'null', nullable: true }));
+  it('nested object → expansion candidate', () => expect(inferType({ a: 1 })).toEqual({ type: 'object', isExpansion: true }));
+});
+
+describe('inferType — collections', () => {
+  it('array of scalars → isCollection, non-expansion', () => {
+    expect(inferType([1, 2])).toEqual({
+      isCollection: true,
+      types: [{ type: 'Edm.Int16' }, { type: 'Edm.Int16' }],
+      isExpansion: false,
+    });
+  });
+  it('array of objects → isCollection + isExpansion', () => {
+    expect(inferType([{ a: 1 }])).toEqual({
+      isCollection: true,
+      types: [{ type: 'object', isExpansion: true }],
+      isExpansion: true,
+    });
+  });
+  it('empty array → isCollection, no element types, non-expansion', () => {
+    expect(inferType([])).toEqual({ isCollection: true, types: [], isExpansion: false });
+  });
+});

--- a/reso-certification/tests/rcf/local-enum-detection.test.ts
+++ b/reso-certification/tests/rcf/local-enum-detection.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { stringFieldStats, classifyStringField, ENUM_MIN_SAMPLE } from '../../src/rcf/local-enum-detection.js';
+
+describe('stringFieldStats', () => {
+  it('keeps non-blank strings and counts total vs distinct', () => {
+    expect(stringFieldStats(['A', 'B', 'A', 'C'])).toEqual({ total: 4, distinct: 3 });
+  });
+  it('drops null, undefined, and blank/whitespace strings', () => {
+    expect(stringFieldStats(['A', 'A', '', '   ', null, undefined])).toEqual({ total: 2, distinct: 1 });
+  });
+  it('drops numeric-looking strings (numbers-as-strings are not enum members)', () => {
+    expect(stringFieldStats(['1', '2', 'Residential', '3.5'])).toEqual({ total: 1, distinct: 1 });
+  });
+  it('ignores non-string values entirely', () => {
+    expect(stringFieldStats([1, 2, true, 'Active', { a: 1 }])).toEqual({ total: 1, distinct: 1 });
+  });
+});
+
+describe('classifyStringField — conservative enum-vs-free-text', () => {
+  it('bounded + heavily repeating → enum', () => {
+    expect(classifyStringField({ total: 100, distinct: 10 })).toBe('enum');
+  });
+  it('near-unique values → free text', () => {
+    expect(classifyStringField({ total: 100, distinct: 95 })).toBe('free-text');
+  });
+  it('too small a sample → free text (no verdict on thin evidence)', () => {
+    expect(classifyStringField({ total: 20, distinct: 5 })).toBe('free-text');
+  });
+  it('a single constant value → free text (not a useful enum)', () => {
+    expect(classifyStringField({ total: 100, distinct: 1 })).toBe('free-text');
+  });
+  it('unbounded distinct set (> cap) → free text', () => {
+    expect(classifyStringField({ total: 1000, distinct: 300 })).toBe('free-text');
+  });
+
+  describe('boundaries', () => {
+    it(`exactly the min sample (${ENUM_MIN_SAMPLE}) with low ratio → enum`, () => {
+      expect(classifyStringField({ total: ENUM_MIN_SAMPLE, distinct: 5 })).toBe('enum');
+    });
+    it('one below the min sample → free text', () => {
+      expect(classifyStringField({ total: ENUM_MIN_SAMPLE - 1, distinct: 5 })).toBe('free-text');
+    });
+    it('distinct ratio exactly at the cutoff (0.5) → enum', () => {
+      expect(classifyStringField({ total: 100, distinct: 50 })).toBe('enum');
+    });
+    it('distinct ratio just over the cutoff → free text', () => {
+      expect(classifyStringField({ total: 100, distinct: 51 })).toBe('free-text');
+    });
+  });
+});


### PR DESCRIPTION
## Deliverable 5 (foundation) — RCF schema-inference module

RESO Common Format certification needs a DD-2.0 metadata report to run the DD machinery (schema validation + variations), but RCF payloads carry **values, not a schema**. This PR is the foundation: **infer** a DD-2.0 metadata report from sampled RCF records — "reverse" data → schema. Clean-room reimplementation of the legacy RCF inference behavior.

`inferMetadataReport({ recordsByResource, referenceMap, version, generatedOn })` → a `MetadataReport`. Pure (reference map injected), so fully unit-testable.

### Modules (`src/rcf`)
- **infer-type** — per-value Edm typing (integer width by range; Decimal scale/precision by digit count; ISO Date/DateTimeOffset probe else Edm.String; arrays → collection; objects → expansion).
- **local-enum-detection** — enum-vs-free-text for *local* string fields via distinct-ratio + cardinality cap + minimum sample; conservative (bias to free text — mis-flagging free text as an enum bloats the report and the `/compute` payload).
- **aggregate** — fold a local field's per-value types (integer widening; max Decimal scale/precision + string length; collections; expansions).
- **assemble-report** — `buildPayloadCache` (accumulate per resource/field, recurse expansions) + DD/local classification → `MetadataReport`.

### Key correctness points (from adversarial review + real-data validation)
- **DD fields take reference types** (ground truth); only local fields are inferred.
- **DD lookups serialize on the enum FQDN** (`lookup.lookupName === field.type`) so a re-read via `buildMetadataMap` recovers `isLookupField` — both the variations service and the schema generator rely on that join.
- **Collection (multi-value) lookups** (`Appliances`, `ExteriorFeatures`, …) are flattened, so their values aren't dropped.
- **`isEnumeration` ⟺ observed lookups** — a DD enum field that's all-null in the sample isn't stamped as an empty enum.
- **`presence → nullable`** for jagged data (a field absent from some records).
- Local expansion fields carry a `typeName` so their schema `$ref` resolves.

### Validation
- **78 unit tests** (value tables + fixture-driven assembly + a `buildMetadataMap` round-trip).
- **Local sweep across every real RCF sample payload** — DD 1.7 and 2.0, `Property` and `Rules` resources, DD + local expansions, collection/local/all-null enums, up to nine nested resources — no crashes, every emitted enum round-trips.
- **Live end-to-end** — an inferred report through the actual variations service returns sensible variations (a provider payload surfaces its non-standard values; a DD-conformant payload returns none).

### Follow-ons (own PRs)
- `reso-cert rcf` command — ingest zip/dir/file → schema-validate (`-a`) → infer → variations, with the full CLI e2e.
- Kind-matching shape scorer — resolve misnamed expansions and complex types by shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
