### PR TITLE
ci: add public build workflow — lint + typecheck + test (#242)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,51 @@
+name: Build
+
+# Public build + quality gate for the workspace: install once, build in dependency
+# order, then lint / typecheck / test every package. Runs on every PR and on pushes
+# to main and the version branches. Supersedes the stale reso-certification-utils
+# clone in compliance.yml for the plain build-and-test path.
+
+on:
+  pull_request:
+  push:
+    branches: [main, 'v*']
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: lint · typecheck · test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22' # the engines floor (>=22); verifies the minimum supported runtime
+          cache: npm
+
+      # The committed lockfile is authored with npm 11 (the team's toolchain). Node 22
+      # ships npm 10, whose stricter `npm ci` rejects it. Pin npm 11 so CI reproduces the
+      # dev environment; the requirement is declared as engines.npm in the root package.json.
+      - name: Pin npm 11 (matches the committed lockfile)
+        run: npm install -g npm@11
+
+      - name: Install (workspaces)
+        run: npm ci
+
+      - name: Build (dependency order)
+        run: npm run build
+
+      - name: Lint (Biome)
+        run: npm run lint
+
+      - name: Typecheck (all packages)
+        run: npm run typecheck
+
+      - name: Test (all packages)
+        run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
         "@vitest/coverage-v8": "^4.1.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22",
+        "npm": ">=11"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   ],
   "type": "module",
   "engines": {
-    "node": ">=22"
+    "node": ">=22",
+    "npm": ">=11"
   },
   "scripts": {
     "bootstrap": "npm install && npm run build",


### PR DESCRIPTION
Adds a public build + quality gate for the workspace: install once, build in dependency order, then lint / typecheck / test every package. Runs on every PR and on pushes to `main` and the version branches.

Supersedes the stale `reso-certification-utils` clone in `compliance.yml` for the plain build-and-test path.

- `npm ci` → `npm run build` (topological) → Biome lint → `tsc --noEmit` (all packages) → `npm test`
- Node 22 (the engines floor), npm cache
- Concurrency-cancel on the same ref

Closes #242.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
