### PR TITLE
docs(readme): refresh root README for the v1.0.0 public tree (#240)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,22 @@
 # RESO Tools
 
-![Tests](https://img.shields.io/badge/tests-1315%20passed-brightgreen)
+![Tests](https://img.shields.io/badge/tests-1620%20passed-brightgreen)
 ![Compliance](https://img.shields.io/badge/RESO%20compliance-4%2F4%20suites-blue)
 [![Download](https://img.shields.io/github/v/release/RESOStandards/reso-tools?label=download&color=blue)](https://github.com/RESOStandards/reso-tools/releases/latest)
 
-Open-source toolkit for building and testing [RESO](https://www.reso.org/)-compliant OData servers. This repository provides the reference server, certification test runner, MCP server for AI agents and shared libraries for OData parsing and validation. The desktop certification app is distributed as a downloadable [release](https://github.com/RESOStandards/reso-tools/releases/latest).
+Open-source toolkit for building and testing [RESO](https://www.reso.org/)-compliant OData servers. This repository holds the reference server, the certification test runner (`reso-cert`), an MCP server for AI agents, and the shared libraries for OData parsing, metadata processing and validation — all published to npm so any project can consume them without the monorepo. The desktop certification app (which bundles a reference server and a local test-data UI) is built separately and distributed here as a downloadable [release](https://github.com/RESOStandards/reso-tools/releases/latest).
 
 ## Packages
 
 | Package | Description | Tests |
 |---------|-------------|-------|
-| [`reso-client/`](reso-client/) | OData 4.01 client SDK -- URI builder, CRUD helpers, CSDL metadata parsing, OAuth2 Client Credentials | 96 |
+| [`reso-common/`](reso-common/) | Universal (browser + Node) RESO metadata model and projections — the shared `ResoMetadata` shape, pure helpers and EDMX generator (zero runtime dependencies) | 16 |
+| [`reso-metadata-utils/`](reso-metadata-utils/) | RESO OData metadata processing — CSDL parse + validate (CSDL/XSD), EDMX → metadata-report serialization, live metadata fetching (the deps-requiring side of the metadata split) | 108 |
+| [`reso-client/`](reso-client/) | OData 4.01 client SDK -- URI builder, CRUD helpers, CSDL metadata parsing, OAuth2 Client Credentials | 116 |
 | [`odata-expression-parser/`](odata-expression-parser/) | Zero-dependency `$filter` and `$expand` expression parser | 180 |
 | [`reso-validation/`](reso-validation/) | Isomorphic field and business-rule validation for RESO Data Dictionary records | 98 |
-| [`reso-reference-server/`](reso-reference-server/) | Metadata-driven OData reference server (PostgreSQL, MongoDB, SQLite) | 258 |
-| [`reso-certification/`](reso-certification/) | RESO certification CLI + SDK – Add/Edit, EntityEvent, Web API Core, DD ([docs](reso-certification/README.md)) | 562 |
+| [`reso-reference-server/`](reso-reference-server/) | Metadata-driven OData reference server (PostgreSQL, MongoDB, SQLite) | 265 |
+| [`reso-certification/`](reso-certification/) | RESO certification CLI + SDK – Add/Edit, EntityEvent, Web API Core, Data Dictionary + RCP-010 schema/replicate/variations ([docs](reso-certification/README.md)) | 816 |
 | [`reso-mcp-server/`](reso-mcp-server/) | MCP server – exposes OData query, write, validation, certification tools for AI agents ([guide](reso-mcp-server/doc/GUIDE.md)) | 21 |
 
 ## Quick Start
@@ -41,7 +43,7 @@ docker compose --profile seed up seed
 
 ### Desktop Certification App
 
-A cross-platform desktop app (macOS, Windows, Linux) runs the full certification suite — Data Dictionary, Web API Core, Add/Edit, EntityEvent — against any OData server, with a bundled reference server and browser UI for local test data. Download the latest build from [Releases](https://github.com/RESOStandards/reso-tools/releases/latest).
+A cross-platform desktop app (macOS, Windows, Linux) runs the full certification suite — Data Dictionary, Web API Core, Add/Edit, EntityEvent — against any OData server, with a bundled reference server and browser UI for local test data. It is built separately (it consumes the public packages above from npm) and published here as a downloadable build — download the latest from [Releases](https://github.com/RESOStandards/reso-tools/releases/latest).
 
 ### Building Individual Packages
 
@@ -68,10 +70,12 @@ npm run typecheck
 npm test
 
 # Run tests for a single package
-npm run test:server
+npm run test:common
+npm run test:metadata-utils
 npm run test:client
 npm run test:validation
 npm run test:filter-parser
+npm run test:server
 npm run test:certification
 npm run test:mcp
 


### PR DESCRIPTION
Closes #240 — the one genuinely release-blocking item from the burndown.

## What changed
- **Package table now lists all 8 packages** — adds the two that were missing: `reso-common` (zero-dep metadata model) and `reso-metadata-utils` (CSDL/EDMX processing).
- **Test counts refreshed from a live run**: badge **1315 → 1620** passing; per-package counts current (`reso-client` 96→116, ref-server 258→265, certification 562→816). Added `test:common` + `test:metadata-utils` to the Development section.
- **Intro + Desktop section clarified**: the public packages publish to npm; the desktop app + local test-data UI are **built separately** (they consume these packages from npm) and distributed here as a downloadable release — their source is not in this public tree.

## Verification
Counts are from a full `npm test` on `v1.0.0-pre` (1620 passed | 2 expected-fail). Markdown-only change; no code path affected.

Staged for review — not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)