### PR TITLE
reso-client resilience + monadic-container adoption (#270, #125)

### DIFF
--- a/reso-certification/src/cli/index.ts
+++ b/reso-certification/src/cli/index.ts
@@ -59,9 +59,11 @@ const loadDefaultMetadata = async (): Promise<string> => {
 const formatResultJson = (results: ReadonlyArray<PipelineResult>): string =>
   JSON.stringify(results.length === 1 ? results[0] : results, null, 2);
 
-/** Determine exit code from pipeline results. */
+/** Determine exit code from pipeline results. A run cut short by its total-timeout budget
+ *  is `incomplete` — not a clean pass, so it exits non-zero (like a failure) rather than
+ *  letting a truncated run read as success; the report distinguishes incomplete from failed. */
 const resolveExitCode = (results: ReadonlyArray<PipelineResult>): number =>
-  results.some(r => r.status === 'failed') ? 1 : 0;
+  results.some(r => r.status === 'failed' || r.status === 'incomplete') ? 1 : 0;
 
 // ── Program ──
 

--- a/reso-certification/src/cli/render.ts
+++ b/reso-certification/src/cli/render.ts
@@ -21,6 +21,7 @@ const statusIcon = (status: StepProgress['status']): string => {
   switch (status) {
     case 'passed': return '\u2713';
     case 'failed': return '\u2717';
+    case 'incomplete': return '\u25D0'; // \u25D0 \u2014 ran out of time; partial results, rest not tested
     case 'skipped': return '-';
     case 'running': return '\u25CB';
     case 'pending': return '\u00B7';
@@ -73,7 +74,7 @@ export const runWithProgress = async (
 
           const passed = pipelineResult.steps.filter(s => s.status === 'passed').length;
           const failed = pipelineResult.steps.filter(s => s.status === 'failed').length;
-          const statusMark = pipelineResult.status === 'passed' ? '\u2713' : '\u2717';
+          const statusMark = pipelineResult.status === 'passed' ? '\u2713' : pipelineResult.status === 'incomplete' ? '\u25d0' : '\u2717';
           task.title = `${statusMark} ${label} \u2014 ${passed} passed, ${failed} failed (${pipelineResult.duration}ms)`;
         },
         rendererOptions: { bottomBar: Infinity },
@@ -112,7 +113,7 @@ export const runConfigEntries = async (
 
         const passed = result.steps.filter(s => s.status === 'passed').length;
         const failed = result.steps.filter(s => s.status === 'failed').length;
-        const statusMark = result.status === 'passed' ? '\u2713' : '\u2717';
+        const statusMark = result.status === 'passed' ? '\u2713' : result.status === 'incomplete' ? '\u25d0' : '\u2717';
         task.title = `${statusMark} ${label} \u2014 ${passed} passed, ${failed} failed (${result.duration}ms)`;
       },
       rendererOptions: { bottomBar: Infinity },

--- a/reso-certification/src/sdk/core.ts
+++ b/reso-certification/src/sdk/core.ts
@@ -10,8 +10,8 @@ import { fetchMetadata, loadMetadataFromFile, parseMetadataXml, getEntityType, p
 import { validateMetadata, formatValidationSummary, collectValidationErrors } from './metadata-validation.js';
 import { buildStandardMap, resolveTestParams, WELL_KNOWN_RESOURCES } from '../web-api-core/index.js';
 import { runCoreResourceScenarios, type ResourceTestReport } from '../web-api-core/test-runner.js';
-import { createResilienceSession, runSettled } from '@reso-standards/reso-client';
-import { createSessionRequester } from '../test-runner/requester.js';
+import { runSettled } from '@reso-standards/reso-client';
+import { createCertSession, createSessionRequester } from '../test-runner/requester.js';
 import type { BaseTestContext, CoreConfig, PipelineStep, StepResult } from './types.js';
 import { createPipeline } from './pipeline.js';
 import { coreReportGenerators, writeReports, prepareOutputDir } from './reports.js';
@@ -130,11 +130,12 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
     const version = ctx.version;
     // Standard map (DD reference) built once per run — field/value membership for standard-first selection.
     const standardMap = buildStandardMap(version);
-    // A shared resilience session for the whole run: the circuit breaker + retries persist across
-    // requests, so a consistently-dead endpoint fails fast rather than being re-hit per scenario.
-    // Pacing is off for cert — a bounded run should stay fast; the ~1 rps floor is a replication
-    // concern. Tune the governor rate here if a picky vendor rate-limits a Core run.
-    const session = createResilienceSession({ governor: { ratePerSec: 0, burst: 0 } });
+    // One resilience session shared across the whole run (see createCertSession for the full
+    // rationale): retries + timeout + Retry-After stay on; the circuit breaker and pacing governor
+    // are configured inert for cert. Every response is a result to record, and "endpoint
+    // unreachable" is handled by sampling → SKIPPED — not by a breaker that would false-fail
+    // scenarios the server actually handles once a burst on one resource trips it open.
+    const session = createCertSession();
     const requester = createSessionRequester(session);
     // Continue-on-error across resources: one bad resource (e.g. a sampling network
     // failure) is captured and the run keeps going, so a walk-away run still yields a

--- a/reso-certification/src/sdk/core.ts
+++ b/reso-certification/src/sdk/core.ts
@@ -10,6 +10,7 @@ import { fetchMetadata, loadMetadataFromFile, parseMetadataXml, getEntityType, p
 import { validateMetadata, formatValidationSummary, collectValidationErrors } from './metadata-validation.js';
 import { buildStandardMap, resolveTestParams, WELL_KNOWN_RESOURCES } from '../web-api-core/index.js';
 import { runCoreResourceScenarios, type ResourceTestReport } from '../web-api-core/test-runner.js';
+import { runSettled } from '@reso-standards/reso-client';
 import type { BaseTestContext, CoreConfig, PipelineStep, StepResult } from './types.js';
 import { createPipeline } from './pipeline.js';
 import { coreReportGenerators, writeReports, prepareOutputDir } from './reports.js';
@@ -95,6 +96,32 @@ const fetchAndParseMetadata = (config: CoreConfig): PipelineStep<CoreContext> =>
   },
 });
 
+/**
+ * A resource that could not be sampled or tested is reported as SKIPPED, not failed —
+ * the tests couldn't run, so it is inconclusive rather than a compliance failure.
+ * Continue-on-error keeps the run going; this keeps the unsampled resource visible in
+ * the verdict as a skip rather than being silently dropped.
+ */
+export const skippedResourceReport = (resource: string, error: unknown): ResourceTestReport => {
+  const detail = error instanceof Error ? error.message : String(error);
+  return {
+    resource,
+    params: { resource, keyField: '', keyValue: '', enumMode: 'string', integerValueHigh: 0, skippedTypes: [], sampleComplete: false },
+    scenarios: [
+      {
+        tag: 'resource-skipped',
+        name: `${resource} could not be sampled or tested: ${detail}`,
+        passed: false,
+        skipped: true,
+        assertions: [],
+        duration: 0,
+      },
+    ],
+    coverage: [],
+    summary: { total: 1, passed: 0, failed: 0, skipped: 1, optional: { passed: 0, notSupported: 0, notTested: 0 } },
+  };
+};
+
 const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
   name: 'Run Core scenarios',
   run: async (ctx, onProgress) => {
@@ -102,58 +129,86 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
     const version = ctx.version;
     // Standard map (DD reference) built once per run — field/value membership for standard-first selection.
     const standardMap = buildStandardMap(version);
-    const resourceReports: ResourceTestReport[] = [];
+    // Continue-on-error across resources: one bad resource (e.g. a sampling network
+    // failure) is captured and the run keeps going, so a walk-away run still yields a
+    // full report. A fatal error (auth revoked) stops the run — surfaced below.
+    const settled = await runSettled(
+      ctx.resources,
+      async (resource): Promise<ResourceTestReport> => {
+        const entityType = getEntityType(metadata, resource)!;
 
-    for (const resource of ctx.resources) {
-      const entityType = getEntityType(metadata, resource)!;
-
-      onProgress({
-        step: 'Run Core scenarios',
-        status: 'running',
-        message: `Sampling ${resource}...`,
-      });
-
-      const enumModeOverride = ctx.enumMode !== 'auto' ? ctx.enumMode as import('../web-api-core/sampling.js').EnumMode : undefined;
-      const params = await resolveTestParams(
-        ctx.serverUrl,
-        resource,
-        entityType,
-        ctx.authToken!,
-        metadata.enumTypes,
-        standardMap,
-        enumModeOverride,
-      );
-
-      if (params.skippedTypes.length > 0) {
         onProgress({
           step: 'Run Core scenarios',
           status: 'running',
-          message: `${resource}: missing types: ${params.skippedTypes.join(', ')} — some scenarios will be skipped`,
+          message: `Sampling ${resource}...`,
         });
-      }
 
-      onProgress({
-        step: 'Run Core scenarios',
-        status: 'running',
-        message: `Testing ${resource}...`,
-      });
+        const enumModeOverride = ctx.enumMode !== 'auto' ? ctx.enumMode as import('../web-api-core/sampling.js').EnumMode : undefined;
+        const params = await resolveTestParams(
+          ctx.serverUrl,
+          resource,
+          entityType,
+          ctx.authToken!,
+          metadata.enumTypes,
+          standardMap,
+          enumModeOverride,
+        );
 
-      const report = await runCoreResourceScenarios(
-        ctx.serverUrl,
-        resource,
-        params,
-        ctx.authToken!,
-        version,
-      );
+        if (params.skippedTypes.length > 0) {
+          onProgress({
+            step: 'Run Core scenarios',
+            status: 'running',
+            message: `${resource}: missing types: ${params.skippedTypes.join(', ')} — some scenarios will be skipped`,
+          });
+        }
 
-      resourceReports.push(report);
+        onProgress({
+          step: 'Run Core scenarios',
+          status: 'running',
+          message: `Testing ${resource}...`,
+        });
 
-      onProgress({
-        step: 'Run Core scenarios',
-        status: 'running',
-        message: `${resource}: ${report.summary.passed} passed, ${report.summary.failed} failed, ${report.summary.skipped} skipped`,
-      });
+        const report = await runCoreResourceScenarios(
+          ctx.serverUrl,
+          resource,
+          params,
+          ctx.authToken!,
+          version,
+        );
+
+        onProgress({
+          step: 'Run Core scenarios',
+          status: 'running',
+          message: `${resource}: ${report.summary.passed} passed, ${report.summary.failed} failed, ${report.summary.skipped} skipped`,
+        });
+
+        return report;
+      },
+      {
+        onError: 'continue',
+        onOutcome: (outcome) => {
+          if (outcome.status === 'failed') {
+            const detail = outcome.error instanceof Error ? outcome.error.message : String(outcome.error);
+            onProgress({
+              step: 'Run Core scenarios',
+              status: 'running',
+              message: `${outcome.item}: skipped (could not sample) — ${detail}`,
+            });
+          }
+        },
+      },
+    );
+
+    if (settled.stoppedEarly && settled.fatalError !== undefined) {
+      throw settled.fatalError; // fatal (e.g. auth revoked) — abort the whole Core run
     }
+
+    // Preserve resource order; a resource we couldn't sample/test is reported as skipped.
+    const resourceReports: ResourceTestReport[] = settled.outcomes.map((outcome): ResourceTestReport =>
+      outcome.status === 'ok'
+        ? outcome.value
+        : skippedResourceReport(outcome.item, outcome.status === 'failed' ? outcome.error : new Error(outcome.reason)),
+    );
 
     // Required scenarios drive the verdict. Optional ("Optional Tests")
     // results are tallied separately and never contribute to `totalFailed`.

--- a/reso-certification/src/sdk/core.ts
+++ b/reso-certification/src/sdk/core.ts
@@ -159,6 +159,7 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
           metadata.enumTypes,
           standardMap,
           enumModeOverride,
+          requester,
         );
 
         if (params.skippedTypes.length > 0) {

--- a/reso-certification/src/sdk/core.ts
+++ b/reso-certification/src/sdk/core.ts
@@ -10,7 +10,8 @@ import { fetchMetadata, loadMetadataFromFile, parseMetadataXml, getEntityType, p
 import { validateMetadata, formatValidationSummary, collectValidationErrors } from './metadata-validation.js';
 import { buildStandardMap, resolveTestParams, WELL_KNOWN_RESOURCES } from '../web-api-core/index.js';
 import { runCoreResourceScenarios, type ResourceTestReport } from '../web-api-core/test-runner.js';
-import { runSettled } from '@reso-standards/reso-client';
+import { createResilienceSession, runSettled } from '@reso-standards/reso-client';
+import { createSessionRequester } from '../test-runner/requester.js';
 import type { BaseTestContext, CoreConfig, PipelineStep, StepResult } from './types.js';
 import { createPipeline } from './pipeline.js';
 import { coreReportGenerators, writeReports, prepareOutputDir } from './reports.js';
@@ -129,6 +130,12 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
     const version = ctx.version;
     // Standard map (DD reference) built once per run — field/value membership for standard-first selection.
     const standardMap = buildStandardMap(version);
+    // A shared resilience session for the whole run: the circuit breaker + retries persist across
+    // requests, so a consistently-dead endpoint fails fast rather than being re-hit per scenario.
+    // Pacing is off for cert — a bounded run should stay fast; the ~1 rps floor is a replication
+    // concern. Tune the governor rate here if a picky vendor rate-limits a Core run.
+    const session = createResilienceSession({ governor: { ratePerSec: 0, burst: 0 } });
+    const requester = createSessionRequester(session);
     // Continue-on-error across resources: one bad resource (e.g. a sampling network
     // failure) is captured and the run keeps going, so a walk-away run still yields a
     // full report. A fatal error (auth revoked) stops the run — surfaced below.
@@ -174,6 +181,7 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
           params,
           ctx.authToken!,
           version,
+          requester,
         );
 
         onProgress({

--- a/reso-certification/src/sdk/core.ts
+++ b/reso-certification/src/sdk/core.ts
@@ -10,7 +10,7 @@ import { fetchMetadata, loadMetadataFromFile, parseMetadataXml, getEntityType, p
 import { validateMetadata, formatValidationSummary, collectValidationErrors } from './metadata-validation.js';
 import { buildStandardMap, resolveTestParams, WELL_KNOWN_RESOURCES } from '../web-api-core/index.js';
 import { runCoreResourceScenarios, type ResourceTestReport } from '../web-api-core/test-runner.js';
-import { runSettled } from '@reso-standards/reso-client';
+import { isDeadlineError, runSettled } from '@reso-standards/reso-client';
 import { createCertSession, createSessionRequester } from '../test-runner/requester.js';
 import type { BaseTestContext, CoreConfig, PipelineStep, StepResult } from './types.js';
 import { createPipeline } from './pipeline.js';
@@ -123,6 +123,75 @@ export const skippedResourceReport = (resource: string, error: unknown): Resourc
   };
 };
 
+/**
+ * A resource we never reached because the run's total-timeout budget was already spent —
+ * reported as SKIPPED (not failed) with a deadline reason, and flagged so the run's verdict
+ * becomes `incomplete`. Distinct from skippedResourceReport, which means "could not sample".
+ */
+export const deadlineResourceReport = (resource: string): ResourceTestReport => ({
+  resource,
+  params: { resource, keyField: '', keyValue: '', enumMode: 'string', integerValueHigh: 0, skippedTypes: [], sampleComplete: false },
+  scenarios: [
+    {
+      tag: 'resource-not-tested',
+      name: `${resource} not tested — run deadline reached`,
+      passed: true,
+      skipped: true,
+      assertions: [{ passed: true, message: 'Not tested — run deadline reached' }],
+      duration: 0,
+    },
+  ],
+  coverage: [],
+  summary: { total: 1, passed: 0, failed: 0, skipped: 1, optional: { passed: 0, notSupported: 0, notTested: 0 } },
+  deadlineReached: true,
+});
+
+/**
+ * The Core run verdict from the aggregate counts — the single source of truth for the run's
+ * status, used by both the test step and the report writer so they can never diverge.
+ *
+ * Precedence: a real failure (a failed required scenario OR a failed coverage gate) is
+ * DEFINITIVE and outranks an `incomplete` (deadline-truncated) run, which outranks `passed`.
+ * Running out of time AFTER observing a real failure does not soften it to "incomplete"; and
+ * not-tested work (skipped) is never a failure. Mirrors the pipeline's failed > incomplete > passed.
+ */
+export const coreVerdict = (args: {
+  readonly totalFailed: number;
+  readonly coverageFailed: boolean;
+  readonly deadlineReached: boolean;
+}): 'passed' | 'failed' | 'incomplete' =>
+  args.totalFailed > 0 || args.coverageFailed
+    ? 'failed'
+    : args.deadlineReached
+      ? 'incomplete'
+      : 'passed';
+
+/**
+ * The report's HEADLINE outcome — coreVerdict plus the "the run did not complete cleanly"
+ * signals the testing counts alone can't see, so a certification report never reads as a clean
+ * PASS for a run whose process verdict is 'failed':
+ *   - `priorStepFailed` — a failed upstream step (service check, metadata validation) that a
+ *     non-failFast run continued past;
+ *   - `testingAborted` — the testing phase produced no results at all (e.g. a fatal-auth abort
+ *     mid-run), so there is nothing to certify.
+ * Either forces 'failed'; otherwise the testing verdict stands. A normal run trips neither and
+ * behaves exactly as coreVerdict.
+ */
+export const reportVerdict = (args: {
+  readonly priorStepFailed: boolean;
+  readonly testingAborted: boolean;
+  readonly totalFailed: number;
+  readonly coverageFailed: boolean;
+  readonly deadlineReached: boolean;
+}): 'passed' | 'failed' | 'incomplete' =>
+  args.priorStepFailed || args.testingAborted
+    ? 'failed'
+    : coreVerdict({
+        totalFailed: args.totalFailed,
+        coverageFailed: args.coverageFailed,
+        deadlineReached: args.deadlineReached
+      });
+
 const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
   name: 'Run Core scenarios',
   run: async (ctx, onProgress) => {
@@ -131,11 +200,11 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
     // Standard map (DD reference) built once per run — field/value membership for standard-first selection.
     const standardMap = buildStandardMap(version);
     // One resilience session shared across the whole run (see createCertSession for the full
-    // rationale): cert makes one request per scenario, records the result, and moves on — no
-    // retries, no breaker, no pacing, just the 15-min per-request timeout. Every response is a
-    // result to record, and "endpoint unreachable" is handled by sampling → SKIPPED, not by a
-    // breaker that would false-fail scenarios the server actually handles.
-    const session = createCertSession();
+    // rationale): cert retries only 429/503 (twice), records every other response and moves on,
+    // with no breaker or pacing and a 15-min per-request timeout. A total run budget bounds the
+    // whole run; when it is spent the run stops gracefully and remaining work is marked NOT TESTED
+    // (status → incomplete), so a partial report is still written rather than the process being killed.
+    const session = createCertSession(config.totalTimeoutMs);
     const requester = createSessionRequester(session);
     // Continue-on-error across resources: one bad resource (e.g. a sampling network
     // failure) is captured and the run keeps going, so a walk-away run still yields a
@@ -152,6 +221,9 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
         });
 
         const enumModeOverride = ctx.enumMode !== 'auto' ? ctx.enumMode as import('../web-api-core/sampling.js').EnumMode : undefined;
+        // Sampling issues requests, so it can hit the run deadline; if it does, this resource is
+        // "not tested" (ran out of time), NOT "could not sample". A deadline reached mid-scenarios
+        // is handled inside runCoreResourceScenarios, which returns a partial report.
         const params = await resolveTestParams(
           ctx.serverUrl,
           resource,
@@ -161,7 +233,11 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
           standardMap,
           enumModeOverride,
           requester,
-        );
+        ).catch((err: unknown) => {
+          if (isDeadlineError(err)) return null;
+          throw err;
+        });
+        if (params === null) return deadlineResourceReport(resource);
 
         if (params.skippedTypes.length > 0) {
           onProgress({
@@ -242,17 +318,23 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
     // In --full-coverage mode, fail if any types are missing
     const requireFullCoverage = config.fullCoverage ?? false;
     const coverageFailed = requireFullCoverage && !fullCoverage;
-    const status = (totalFailed > 0 || coverageFailed) ? 'failed' as const : 'passed' as const;
+    // Verdict precedence (see coreVerdict): a real failure (scenario or coverage gate) is
+    // definitive and outranks an incomplete (deadline-truncated) run, which outranks passed.
+    // A run that ran out of time is `incomplete` only if it observed no real failure.
+    const deadlineReached = resourceReports.some(r => r.deadlineReached);
+    const status = coreVerdict({ totalFailed, coverageFailed, deadlineReached });
 
     const coverageMsg = fullCoverage
       ? 'Full type coverage achieved'
       : `Missing coverage: ${missingTypes.join(', ')}`;
     const modeMsg = requireFullCoverage ? ' (--full-coverage enabled)' : '';
+    const incompleteMsg = deadlineReached ? 'INCOMPLETE — run deadline reached; remaining resources/scenarios not tested. ' : '';
 
     return {
       context: { ...ctx, resourceReports, coverageMatrix: { coveredTypes, missingTypes, fullCoverage } },
       status,
-      summary: `${totalPassed} passed, ${totalFailed} failed, ${totalSkipped} skipped`
+      summary: incompleteMsg
+        + `${totalPassed} passed, ${totalFailed} failed, ${totalSkipped} skipped`
         + (optTotal > 0 ? `; optional: ${optPassed} passed, ${optNotSupported} not supported, ${optNotTested} not tested` : '')
         + ` (${totalScenarios} scenarios across ${resourceReports.length} resources). ${coverageMsg}${modeMsg}`,
       counts: {
@@ -280,9 +362,26 @@ const writeComplianceReports = (config: CoreConfig): PipelineStep<CoreContext> =
 
     const resourceReports = ctx.resourceReports as ReadonlyArray<ResourceTestReport> ?? [];
     const totalFailed = resourceReports.reduce((sum, r) => sum + r.summary.failed, 0);
+    // The report's headline outcome must agree with the run's process verdict (and CLI exit
+    // code), so it is derived via reportVerdict (see there). It folds the TESTING result
+    // (coreVerdict on scenario/coverage/deadline) together with two "the run did not complete
+    // cleanly" signals, so a certification report can never read as a clean PASS for a run that
+    // actually failed:
+    //   - a failed UPSTREAM step (service check, metadata validation) that a non-failFast run
+    //     continued past — such a step lands in ctx.pipelineSteps;
+    //   - a testing phase that produced NO results at all — e.g. a fatal-auth abort mid-run,
+    //     where sampleAndTest threw and never threaded resourceReports onto the context.
+    // The coverage gate is a run-level check that never shows up in totalFailed, so it is
+    // carried explicitly.
+    const deadlineReached = resourceReports.some(r => r.deadlineReached);
+    const coverageMatrix = ctx.coverageMatrix as { readonly fullCoverage?: boolean } | undefined;
+    const coverageFailed = (config.fullCoverage ?? false) && !(coverageMatrix?.fullCoverage ?? true);
+    const priorSteps = ctx.pipelineSteps as ReadonlyArray<StepResult> ?? [];
+    const priorStepFailed = priorSteps.some(s => s.status === 'failed');
+    const testingAborted = (ctx.resources?.length ?? 0) > 0 && resourceReports.length === 0;
 
     const pipelineResult = {
-      status: totalFailed > 0 ? 'failed' as const : 'passed' as const,
+      status: reportVerdict({ priorStepFailed, testingAborted, totalFailed, coverageFailed, deadlineReached }),
       endorsement: 'core',
       steps: ctx.pipelineSteps as ReadonlyArray<StepResult> ?? [],
       context: ctx,

--- a/reso-certification/src/sdk/core.ts
+++ b/reso-certification/src/sdk/core.ts
@@ -131,10 +131,10 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
     // Standard map (DD reference) built once per run — field/value membership for standard-first selection.
     const standardMap = buildStandardMap(version);
     // One resilience session shared across the whole run (see createCertSession for the full
-    // rationale): retries + timeout + Retry-After stay on; the circuit breaker and pacing governor
-    // are configured inert for cert. Every response is a result to record, and "endpoint
-    // unreachable" is handled by sampling → SKIPPED — not by a breaker that would false-fail
-    // scenarios the server actually handles once a burst on one resource trips it open.
+    // rationale): cert makes one request per scenario, records the result, and moves on — no
+    // retries, no breaker, no pacing, just the 15-min per-request timeout. Every response is a
+    // result to record, and "endpoint unreachable" is handled by sampling → SKIPPED, not by a
+    // breaker that would false-fail scenarios the server actually handles.
     const session = createCertSession();
     const requester = createSessionRequester(session);
     // Continue-on-error across resources: one bad resource (e.g. a sampling network

--- a/reso-certification/src/sdk/pipeline.ts
+++ b/reso-certification/src/sdk/pipeline.ts
@@ -53,11 +53,16 @@ const executeStepFunctions = async <TContext extends PipelineContext>(
       (acc, r) => ({ ...acc, ...r.counts }),
       {} as Record<string, number>,
     );
-    const hasFailure = results.some(r => r.status === 'failed');
+    // Merge sub-status with the same precedence as the sequential runner: failed > incomplete > passed.
+    const mergedStatus = results.some(r => r.status === 'failed')
+      ? 'failed' as const
+      : results.some(r => r.status === 'incomplete')
+        ? 'incomplete' as const
+        : 'passed' as const;
 
     return {
       context: mergedContext,
-      status: hasFailure ? 'failed' : 'passed',
+      status: mergedStatus,
       summary: summaries.join('; '),
       errors: errors.length > 0 ? errors : undefined,
       artifacts: artifacts.length > 0 ? artifacts : undefined,
@@ -129,7 +134,8 @@ export const createPipeline = <TContext extends PipelineContext>(
     const startTime = Date.now();
     const stepResults: StepResult[] = [];
     let context = { ...initialContext };
-    let pipelineStatus: 'passed' | 'failed' = 'passed';
+    // Precedence: a real failure outranks an incomplete (deadline) run, which outranks passed.
+    let pipelineStatus: 'passed' | 'failed' | 'incomplete' = 'passed';
 
     for (const step of steps) {
       const stepStart = Date.now();
@@ -173,6 +179,10 @@ export const createPipeline = <TContext extends PipelineContext>(
         if (status === 'failed') {
           pipelineStatus = 'failed';
           if (failFast) break;
+        } else if (status === 'incomplete' && pipelineStatus === 'passed') {
+          // A deadline-truncated step makes the run incomplete unless a real failure outranks it.
+          // Do NOT failFast — finalizer steps (report writing) must still run to persist the partial report.
+          pipelineStatus = 'incomplete';
         }
       } catch (err) {
         const duration = Date.now() - stepStart;

--- a/reso-certification/src/sdk/types.ts
+++ b/reso-certification/src/sdk/types.ts
@@ -3,8 +3,9 @@ import type { DDVersion } from './dd-versions.js';
 
 // ── Pipeline ──
 
-/** Progress status for a pipeline step. */
-export type StepStatus = 'pending' | 'running' | 'passed' | 'failed' | 'skipped';
+/** Progress status for a pipeline step. `incomplete` = the step ran out of its
+ *  total-timeout budget before finishing; results gathered are valid, the rest is not tested. */
+export type StepStatus = 'pending' | 'running' | 'passed' | 'failed' | 'skipped' | 'incomplete';
 
 /** Progress update emitted by each pipeline step. */
 export interface StepProgress {
@@ -151,7 +152,7 @@ export interface StepResult {
 
 /** Result of a completed pipeline execution. */
 export interface PipelineResult<TContext extends PipelineContext = PipelineContext> {
-  readonly status: 'passed' | 'failed';
+  readonly status: 'passed' | 'failed' | 'incomplete';
   readonly endorsement: string;
   readonly steps: ReadonlyArray<StepResult>;
   readonly context: TContext;
@@ -270,6 +271,14 @@ export interface CoreConfig extends BaseComplianceConfig {
   readonly enumMode?: 'auto' | 'isflags' | 'collections' | 'string';
   readonly metadataPath?: string;
   readonly fullCoverage?: boolean;
+  /**
+   * Total wall-clock budget for the whole run, in ms. When it is spent the run stops
+   * gracefully — remaining resources/scenarios are reported NOT TESTED and the verdict is
+   * `incomplete` — rather than hanging or being hard-killed. Defaults to a generous value
+   * (see createCertSession); set it under the job scheduler's own timeout so the client
+   * stops first and still writes a partial report.
+   */
+  readonly totalTimeoutMs?: number;
 }
 
 /** Discriminated union of all endorsement configs. */

--- a/reso-certification/src/test-runner/client.ts
+++ b/reso-certification/src/test-runner/client.ts
@@ -5,7 +5,7 @@
  * so that certification test scenarios require no changes.
  */
 
-import { buildUri, createClient } from '@reso-standards/reso-client';
+import { buildUri, createClient, type ResilienceSession } from '@reso-standards/reso-client';
 import type { ODataResponse } from './types.js';
 
 /** Options for making an OData HTTP request. */
@@ -23,16 +23,21 @@ export interface RequestOptions {
  * Uses @reso-standards/reso-client's createClient under the hood. Creates a lightweight
  * client per call since the auth token may vary between requests.
  */
-export const odataRequest = async (options: RequestOptions & { readonly odataVersion?: string }): Promise<ODataResponse> => {
+export const odataRequest = async (
+  options: RequestOptions & { readonly odataVersion?: string; readonly session?: ResilienceSession }
+): Promise<ODataResponse> => {
   const defaultHeaders: Record<string, string> = {};
   if (options.odataVersion) {
     defaultHeaders['OData-Version'] = options.odataVersion;
   }
 
+  // A shared session (created once per run) makes pacing + the circuit breaker persist across
+  // the run's requests; omitted → a per-call default, i.e. today's behavior.
   const client = await createClient({
     baseUrl: '',
     auth: { mode: 'token', authToken: options.authToken },
     defaultHeaders,
+    session: options.session,
   });
 
   return client.request(options.method, options.url, {

--- a/reso-certification/src/test-runner/index.ts
+++ b/reso-certification/src/test-runner/index.ts
@@ -37,7 +37,7 @@ export { formatConsoleReport, formatJsonReport } from './reporter.js';
 export { odataRequest, buildResourceUrl } from './client.js';
 
 // Injectable request seam (containers — #125)
-export { webRequester } from './requester.js';
+export { webRequester, createSessionRequester } from './requester.js';
 export type { ODataRequester } from './requester.js';
 
 // Auth

--- a/reso-certification/src/test-runner/index.ts
+++ b/reso-certification/src/test-runner/index.ts
@@ -36,6 +36,10 @@ export { formatConsoleReport, formatJsonReport } from './reporter.js';
 // Client
 export { odataRequest, buildResourceUrl } from './client.js';
 
+// Injectable request seam (containers — #125)
+export { webRequester } from './requester.js';
+export type { ODataRequester } from './requester.js';
+
 // Auth
 export { resolveAuthToken, fetchAccessToken } from './auth.js';
 

--- a/reso-certification/src/test-runner/requester.ts
+++ b/reso-certification/src/test-runner/requester.ts
@@ -35,9 +35,11 @@ export const createSessionRequester = (session: ResilienceSession): ODataRequest
 /**
  * The resilience session for a certification run.
  *
- * Cert deliberately runs with the stateful resilience layers off AND without retries,
- * because cert's job is to *record* how a server behaves, not to protect a workload
- * from it. One request per scenario, record the result, move on:
+ * Cert runs with the stateful resilience layers off and retries limited to the two
+ * statuses that mean "reachable, come back later", because cert's job is to *record*
+ * how a server behaves, not to protect a workload from it. Effectively: one request per
+ * scenario, record the result, and move on — except a 429/503 is retried a couple of
+ * times first:
  *
  *  - **Circuit breaker off.** In cert every HTTP response — a 5xx included — is a
  *    result to record, not a health signal to fail fast on. A shared breaker keyed per
@@ -47,33 +49,53 @@ export const createSessionRequester = (session: ResilienceSession): ODataRequest
  *    onto one key, so a burst on one resource silently blocks testing of the others.
  *    "Endpoint unreachable" is already handled explicitly: sampling gates reachability
  *    and an unsampleable resource is reported SKIPPED, not FAILED.
- *  - **No retries.** A re-send only helps when the first failure wasn't the server's
- *    verdict — but a 5xx *is* the verdict (re-sending gets the same answer and risks a
- *    picky vendor blocking us for duplicate queries), a 429 means we paced too hard (the
- *    lever there is pacing, not a retry that hammers the rate limit), and a timeout
- *    re-sent is how a run balloons to 15 min × N. So cert records the first outcome and
- *    moves on. If rate-limiting shows up with pacing off, the lever is the governor.
+ *  - **Retry only when the server tells us to** (429 / 503), up to twice, honoring
+ *    Retry-After. Those two statuses mean "come back later", so a re-send can genuinely
+ *    succeed. Every other failure is a verdict to record and move on: a 500/502/504 is
+ *    the server's answer (re-sending gets the same one and risks a duplicate-query
+ *    block), and a network drop or timeout is re-sent into the same wall. Two retries
+ *    (down from the SDK default of five) caps the wait; a rate-limit that outlasts even
+ *    that is bounded by the job's own timeout, not by hammering the server.
  *  - **Governor (pacing) off.** A bounded cert run should stay fast; the ~1 rps floor
  *    is a replication concern. Tune the rate here if a picky vendor rate-limits a run.
  *
- * What stays on is the per-request 15-minute timeout — the one protection cert still
- * wants, so a single hung request can't stall the run indefinitely. Cert declares it
- * explicitly (rather than inheriting the SDK default) so the contract is self-owned and
- * a change to the SDK default can't silently shorten it under a legitimately slow read.
+ * What stays on is the per-request 15-minute timeout — so a single hung request can't
+ * stall the run indefinitely — plus the bounded 429/503 retry above. Cert declares the
+ * timeout explicitly (rather than inheriting the SDK default) so the contract is
+ * self-owned and a change to the SDK default can't silently shorten it under a slow read.
  *
  * The shared-session plumbing itself is retained — it is the seam the future parallel
  * fetchers (#271) and the DD 2.2 sampling migration will draw a shared rate budget
- * from, where retries + Retry-After + the breaker all earn their keep; cert just
- * configures those layers inert today. An infinite breaker threshold is a real breaker
- * that provably never opens; maxRetries 0 is a real send path that never re-sends.
+ * from, where full retries + the breaker also earn their keep; cert just configures the
+ * breaker + governor inert today. An infinite breaker threshold is a real breaker that
+ * provably never opens.
+ *
+ * Note: a bare 503 (no Retry-After) retries on the short exponential backoff, while a
+ * 429 falls back to the long `defaultRetryWaitMs` — rate-limit windows are long, a 503
+ * is usually a transient blip. Both honor a Retry-After header when present.
  */
 /** Cert's per-request timeout: 15 min. Some legitimate paged reads run this long (Josh's call). */
 const CERT_REQUEST_TIMEOUT_MS = 15 * 60_000;
 
-export const createCertSession = (): ResilienceSession =>
+/** The two statuses that mean "reachable, come back later" — the only ones cert retries. */
+const CERT_RETRYABLE_STATUSES = [429, 503] as const;
+
+/**
+ * Default total run budget: 55 min. Generous for a normal Core run, and meant to sit UNDER
+ * the job scheduler's own kill (e.g. a 1 h AWS Batch timeout) so the client stops first — it
+ * unwinds gracefully and writes a partial report, where a hard kill would leave none. Override
+ * via `CoreConfig.totalTimeoutMs` to match the actual scheduler timeout.
+ */
+export const DEFAULT_CERT_TOTAL_TIMEOUT_MS = 55 * 60_000;
+
+export const createCertSession = (
+  totalTimeoutMs: number = DEFAULT_CERT_TOTAL_TIMEOUT_MS
+): ResilienceSession =>
   createResilienceSession({
     governor: { ratePerSec: 0, burst: 0 },
     breaker: { threshold: Number.POSITIVE_INFINITY, cooldownMs: 0 },
-    backoff: { ...DEFAULT_BACKOFF, maxRetries: 0 },
-    timeoutMs: CERT_REQUEST_TIMEOUT_MS
+    backoff: { ...DEFAULT_BACKOFF, maxRetries: 2 },
+    retryableStatuses: CERT_RETRYABLE_STATUSES,
+    timeoutMs: CERT_REQUEST_TIMEOUT_MS,
+    totalTimeoutMs
   });

--- a/reso-certification/src/test-runner/requester.ts
+++ b/reso-certification/src/test-runner/requester.ts
@@ -9,6 +9,7 @@
  * requester — no `vi.mock`, no "test mode" branches.
  */
 
+import type { ResilienceSession } from '@reso-standards/reso-client';
 import { type RequestOptions, odataRequest } from './client.js';
 import type { ODataResponse } from './types.js';
 
@@ -21,3 +22,12 @@ export interface ODataRequester {
 export const webRequester: ODataRequester = {
   request: (options) => odataRequest(options)
 };
+
+/**
+ * A web requester bound to a shared resilience session. Created once per run and injected, it
+ * makes the governor + circuit breaker persist across the run's requests (per-call clients each
+ * see the same session), which is where the shared breaker's fail-fast behavior comes from.
+ */
+export const createSessionRequester = (session: ResilienceSession): ODataRequester => ({
+  request: (options) => odataRequest({ ...options, session })
+});

--- a/reso-certification/src/test-runner/requester.ts
+++ b/reso-certification/src/test-runner/requester.ts
@@ -9,7 +9,7 @@
  * requester — no `vi.mock`, no "test mode" branches.
  */
 
-import type { ResilienceSession } from '@reso-standards/reso-client';
+import { DEFAULT_BACKOFF, type ResilienceSession, createResilienceSession } from '@reso-standards/reso-client';
 import { type RequestOptions, odataRequest } from './client.js';
 import type { ODataResponse } from './types.js';
 
@@ -31,3 +31,35 @@ export const webRequester: ODataRequester = {
 export const createSessionRequester = (session: ResilienceSession): ODataRequester => ({
   request: (options) => odataRequest({ ...options, session })
 });
+
+/**
+ * The resilience session for a certification run.
+ *
+ * Cert deliberately runs with the two STATEFUL resilience layers off, because cert's
+ * job is to *record* how a server behaves, not to protect a workload from it:
+ *
+ *  - **Circuit breaker off.** In cert every HTTP response — a 5xx included — is a
+ *    result to record, not a health signal to fail fast on. A shared breaker keyed per
+ *    host|resource would (a) false-fail scenarios the server actually handles once a
+ *    burst of 5xx/timeouts on one resource trips it open, and (b) on a path-prefixed
+ *    service root (host/odata/Property, host/odata/Member, …) collapse every resource
+ *    onto one key, so a burst on one resource silently blocks testing of the others.
+ *    "Endpoint unreachable" is already handled explicitly: sampling gates reachability
+ *    and an unsampleable resource is reported SKIPPED, not FAILED.
+ *  - **Governor (pacing) off.** A bounded cert run should stay fast; the ~1 rps floor
+ *    is a replication concern. Tune the rate here if a picky vendor rate-limits a run.
+ *
+ * What stays on is per-request and stateless: a single retry with short backoff
+ * ("try again or move on"), Retry-After handling, and the 15-minute timeout.
+ *
+ * The shared-session plumbing itself is retained — it is the seam the future parallel
+ * fetchers (#271) and the DD 2.2 sampling migration will draw a shared rate budget
+ * from; cert just configures the stateful layers inert today, as the governor already
+ * was. An infinite breaker threshold is a real breaker that provably never opens.
+ */
+export const createCertSession = (): ResilienceSession =>
+  createResilienceSession({
+    governor: { ratePerSec: 0, burst: 0 },
+    breaker: { threshold: Number.POSITIVE_INFINITY, cooldownMs: 0 },
+    backoff: { ...DEFAULT_BACKOFF, maxRetries: 1 }
+  });

--- a/reso-certification/src/test-runner/requester.ts
+++ b/reso-certification/src/test-runner/requester.ts
@@ -1,0 +1,23 @@
+/**
+ * The injectable request seam for the certification containers (reso-tools #125).
+ *
+ * A runner depends on an `ODataRequester` — the single capability it needs (make a
+ * request, get a response) — instead of reaching for the free `odataRequest`. The
+ * web requester wraps reso-client (and, in a later increment, the run's shared
+ * resilience session); a test requester returns scripted responses. The same runner
+ * logic then runs against a live server or a fixture just by swapping the injected
+ * requester — no `vi.mock`, no "test mode" branches.
+ */
+
+import { type RequestOptions, odataRequest } from './client.js';
+import type { ODataResponse } from './types.js';
+
+/** What a certification runner needs from its client: issue an OData request, get a response. */
+export interface ODataRequester {
+  request(options: RequestOptions & { readonly odataVersion?: string }): Promise<ODataResponse>;
+}
+
+/** The production requester — reso-client via `odataRequest` (today's behavior, unchanged). */
+export const webRequester: ODataRequester = {
+  request: (options) => odataRequest(options)
+};

--- a/reso-certification/src/test-runner/requester.ts
+++ b/reso-certification/src/test-runner/requester.ts
@@ -35,8 +35,9 @@ export const createSessionRequester = (session: ResilienceSession): ODataRequest
 /**
  * The resilience session for a certification run.
  *
- * Cert deliberately runs with the two STATEFUL resilience layers off, because cert's
- * job is to *record* how a server behaves, not to protect a workload from it:
+ * Cert deliberately runs with the stateful resilience layers off AND without retries,
+ * because cert's job is to *record* how a server behaves, not to protect a workload
+ * from it. One request per scenario, record the result, move on:
  *
  *  - **Circuit breaker off.** In cert every HTTP response — a 5xx included — is a
  *    result to record, not a health signal to fail fast on. A shared breaker keyed per
@@ -46,20 +47,33 @@ export const createSessionRequester = (session: ResilienceSession): ODataRequest
  *    onto one key, so a burst on one resource silently blocks testing of the others.
  *    "Endpoint unreachable" is already handled explicitly: sampling gates reachability
  *    and an unsampleable resource is reported SKIPPED, not FAILED.
+ *  - **No retries.** A re-send only helps when the first failure wasn't the server's
+ *    verdict — but a 5xx *is* the verdict (re-sending gets the same answer and risks a
+ *    picky vendor blocking us for duplicate queries), a 429 means we paced too hard (the
+ *    lever there is pacing, not a retry that hammers the rate limit), and a timeout
+ *    re-sent is how a run balloons to 15 min × N. So cert records the first outcome and
+ *    moves on. If rate-limiting shows up with pacing off, the lever is the governor.
  *  - **Governor (pacing) off.** A bounded cert run should stay fast; the ~1 rps floor
  *    is a replication concern. Tune the rate here if a picky vendor rate-limits a run.
  *
- * What stays on is per-request and stateless: a single retry with short backoff
- * ("try again or move on"), Retry-After handling, and the 15-minute timeout.
+ * What stays on is the per-request 15-minute timeout — the one protection cert still
+ * wants, so a single hung request can't stall the run indefinitely. Cert declares it
+ * explicitly (rather than inheriting the SDK default) so the contract is self-owned and
+ * a change to the SDK default can't silently shorten it under a legitimately slow read.
  *
  * The shared-session plumbing itself is retained — it is the seam the future parallel
  * fetchers (#271) and the DD 2.2 sampling migration will draw a shared rate budget
- * from; cert just configures the stateful layers inert today, as the governor already
- * was. An infinite breaker threshold is a real breaker that provably never opens.
+ * from, where retries + Retry-After + the breaker all earn their keep; cert just
+ * configures those layers inert today. An infinite breaker threshold is a real breaker
+ * that provably never opens; maxRetries 0 is a real send path that never re-sends.
  */
+/** Cert's per-request timeout: 15 min. Some legitimate paged reads run this long (Josh's call). */
+const CERT_REQUEST_TIMEOUT_MS = 15 * 60_000;
+
 export const createCertSession = (): ResilienceSession =>
   createResilienceSession({
     governor: { ratePerSec: 0, burst: 0 },
     breaker: { threshold: Number.POSITIVE_INFINITY, cooldownMs: 0 },
-    backoff: { ...DEFAULT_BACKOFF, maxRetries: 1 }
+    backoff: { ...DEFAULT_BACKOFF, maxRetries: 0 },
+    timeoutMs: CERT_REQUEST_TIMEOUT_MS
   });

--- a/reso-certification/src/web-api-core/sampling.ts
+++ b/reso-certification/src/web-api-core/sampling.ts
@@ -9,7 +9,7 @@
 
 import type { EnumRepresentation } from '@reso-standards/reso-client';
 import type { CsdlEnumType } from '@reso-standards/reso-metadata-utils';
-import { odataRequest, buildResourceUrl } from '../test-runner/index.js';
+import { type ODataRequester, buildResourceUrl, webRequester } from '../test-runner/index.js';
 import type { EntityType } from '../test-runner/types.js';
 import { type EnumCandidate, isMultiRep, isSingleRep, selectEnumCandidates } from './enum-selection.js';
 import type { StandardMap } from './standard-map.js';
@@ -294,6 +294,7 @@ export const resolveTestParams = async (
   enumTypes: ReadonlyArray<CsdlEnumType>,
   standardMap: StandardMap,
   enumModeOverride?: EnumMode,
+  requester: ODataRequester = webRequester,
 ): Promise<TestParams> => {
   // enumMode is retained as an informational/coverage field only — selection and gating are now per-field
   // (resolveEnum), so the `--enumMode` override no longer steers field choice. Vestigial; a candidate for removal.
@@ -304,7 +305,7 @@ export const resolveTestParams = async (
   // Fetch sample records. 1000 (up from 100) gives far better field/value coverage for enum selection —
   // more fields are populated across the wider sample — while staying a single fast request.
   const url = `${buildResourceUrl(serverUrl, resource)}?$top=${SAMPLE_TOP}`;
-  const response = await odataRequest({ method: 'GET', url, authToken });
+  const response = await requester.request({ method: 'GET', url, authToken });
   const body = response.body as { value?: ReadonlyArray<Record<string, unknown>> } | null;
   const records = body?.value ?? [];
   // Was this page the COMPLETE resource? Drives the ne/gt/lt empty-verdict's pass-vs-skip split. A full page

--- a/reso-certification/src/web-api-core/test-runner.ts
+++ b/reso-certification/src/web-api-core/test-runner.ts
@@ -781,12 +781,13 @@ const runStructuralScenario = async (
 };
 
 /** Run server-driven paging scenario (v2.1.0). */
-const runPagingScenario = async (
+export const runPagingScenario = async (
   serverUrl: string,
   resource: string,
   params: TestParams,
   authToken: string,
   start: number,
+  requester: ODataRequester = webRequester,
 ): Promise<ScenarioResult> => {
   const assertions: AssertionResult[] = [];
   // Initial paging URL — kept in scope outside the try/while so the
@@ -800,7 +801,7 @@ const runPagingScenario = async (
     const maxPages = 20;
 
     while (url && pages < maxPages) {
-      const response = await odataRequest({ method: 'GET', url, authToken });
+      const response = await requester.request({ method: 'GET', url, authToken });
       if (response.status !== 200) {
         assertions.push({ passed: false, message: `Page ${pages + 1}: HTTP ${response.status}` });
         break;

--- a/reso-certification/src/web-api-core/test-runner.ts
+++ b/reso-certification/src/web-api-core/test-runner.ts
@@ -5,7 +5,7 @@
  * approach: build query → make request → assert results.
  */
 
-import { odataRequest } from '../test-runner/index.js';
+import { type ODataRequester, odataRequest, webRequester } from '../test-runner/index.js';
 import { fetchMetadataWithVersion } from '../test-runner/metadata.js';
 import { MetadataFetchError, decodeFlagsValue } from '@reso-standards/reso-metadata-utils';
 import type { EnumRepresentation } from '@reso-standards/reso-client';
@@ -275,13 +275,14 @@ export const emptyOutcome = (
  * inconclusive 200-empty) so the caller may try another candidate; false on a determinate pass/fail
  * (including a guaranteed-match 200-empty, which is a determinate FAIL).
  */
-const executeStandardScenario = async (
+export const executeStandardScenario = async (
   serverUrl: string,
   resource: string,
   scenario: CoreScenario,
   params: TestParams,
   authToken: string,
   start: number,
+  requester: ODataRequester = webRequester,
 ): Promise<{ readonly result: ScenarioResult; readonly retryable: boolean; readonly rejected: boolean; readonly accepted: boolean }> => {
   const query = buildScenarioQuery(serverUrl, resource, scenario, params);
   if (!query) {
@@ -292,7 +293,7 @@ const executeStandardScenario = async (
   const assertions: AssertionResult[] = [];
   try {
     const reqStart = Date.now();
-    const response = await odataRequest({ method: 'GET', url: query.url, authToken });
+    const response = await requester.request({ method: 'GET', url: query.url, authToken });
     const requestLatency = Date.now() - reqStart;
 
     const responseCheck = assertODataResponse(response, 200);

--- a/reso-certification/src/web-api-core/test-runner.ts
+++ b/reso-certification/src/web-api-core/test-runner.ts
@@ -343,6 +343,7 @@ const runEnumFamilyScenario = async (
   authToken: string,
   start: number,
   op: EnumOp,
+  requester: ODataRequester = webRequester,
 ): Promise<ScenarioResult> => {
   const slot = scenarioSlot(scenario);
   const candidates = (slot === 'multi' ? params.multiLookupCandidates : params.singleLookupCandidates) ?? [];
@@ -358,7 +359,7 @@ const runEnumFamilyScenario = async (
   let anyAccepted = false; // some eligible field returned 200 — the operator ran, so it is not an all-reject gap
   let firstRejection: ScenarioResult | undefined;
   for (const candidate of eligible) {
-    const { result, retryable, rejected, accepted } = await executeStandardScenario(serverUrl, resource, scenario, paramsWithCandidate(params, slot, candidate), authToken, start);
+    const { result, retryable, rejected, accepted } = await executeStandardScenario(serverUrl, resource, scenario, paramsWithCandidate(params, slot, candidate), authToken, start, requester);
     if (!retryable) return result; // determinate pass/fail (incl. a guaranteed-match 200-empty → fail) — done
     if (accepted) anyAccepted = true;
     if (rejected) firstRejection ??= result;
@@ -386,6 +387,7 @@ const runLookupResourceScenario = async (
   params: TestParams,
   authToken: string,
   start: number,
+  requester: ODataRequester = webRequester,
 ): Promise<ScenarioResult> => {
   const stringField = (params.singleLookupCandidates ?? []).find(c => c.representation === 'SINGLE_STRING');
   if (!stringField) {
@@ -405,7 +407,7 @@ const runLookupResourceScenario = async (
   const assertions: AssertionResult[] = [];
   try {
     const reqStart = Date.now();
-    const response = await odataRequest({ method: 'GET', url: query.url, authToken });
+    const response = await requester.request({ method: 'GET', url: query.url, authToken });
     const requestLatency = Date.now() - reqStart;
     const responseCheck = assertODataResponse(response, 200);
     assertions.push(responseCheck);
@@ -421,7 +423,7 @@ const runLookupResourceScenario = async (
     while (nextLink && pages < 25) {
       let pageResp: Awaited<ReturnType<typeof odataRequest>>;
       try {
-        pageResp = await odataRequest({ method: 'GET', url: rebaseNextLink(nextLink, query.url), authToken });
+        pageResp = await requester.request({ method: 'GET', url: rebaseNextLink(nextLink, query.url), authToken });
       } catch {
         break; // a page fetch failed even after re-basing — validate with the rows we already have, don't hard-error
       }
@@ -446,19 +448,20 @@ const runScenario = async (
   scenario: CoreScenario,
   params: TestParams,
   authToken: string,
+  requester: ODataRequester = webRequester,
 ): Promise<ScenarioResult> => {
   const start = Date.now();
 
   // Lookup Resource validation applies only to string (Lookup Resource) lookups.
   if (scenario.category === 'lookup-resource') {
-    return runLookupResourceScenario(serverUrl, resource, scenario, params, authToken, start);
+    return runLookupResourceScenario(serverUrl, resource, scenario, params, authToken, start, requester);
   }
 
   // Enum-family scenarios gate on the selected field's REAL representation and try candidate fields —
   // replacing the resource-wide enumMode skip. A single enum never gets `has`; a flags enum never `eq`.
   const op = enumScenarioOp(scenario);
   if (op !== undefined) {
-    return runEnumFamilyScenario(serverUrl, resource, scenario, params, authToken, start, op);
+    return runEnumFamilyScenario(serverUrl, resource, scenario, params, authToken, start, op, requester);
   }
 
   // Build query — undefined means required params missing, skip.
@@ -469,20 +472,20 @@ const runScenario = async (
 
   try {
     if (scenario.category === 'structural') {
-      return runStructuralScenario(serverUrl, resource, scenario.assertion, query, params, authToken, start);
+      return runStructuralScenario(serverUrl, resource, scenario.assertion, query, params, authToken, start, requester);
     }
     if (scenario.category === 'paging') {
-      return runPagingScenario(serverUrl, resource, params, authToken, start);
+      return runPagingScenario(serverUrl, resource, params, authToken, start, requester);
     }
     if (scenario.category === 'error') {
       const reqStart = Date.now();
-      const response = await odataRequest({ method: 'GET', url: query.url, authToken });
+      const response = await requester.request({ method: 'GET', url: query.url, authToken });
       const requestLatency = Date.now() - reqStart;
       const responseCheck = assertODataResponse(response, scenario.expectedStatus);
       return { tag: scenario.tag, name: scenario.name, passed: responseCheck.passed, skipped: false, assertions: [responseCheck], duration: Date.now() - start, requestLatency, requestUrl: query.url };
     }
     // Other standard scenarios (filter / orderby / expand / lookup-resource): a single execution.
-    const { result } = await executeStandardScenario(serverUrl, resource, scenario, params, authToken, start);
+    const { result } = await executeStandardScenario(serverUrl, resource, scenario, params, authToken, start, requester);
     return result;
   } catch (err) {
     return { tag: scenario.tag, name: scenario.name, passed: false, skipped: false, errored: true, assertions: [{ passed: false, message: `Error: ${err instanceof Error ? err.message : String(err)}` }], duration: Date.now() - start, requestUrl: query.url };
@@ -677,6 +680,7 @@ const runStructuralScenario = async (
   params: TestParams,
   authToken: string,
   start: number,
+  requester: ODataRequester = webRequester,
 ): Promise<ScenarioResult> => {
   const assertions: AssertionResult[] = [];
   const tag = assertion;
@@ -721,12 +725,12 @@ const runStructuralScenario = async (
       }
     } else if (assertion === 'skip') {
       // Skip test requires two requests and comparing results
-      const resp1 = await odataRequest({ method: 'GET', url: query.url, authToken });
+      const resp1 = await requester.request({ method: 'GET', url: query.url, authToken });
       assertions.push(assertODataResponse(resp1, 200));
       const records1 = extractRecords(resp1.body);
 
       const skipUrl = `${query.url}&$skip=5`;
-      const resp2 = await odataRequest({ method: 'GET', url: skipUrl, authToken });
+      const resp2 = await requester.request({ method: 'GET', url: skipUrl, authToken });
       assertions.push(assertODataResponse(resp2, 200));
       const records2 = extractRecords(resp2.body);
 
@@ -739,7 +743,7 @@ const runStructuralScenario = async (
           : { passed: false, message: `$skip overlap: ${overlap.length} keys appear in both pages` }
       );
     } else if (assertion === 'count') {
-      const response = await odataRequest({ method: 'GET', url: query.url, authToken });
+      const response = await requester.request({ method: 'GET', url: query.url, authToken });
       assertions.push(assertODataResponse(response, 200));
       const count = extractCount(response.body);
       const records = extractRecords(response.body);
@@ -749,7 +753,7 @@ const runStructuralScenario = async (
           : { passed: false, message: `@odata.count=${count ?? 'missing'}, results=${records.length}` }
       );
     } else if (assertion === 'top') {
-      const response = await odataRequest({ method: 'GET', url: query.url, authToken });
+      const response = await requester.request({ method: 'GET', url: query.url, authToken });
       assertions.push(assertODataResponse(response, 200));
       const records = extractRecords(response.body);
       assertions.push(
@@ -758,7 +762,7 @@ const runStructuralScenario = async (
           : { passed: false, message: `$top=5 returned ${records.length} records (expected <= 5)` }
       );
     } else if (assertion === 'fetch-by-key') {
-      const response = await odataRequest({ method: 'GET', url: query.url, authToken });
+      const response = await requester.request({ method: 'GET', url: query.url, authToken });
       assertions.push(assertODataResponse(response, 200));
       const body = response.body as Record<string, unknown> | null;
       assertions.push(
@@ -768,7 +772,7 @@ const runStructuralScenario = async (
       );
     } else {
       // service-document, select
-      const response = await odataRequest({ method: 'GET', url: query.url, authToken });
+      const response = await requester.request({ method: 'GET', url: query.url, authToken });
       assertions.push(assertODataResponse(response, 200));
       assertions.push(assertHasResults(response.body));
     }
@@ -848,6 +852,7 @@ export const runCoreResourceScenarios = async (
   params: TestParams,
   authToken: string,
   version: '2.0.0' | '2.1.0' = '2.0.0',
+  requester: ODataRequester = webRequester,
 ): Promise<ResourceTestReport> => {
   const scenarios = scenariosForVersion(version);
   const results: ScenarioResult[] = [];
@@ -887,7 +892,7 @@ export const runCoreResourceScenarios = async (
       continue;
     }
 
-    const result = await runScenario(serverUrl, resource, scenario, params, authToken);
+    const result = await runScenario(serverUrl, resource, scenario, params, authToken, requester);
     results.push({ ...result, optional: scenario.optional });
 
     // Latch state for subsequent iterations.

--- a/reso-certification/src/web-api-core/test-runner.ts
+++ b/reso-certification/src/web-api-core/test-runner.ts
@@ -8,7 +8,7 @@
 import { type ODataRequester, odataRequest, webRequester } from '../test-runner/index.js';
 import { fetchMetadataWithVersion } from '../test-runner/metadata.js';
 import { MetadataFetchError, decodeFlagsValue } from '@reso-standards/reso-metadata-utils';
-import type { EnumRepresentation } from '@reso-standards/reso-client';
+import { type EnumRepresentation, isDeadlineError } from '@reso-standards/reso-client';
 import type { TestParams } from './sampling.js';
 import type { EnumCandidate } from './enum-selection.js';
 import { buildScenarioQuery } from './queries.js';
@@ -69,6 +69,10 @@ export interface ResourceTestReport {
   readonly scenarios: ReadonlyArray<ScenarioResult>;
   readonly coverage: ReadonlyArray<TypeCoverage>;
   readonly summary: CoreSummary;
+  /** True when the run's total-timeout budget was spent before this resource finished:
+   *  the scenarios (or the whole resource) after that point are reported SKIPPED with a
+   *  "run deadline reached" reason, never failed. Drives the run's `incomplete` status. */
+  readonly deadlineReached?: boolean;
 }
 
 /** The three outcomes an Optional Test can render. */
@@ -193,6 +197,19 @@ const skipResult = (scenario: CoreScenario, start: number, message: string): Sce
   skipped: true,
   assertions: [{ passed: true, message: `Skipped: ${message}` }],
   duration: Date.now() - start,
+});
+
+/** A "not tested — run deadline reached" result. Counts as SKIPPED, never failed: the
+ *  scenario was never executed because the run spent its total-timeout budget. Distinct
+ *  from a can't-sample skip by its reason, so a partial run never misreports a vendor. */
+const deadlineSkipResult = (scenario: CoreScenario): ScenarioResult => ({
+  tag: scenario.tag,
+  name: scenario.name,
+  passed: true,
+  skipped: true,
+  assertions: [{ passed: true, message: 'Not tested — run deadline reached' }],
+  duration: 0,
+  optional: scenario.optional,
 });
 
 /**
@@ -322,6 +339,7 @@ export const executeStandardScenario = async (
     const allPassed = assertions.every(a => a.passed);
     return { result: { tag: scenario.tag, name: scenario.name, passed: allPassed, skipped: false, assertions, duration: Date.now() - start, requestLatency, requestUrl: query.url }, retryable: false, rejected: false, accepted: true };
   } catch (err) {
+    if (isDeadlineError(err)) throw err; // out of run budget — propagate so the run stops gracefully
     // A transport/parse error is indeterminate — UNTESTABLE, neither a rejection nor an acceptance.
     assertions.push({ passed: false, message: `Error: ${err instanceof Error ? err.message : String(err)}` });
     return { result: { tag: scenario.tag, name: scenario.name, passed: false, skipped: false, errored: true, assertions, duration: Date.now() - start, requestUrl: query.url }, retryable: true, rejected: false, accepted: false };
@@ -424,7 +442,8 @@ const runLookupResourceScenario = async (
       let pageResp: Awaited<ReturnType<typeof odataRequest>>;
       try {
         pageResp = await requester.request({ method: 'GET', url: rebaseNextLink(nextLink, query.url), authToken });
-      } catch {
+      } catch (err) {
+        if (isDeadlineError(err)) throw err; // out of run budget — stop the whole run, not just paging
         break; // a page fetch failed even after re-basing — validate with the rows we already have, don't hard-error
       }
       if (!assertODataResponse(pageResp, 200).passed) break;
@@ -437,6 +456,7 @@ const runLookupResourceScenario = async (
     const allPassed = assertions.every(a => a.passed);
     return { tag: scenario.tag, name: scenario.name, passed: allPassed, skipped: false, assertions, duration: Date.now() - start, requestLatency, requestUrl: query.url };
   } catch (err) {
+    if (isDeadlineError(err)) throw err; // out of run budget — propagate so the run stops gracefully
     return { tag: scenario.tag, name: scenario.name, passed: false, skipped: false, errored: true, assertions: [{ passed: false, message: `Error: ${err instanceof Error ? err.message : String(err)}` }], duration: Date.now() - start, requestUrl: query.url };
   }
 };
@@ -488,6 +508,7 @@ const runScenario = async (
     const { result } = await executeStandardScenario(serverUrl, resource, scenario, params, authToken, start, requester);
     return result;
   } catch (err) {
+    if (isDeadlineError(err)) throw err; // out of run budget — propagate so the run stops gracefully
     return { tag: scenario.tag, name: scenario.name, passed: false, skipped: false, errored: true, assertions: [{ passed: false, message: `Error: ${err instanceof Error ? err.message : String(err)}` }], duration: Date.now() - start, requestUrl: query.url };
   }
 };
@@ -777,6 +798,7 @@ const runStructuralScenario = async (
       assertions.push(assertHasResults(response.body));
     }
   } catch (err) {
+    if (isDeadlineError(err)) throw err; // out of run budget — propagate so the run stops gracefully
     assertions.push({ passed: false, message: `Error: ${err instanceof Error ? err.message : String(err)}` });
   }
 
@@ -834,6 +856,7 @@ export const runPagingScenario = async (
       assertions.push({ passed: true, message: 'Final page has no @odata.nextLink' });
     }
   } catch (err) {
+    if (isDeadlineError(err)) throw err; // out of run budget — propagate so the run stops gracefully
     assertions.push({ passed: false, message: `Error: ${err instanceof Error ? err.message : String(err)}` });
   }
 
@@ -860,8 +883,9 @@ export const runCoreResourceScenarios = async (
   // Track cross-scenario state for cascade-skip + OData-version gating.
   let lookupResourceFailed = false;
   let detectedODataVersion: string | undefined;
+  let deadlineReached = false;
 
-  for (const scenario of scenarios) {
+  for (const [i, scenario] of scenarios.entries()) {
     // Cascade-skip: dependent string-enum + in-operator scenarios are
     // pointless if the Lookup Resource didn't return the expected
     // LookupName / sample values. Skip them with a clear reason.
@@ -892,15 +916,23 @@ export const runCoreResourceScenarios = async (
       continue;
     }
 
-    const result = await runScenario(serverUrl, resource, scenario, params, authToken, requester);
-    results.push({ ...result, optional: scenario.optional });
+    try {
+      const result = await runScenario(serverUrl, resource, scenario, params, authToken, requester);
+      results.push({ ...result, optional: scenario.optional });
 
-    // Latch state for subsequent iterations.
-    if (scenario.tag === 'lookup-resource-validation' && !result.passed && !result.skipped) {
-      lookupResourceFailed = true;
-    }
-    if (result.odataVersion && !detectedODataVersion) {
-      detectedODataVersion = result.odataVersion;
+      // Latch state for subsequent iterations.
+      if (scenario.tag === 'lookup-resource-validation' && !result.passed && !result.skipped) {
+        lookupResourceFailed = true;
+      }
+      if (result.odataVersion && !detectedODataVersion) {
+        detectedODataVersion = result.odataVersion;
+      }
+    } catch (err) {
+      if (!isDeadlineError(err)) throw err; // runners swallow ordinary errors; only a deadline reaches here
+      // Out of run budget: this scenario and every one after it are NOT TESTED, not failed.
+      for (const remaining of scenarios.slice(i)) results.push(deadlineSkipResult(remaining));
+      deadlineReached = true;
+      break;
     }
   }
 
@@ -910,5 +942,6 @@ export const runCoreResourceScenarios = async (
     coverage: buildCoverage(params),
     scenarios: results,
     summary: summarizeScenarios(results),
+    ...(deadlineReached ? { deadlineReached: true } : {}),
   };
 };

--- a/reso-certification/tests/cert-session.test.ts
+++ b/reso-certification/tests/cert-session.test.ts
@@ -34,7 +34,16 @@ describe('createCertSession — cert resilience configuration', () => {
     expect(breaker.canProceed(COLLAPSED_KEY)).toBe(false);
   });
 
-  it('retries at most once ("try again or move on"), not the SDK default of five', () => {
-    expect(createCertSession().config.backoff.maxRetries).toBe(1);
+  it('does not retry ("record the result and move on"), unlike the SDK default of five', () => {
+    // A re-send in cert only risks a block (5xx is the server's verdict; 429 wants pacing,
+    // not a retry) or balloons the run (a re-sent 15-min timeout). One request per scenario.
+    expect(createCertSession().config.backoff.maxRetries).toBe(0);
+  });
+
+  it('keeps a 15-minute per-request timeout — the one retained protection, declared explicitly', () => {
+    // Stated independently of the source constant so an accidental change to cert's own
+    // timeout (or a regression to inheriting a shorter SDK default) turns this red rather
+    // than silently timing out a legitimately slow paged read as a false FAIL.
+    expect(createCertSession().config.timeoutMs).toBe(15 * 60_000);
   });
 });

--- a/reso-certification/tests/cert-session.test.ts
+++ b/reso-certification/tests/cert-session.test.ts
@@ -1,0 +1,40 @@
+import { DEFAULT_BREAKER, createResilienceSession } from '@reso-standards/reso-client';
+import { describe, expect, it } from 'vitest';
+import { createCertSession } from '../src/test-runner/requester.js';
+
+/**
+ * Regression guard for the adversarial-review finding (#273): the run-shared circuit
+ * breaker at its default threshold false-failed scenarios the server actually handles.
+ * Once a burst of 5xx/timeouts on one resource opened the breaker, every later request
+ * on that key short-circuited with `circuit-open` and was recorded as FAILED; on a
+ * path-prefixed service root the collapsed `host|<segment>` key blocked other resources
+ * too. Cert now configures the breaker inert. These tests lock that.
+ */
+describe('createCertSession — cert resilience configuration', () => {
+  // The single key every resource collapses onto behind a path-prefixed service root
+  // (host/odata/Property, host/odata/Member, …) — the worst case the breaker would harm.
+  const COLLAPSED_KEY = 'host|odata';
+
+  it('never opens the circuit breaker, so a burst on one resource cannot false-fail later scenarios or block other resources', () => {
+    const { breaker } = createCertSession();
+
+    // Ten times the default threshold — well past anything a real run could produce.
+    Array.from({ length: DEFAULT_BREAKER.threshold * 10 }).forEach(() => breaker.onFailure(COLLAPSED_KEY));
+
+    expect(breaker.stateOf(COLLAPSED_KEY)).toBe('closed');
+    expect(breaker.canProceed(COLLAPSED_KEY)).toBe(true);
+  });
+
+  it('is non-vacuous: the SDK-default session WOULD open on the same burst (that is the regression this guards)', () => {
+    const { breaker } = createResilienceSession();
+
+    Array.from({ length: DEFAULT_BREAKER.threshold }).forEach(() => breaker.onFailure(COLLAPSED_KEY));
+
+    expect(breaker.stateOf(COLLAPSED_KEY)).toBe('open');
+    expect(breaker.canProceed(COLLAPSED_KEY)).toBe(false);
+  });
+
+  it('retries at most once ("try again or move on"), not the SDK default of five', () => {
+    expect(createCertSession().config.backoff.maxRetries).toBe(1);
+  });
+});

--- a/reso-certification/tests/cert-session.test.ts
+++ b/reso-certification/tests/cert-session.test.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_BREAKER, createResilienceSession } from '@reso-standards/reso-client';
 import { describe, expect, it } from 'vitest';
-import { createCertSession } from '../src/test-runner/requester.js';
+import { DEFAULT_CERT_TOTAL_TIMEOUT_MS, createCertSession } from '../src/test-runner/requester.js';
 
 /**
  * Regression guard for the adversarial-review finding (#273): the run-shared circuit
@@ -34,10 +34,14 @@ describe('createCertSession — cert resilience configuration', () => {
     expect(breaker.canProceed(COLLAPSED_KEY)).toBe(false);
   });
 
-  it('does not retry ("record the result and move on"), unlike the SDK default of five', () => {
-    // A re-send in cert only risks a block (5xx is the server's verdict; 429 wants pacing,
-    // not a retry) or balloons the run (a re-sent 15-min timeout). One request per scenario.
-    expect(createCertSession().config.backoff.maxRetries).toBe(0);
+  it('retries only the "come back later" statuses (429/503), at most twice', () => {
+    // Every other failure is a verdict to record and move on: a 500/502/504 re-sent gets the
+    // same answer and risks a duplicate-query block; a network/timeout is re-sent into the same
+    // wall. Two retries (down from the SDK default of five) caps the wait. The SDK's allowlist
+    // behavior — 429/503 retry, others do not — is covered in reso-client's resilient-send tests.
+    const { config } = createCertSession();
+    expect(config.backoff.maxRetries).toBe(2);
+    expect(config.retryableStatuses).toEqual([429, 503]);
   });
 
   it('keeps a 15-minute per-request timeout — the one retained protection, declared explicitly', () => {
@@ -45,5 +49,12 @@ describe('createCertSession — cert resilience configuration', () => {
     // timeout (or a regression to inheriting a shorter SDK default) turns this red rather
     // than silently timing out a legitimately slow paged read as a false FAIL.
     expect(createCertSession().config.timeoutMs).toBe(15 * 60_000);
+  });
+
+  it('bounds the whole run with a total-timeout budget (a generous default), overridable per run', () => {
+    // The client-side total cap is what lets a run stop gracefully (partial report) on a 429
+    // flood instead of hanging; the runtime passes a value under its scheduler's own kill.
+    expect(createCertSession().config.totalTimeoutMs).toBe(DEFAULT_CERT_TOTAL_TIMEOUT_MS);
+    expect(createCertSession(10 * 60_000).config.totalTimeoutMs).toBe(10 * 60_000);
   });
 });

--- a/reso-certification/tests/helpers/core-mock-server.ts
+++ b/reso-certification/tests/helpers/core-mock-server.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { vi } from 'vitest';
+
+/**
+ * A fetch-level mock OData server for end-to-end Web API Core runs. It routes the three request
+ * shapes a Core run makes — the service document, `$metadata`, and resource queries — to canned
+ * responses, and lets a test inject the failure paths (invalid metadata, a 401, empty data, slow)
+ * so `runCoreCompliance` can be exercised whole without a live server. Pair it with report-file
+ * assertions (read `result.context.outputPath`) for run-completion / verdict guardrails.
+ */
+
+const FIXTURES = join(import.meta.dirname, '../fixtures/commander');
+
+/** A minimal, valid EDMX (one `Property` resource with a key) — enough to sample and test. */
+export const VALID_EDMX = readFileSync(join(FIXTURES, 'good-edmx.xml'), 'utf-8');
+/** Parseable XML whose schema is invalid (a `Property` with no key) — fails XSD/semantic validation. */
+export const INVALID_EDMX = readFileSync(join(FIXTURES, 'bad-edmx-no-keyfield.xml'), 'utf-8');
+
+export interface CoreMockOptions {
+  /** EDMX served at `$metadata` (default: VALID_EDMX). */
+  readonly metadataXml?: string;
+  /** HTTP status for `$metadata` (default 200). */
+  readonly metadataStatus?: number;
+  /** HTTP status for resource queries (default 200) — set 401 to abort sampling with fatal-auth. */
+  readonly resourceStatus?: number;
+  /** Body for resource queries (default: zero rows, which makes scenarios SKIP rather than fail). */
+  readonly resourceBody?: unknown;
+}
+
+export interface InstalledMock {
+  /** Every URL fetched, in order — for asserting what the run did (and did not) request. */
+  readonly calls: ReadonlyArray<string>;
+  restore(): void;
+}
+
+const odataJson = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', 'odata-version': '4.01' }
+  });
+
+/**
+ * Install the mock over `globalThis.fetch` (restore in afterEach). `base` is the server URL the
+ * run is configured with; every request is routed by its path relative to `base`.
+ */
+export const installCoreMockServer = (base: string, opts: CoreMockOptions = {}): InstalledMock => {
+  const calls: string[] = [];
+  const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    calls.push(url);
+
+    // $metadata (may carry a $format query) — checked first so it never falls through to a resource.
+    if (url.includes('/$metadata')) {
+      return new Response(opts.metadataXml ?? VALID_EDMX, {
+        status: opts.metadataStatus ?? 200,
+        headers: { 'content-type': 'application/xml', 'odata-version': '4.01' }
+      });
+    }
+
+    // Service document: the base URL itself (optionally with a trailing slash / query, no resource).
+    const path = url.startsWith(base) ? url.slice(base.length).replace(/^\//, '') : url;
+    if (path === '' || path.startsWith('?')) {
+      return odataJson({ '@odata.context': `${base}/$metadata`, value: [{ name: 'Property', url: 'Property' }] });
+    }
+
+    // Resource query — default is zero rows, which the sampler treats as "can't sample" (skip), not fail.
+    return odataJson(opts.resourceBody ?? { value: [], '@odata.count': 0 }, opts.resourceStatus ?? 200);
+  });
+
+  return { calls, restore: () => spy.mockRestore() };
+};

--- a/reso-certification/tests/sdk/core-verdict.test.ts
+++ b/reso-certification/tests/sdk/core-verdict.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { coreVerdict, deadlineResourceReport, reportVerdict } from '../../src/sdk/core.js';
+
+/**
+ * Guards the run-verdict precedence surfaced by the adversarial review of the graceful-stop
+ * change: a definitive failure must NOT be softened to "incomplete" just because the run also
+ * ran out of time, and a not-tested (deadline) resource must never read as a failure.
+ */
+describe('coreVerdict — failed > incomplete > passed', () => {
+  it('passed: nothing failed and the run finished', () => {
+    expect(coreVerdict({ totalFailed: 0, coverageFailed: false, deadlineReached: false })).toBe('passed');
+  });
+
+  it('failed: a real required-scenario failure', () => {
+    expect(coreVerdict({ totalFailed: 1, coverageFailed: false, deadlineReached: false })).toBe('failed');
+  });
+
+  it('failed: a coverage-gate failure with no scenario failures (the gate is run-level)', () => {
+    expect(coreVerdict({ totalFailed: 0, coverageFailed: true, deadlineReached: false })).toBe('failed');
+  });
+
+  it('incomplete: cut short by the deadline, but observed no failure', () => {
+    expect(coreVerdict({ totalFailed: 0, coverageFailed: false, deadlineReached: true })).toBe('incomplete');
+  });
+
+  it('FAILED, not incomplete: a real failure AND a deadline — a definitive failure is not softened', () => {
+    expect(coreVerdict({ totalFailed: 1, coverageFailed: false, deadlineReached: true })).toBe('failed');
+    expect(coreVerdict({ totalFailed: 0, coverageFailed: true, deadlineReached: true })).toBe('failed');
+  });
+});
+
+describe('reportVerdict — the report headline is never a false-PASS for an incomplete/aborted run', () => {
+  const clean = {
+    priorStepFailed: false,
+    testingAborted: false,
+    totalFailed: 0,
+    coverageFailed: false,
+    deadlineReached: false
+  };
+
+  it('a clean, fully-passing run is passed', () => {
+    expect(reportVerdict(clean)).toBe('passed');
+  });
+
+  it('a failed UPSTREAM step forces failed even when every sampled scenario passed (was a false-PASS)', () => {
+    // e.g. metadata XSD/semantic validation failed but failFast=false let sampling proceed and pass.
+    expect(reportVerdict({ ...clean, priorStepFailed: true })).toBe('failed');
+  });
+
+  it('a testing ABORT (no results at all — e.g. fatal-auth mid-run) forces failed, never passed (was a false-PASS)', () => {
+    expect(reportVerdict({ ...clean, testingAborted: true })).toBe('failed');
+  });
+
+  it('otherwise it defers to the testing verdict (failed > incomplete > passed)', () => {
+    expect(reportVerdict({ ...clean, totalFailed: 1 })).toBe('failed');
+    expect(reportVerdict({ ...clean, coverageFailed: true })).toBe('failed');
+    expect(reportVerdict({ ...clean, deadlineReached: true })).toBe('incomplete');
+  });
+
+  it('a real failure is never masked, even when the run was also aborted or incomplete', () => {
+    expect(reportVerdict({ ...clean, testingAborted: true, deadlineReached: true })).toBe('failed');
+    expect(reportVerdict({ ...clean, priorStepFailed: true, totalFailed: 0 })).toBe('failed');
+  });
+});
+
+describe('deadlineResourceReport — a resource not reached before the run deadline', () => {
+  it('is reported NOT TESTED (skipped, never failed) and flags the run incomplete', () => {
+    const report = deadlineResourceReport('Property');
+    expect(report.resource).toBe('Property');
+    expect(report.deadlineReached).toBe(true);
+    expect(report.summary.failed).toBe(0); // the core guarantee: never a failure — no vendor misreport
+    expect(report.summary.skipped).toBe(1);
+    expect(report.summary.passed).toBe(0);
+    // Its lone synthetic scenario is a skip, not a failure.
+    expect(report.scenarios.every(s => s.skipped && s.passed)).toBe(true);
+  });
+});

--- a/reso-certification/tests/sdk/skipped-resource-report.test.ts
+++ b/reso-certification/tests/sdk/skipped-resource-report.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { skippedResourceReport } from '../../src/sdk/core.js';
+
+// A resource that can't be sampled/tested (e.g. a sampling network failure) must not be
+// silently dropped by continue-on-error — it surfaces as a SKIPPED report. The tests
+// couldn't run, so it is inconclusive, not a compliance failure.
+describe('skippedResourceReport', () => {
+  it('reports an untestable resource as skipped, not failed', () => {
+    const report = skippedResourceReport('Media', new Error('sampling failed: ECONNRESET'));
+
+    expect(report.resource).toBe('Media');
+    // Counts as a skip, never a failure.
+    expect(report.summary).toMatchObject({ total: 1, passed: 0, failed: 0, skipped: 1 });
+    expect(report.scenarios).toHaveLength(1);
+    expect(report.scenarios[0]?.skipped).toBe(true);
+    expect(report.scenarios[0]?.passed).toBe(false);
+    expect(report.scenarios[0]?.name).toContain('ECONNRESET');
+    // A well-formed report the aggregators/formatters can consume.
+    expect(report.params.resource).toBe('Media');
+    expect(report.coverage).toEqual([]);
+  });
+
+  it('stringifies a non-Error thrown value', () => {
+    const report = skippedResourceReport('Property', 'boom');
+    expect(report.scenarios[0]?.name).toContain('boom');
+    expect(report.summary.skipped).toBe(1);
+  });
+});

--- a/reso-certification/tests/session-requester.test.ts
+++ b/reso-certification/tests/session-requester.test.ts
@@ -1,0 +1,29 @@
+import { createResilienceSession } from '@reso-standards/reso-client';
+import { describe, expect, it, vi } from 'vitest';
+
+// Mock the underlying odataRequest so we can assert the session is threaded onto every request.
+vi.mock('../src/test-runner/client.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../src/test-runner/client.js')>();
+  return {
+    ...actual,
+    odataRequest: vi.fn(async () => ({ status: 200, headers: {}, body: {}, rawBody: '' }))
+  };
+});
+
+import { odataRequest } from '../src/test-runner/client.js';
+import { createSessionRequester } from '../src/test-runner/requester.js';
+
+describe('createSessionRequester', () => {
+  it('threads the shared session onto every request (so the breaker/pacing persist across the run)', async () => {
+    const session = createResilienceSession({ governor: { ratePerSec: 0, burst: 0 } });
+    const requester = createSessionRequester(session);
+
+    await requester.request({ method: 'GET', url: 'http://server/Property', authToken: 'tok' });
+    await requester.request({ method: 'GET', url: 'http://server/Member', authToken: 'tok' });
+
+    // Both requests carry the SAME session instance — that's what makes it shared.
+    expect(odataRequest).toHaveBeenCalledTimes(2);
+    expect(odataRequest).toHaveBeenNthCalledWith(1, expect.objectContaining({ session, url: 'http://server/Property' }));
+    expect(odataRequest).toHaveBeenNthCalledWith(2, expect.objectContaining({ session, url: 'http://server/Member' }));
+  });
+});

--- a/reso-certification/tests/web-api-core/core-e2e-guardrails.test.ts
+++ b/reso-certification/tests/web-api-core/core-e2e-guardrails.test.ts
@@ -1,0 +1,74 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { runCoreCompliance } from '../../src/sdk/core.js';
+import type { CoreConfig } from '../../src/sdk/types.js';
+import { INVALID_EDMX, type InstalledMock, installCoreMockServer } from '../helpers/core-mock-server.js';
+
+/**
+ * End-to-end guardrails for the Core run: a whole `runCoreCompliance` against a fetch-level mock
+ * server, asserting the verdict AND the written report file. These lock the run-completion
+ * correctness the adversarial review surfaced — a run that aborted or hit the deadline must never
+ * write a clean-PASS report — so future cert changes can't silently reintroduce a false-PASS.
+ */
+const BASE = 'http://mock.local';
+
+const makeConfig = (outputDir: string, over: Partial<CoreConfig> = {}): CoreConfig => ({
+  endorsement: 'core',
+  version: '2.0.0',
+  resources: ['Property'], // the one resource the mock EDMX defines
+  server: { url: BASE, auth: { mode: 'token', authToken: 'test' } },
+  options: { outputDir },
+  ...over
+});
+
+const readReportOutcome = async (outputPath: string): Promise<string> => {
+  const detailed = JSON.parse(await readFile(join(outputPath, 'report-detailed.json'), 'utf-8'));
+  return detailed.outcome;
+};
+
+describe('Core end-to-end guardrails (mock server + report-file assertions)', () => {
+  let outputDir = '';
+  let mock: InstalledMock | undefined;
+
+  beforeEach(async () => {
+    outputDir = await mkdtemp(join(tmpdir(), 'core-e2e-'));
+  });
+  afterEach(async () => {
+    mock?.restore();
+    await rm(outputDir, { recursive: true, force: true });
+  });
+
+  it('fatal-auth mid-run (sampling returns 401) → verdict AND report outcome are FAILED, not a false-PASS', async () => {
+    mock = installCoreMockServer(BASE, { resourceStatus: 401 });
+
+    const result = await runCoreCompliance(makeConfig(outputDir));
+
+    expect(result.status).toBe('failed');
+    expect(await readReportOutcome(result.context.outputPath)).toBe('failed');
+  });
+
+  it('invalid metadata → verdict AND report outcome are FAILED (a metadata failure is never passed)', async () => {
+    // A run whose $metadata fails XSD/semantic validation must never write a 'passed' report.
+    // (This exercises the failed-metadata-step outcome end to end; the specific priorStepFailed
+    // guard — an upstream failure with zero test failures — is isolated in core-verdict.test.ts,
+    // since empty-data sampling here makes some structural scenarios fail rather than skip.)
+    mock = installCoreMockServer(BASE, { metadataXml: INVALID_EDMX });
+
+    const result = await runCoreCompliance(makeConfig(outputDir));
+
+    expect(result.status).toBe('failed');
+    expect(await readReportOutcome(result.context.outputPath)).toBe('failed');
+  });
+
+  it('run deadline spent → verdict AND report outcome are INCOMPLETE, and a partial report is still written', async () => {
+    mock = installCoreMockServer(BASE);
+
+    // A zero budget makes the deadline fire on the first sampled request — the run stops gracefully.
+    const result = await runCoreCompliance(makeConfig(outputDir, { totalTimeoutMs: 0 }));
+
+    expect(result.status).toBe('incomplete');
+    expect(await readReportOutcome(result.context.outputPath)).toBe('incomplete');
+  });
+});

--- a/reso-certification/tests/web-api-core/core-resource-container.test.ts
+++ b/reso-certification/tests/web-api-core/core-resource-container.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ODataRequester } from '../../src/test-runner/requester.js';
+import type { TestParams } from '../../src/web-api-core/sampling.js';
+
+// The metadata scenario fetches through a separate path (fetchMetadataWithVersion), not the
+// requester seam, so mock it — this test is about the requester threading, not the metadata path.
+vi.mock('../../src/test-runner/metadata.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/test-runner/metadata.js')>();
+  return {
+    ...actual,
+    fetchMetadataWithVersion: vi.fn(async () => ({ xml: '<edmx:Edmx></edmx:Edmx>', odataVersion: '4.01' }))
+  };
+});
+
+import { runCoreResourceScenarios } from '../../src/web-api-core/test-runner.js';
+
+const params: TestParams = {
+  resource: 'Property',
+  keyField: 'ListingKey',
+  keyValue: '1',
+  enumMode: 'string',
+  integerField: 'BedroomsTotal',
+  integerValueHigh: 3,
+  integerValueLow: 1,
+  integerValueMin: 1,
+  integerValueMax: 5,
+  integerNotSentinel: -1,
+  skippedTypes: [],
+  sampleComplete: true
+};
+
+// A recording test client — serves every OData request from the injected seam and logs the URLs.
+const recordingRequester = (): { requester: ODataRequester; urls: string[] } => {
+  const urls: string[] = [];
+  return {
+    requester: {
+      request: async (options) => {
+        urls.push(options.url);
+        return {
+          status: 200,
+          headers: { 'odata-version': '4.01' },
+          body: { value: [{ ListingKey: '1', BedroomsTotal: 3 }], '@odata.count': 1 },
+          rawBody: ''
+        };
+      }
+    },
+    urls
+  };
+};
+
+describe('runCoreResourceScenarios — container with an injected test client (#125)', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('runs the whole resource through the injected requester — no real network', async () => {
+    // If any runner still reached the free odataRequest (a missed thread), it would call global
+    // fetch. With the requester injected and metadata mocked, complete threading means fetch is
+    // never touched — so this spy is the end-to-end proof.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('unexpected real network call'));
+    const rec = recordingRequester();
+
+    const report = await runCoreResourceScenarios('http://server', 'Property', params, 'tok', '2.0.0', rec.requester);
+
+    // The container produced a well-formed report.
+    expect(report.resource).toBe('Property');
+    expect(report.scenarios.length).toBeGreaterThan(0);
+    expect(report.summary).toBeDefined();
+
+    // Every OData request went through the injected client, and nothing reached the network.
+    expect(rec.urls.length).toBeGreaterThan(0);
+    for (const url of rec.urls) expect(url).toContain('http://server');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/reso-certification/tests/web-api-core/deadline-graceful-stop.test.ts
+++ b/reso-certification/tests/web-api-core/deadline-graceful-stop.test.ts
@@ -1,0 +1,109 @@
+import { isDeadlineError } from '@reso-standards/reso-client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ODataRequester } from '../../src/test-runner/requester.js';
+import type { TestParams } from '../../src/web-api-core/sampling.js';
+
+// The metadata scenario fetches through a separate path (fetchMetadataWithVersion), not the
+// requester seam. Mock it to succeed so this test isolates the deadline behavior on the
+// requester-driven scenarios.
+vi.mock('../../src/test-runner/metadata.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../src/test-runner/metadata.js')>();
+  return {
+    ...actual,
+    fetchMetadataWithVersion: vi.fn(async () => ({ xml: '<edmx:Edmx></edmx:Edmx>', odataVersion: '4.01' }))
+  };
+});
+
+import { runCoreResourceScenarios } from '../../src/web-api-core/test-runner.js';
+
+const params: TestParams = {
+  resource: 'Property',
+  keyField: 'ListingKey',
+  keyValue: '1',
+  enumMode: 'string',
+  integerField: 'BedroomsTotal',
+  integerValueHigh: 3,
+  integerValueLow: 1,
+  integerValueMin: 1,
+  integerValueMax: 5,
+  integerNotSentinel: -1,
+  skippedTypes: [],
+  sampleComplete: true
+};
+
+const DEADLINE_MSG = 'Not tested — run deadline reached';
+
+/** Build the deadline-exceeded error the resilient client throws once the run budget is spent. */
+const deadlineError = (): Error =>
+  Object.assign(new Error('Total run timeout exceeded'), { resilienceKind: 'deadline-exceeded' as const });
+
+/** A requester that serves `okCount` requests, then throws deadline-exceeded on every call after. */
+const deadlineAfter = (okCount: number): ODataRequester => {
+  const calls: string[] = []; // closure-local counter (const binding, mutated via push)
+  return {
+    request: async (options) => {
+      calls.push(options.url);
+      if (calls.length > okCount) throw deadlineError();
+      return {
+        status: 200,
+        headers: { 'odata-version': '4.01' },
+        body: { value: [{ ListingKey: '1', BedroomsTotal: 3 }], '@odata.count': 1 },
+        rawBody: ''
+      };
+    }
+  };
+};
+
+/** A requester that always succeeds — the no-deadline baseline. */
+const okRequester = (): ODataRequester => deadlineAfter(Number.POSITIVE_INFINITY);
+
+describe('runCoreResourceScenarios — graceful stop on the run deadline', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('sanity: the constructed deadline error is what the SDK recognizes (non-vacuity guard)', () => {
+    expect(isDeadlineError(deadlineError())).toBe(true);
+    expect(isDeadlineError(new Error('ordinary failure'))).toBe(false);
+  });
+
+  it('stops at the deadline: remaining scenarios are NOT TESTED (skipped), never failed', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('unexpected real network call'));
+
+    // Baseline: the same resource with every request succeeding (no deadline).
+    const full = await runCoreResourceScenarios('http://server', 'Property', params, 'tok', '2.0.0', okRequester());
+    // Cut short: the run budget is spent after the third request.
+    const cut = await runCoreResourceScenarios('http://server', 'Property', params, 'tok', '2.0.0', deadlineAfter(3));
+
+    expect(cut.deadlineReached).toBe(true);
+    expect(full.deadlineReached).toBeUndefined();
+
+    // Some scenarios ran before the budget was spent (a genuine partial report).
+    expect(cut.scenarios.filter(s => !s.skipped).length).toBeGreaterThan(0);
+
+    // Every deadline-affected scenario is SKIPPED with the deadline reason, never failed.
+    const deadlineScenarios = cut.scenarios.filter(s => s.assertions.some(a => a.message === DEADLINE_MSG));
+    expect(deadlineScenarios.length).toBeGreaterThan(0);
+    for (const s of deadlineScenarios) {
+      expect(s.skipped).toBe(true);
+      expect(s.passed).toBe(true); // a skip never counts as a failure
+    }
+
+    // THE CORE GUARANTEE, stated non-vacuously against a swallow-as-failed regression: a deadline can
+    // only turn a would-be-tested scenario into a SKIP, never a failure — so the cut run has no MORE
+    // failures than the full run, and strictly more skips. If the deadline were recorded as a failed
+    // (or errored) scenario instead, cut.summary.failed would exceed the baseline and this would fail.
+    expect(cut.summary.failed).toBeLessThanOrEqual(full.summary.failed);
+    expect(cut.summary.skipped).toBeGreaterThan(full.summary.skipped);
+  });
+
+  it('marks (almost) everything not-tested when the budget is already spent at the first request', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('unexpected real network call'));
+
+    // Metadata is mocked (no requester call), so the first requester call is the first data scenario.
+    const report = await runCoreResourceScenarios('http://server', 'Property', params, 'tok', '2.0.0', deadlineAfter(0));
+
+    expect(report.deadlineReached).toBe(true);
+    // No REQUIRED scenario is a genuine failure — the (mocked) metadata passes, the rest is not-tested.
+    const genuineRequiredFailures = report.scenarios.filter(s => !s.passed && !s.skipped && !s.optional);
+    expect(genuineRequiredFailures).toEqual([]);
+  });
+});

--- a/reso-certification/tests/web-api-core/execute-standard-scenario.test.ts
+++ b/reso-certification/tests/web-api-core/execute-standard-scenario.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import type { ODataRequester } from '../../src/test-runner/requester.js';
+import type { ODataResponse } from '../../src/test-runner/types.js';
+import type { FilterScenario } from '../../src/web-api-core/scenarios.js';
+import type { TestParams } from '../../src/web-api-core/sampling.js';
+import { executeStandardScenario } from '../../src/web-api-core/test-runner.js';
+
+// A conformant 2xx needs the OData-Version header, or assertODataResponse rejects it.
+const response = (status: number, value: unknown[] = []): ODataResponse => ({
+  status,
+  headers: { 'odata-version': '4.01' },
+  body: { value },
+  rawBody: JSON.stringify({ value })
+});
+
+// The injected "test client" — returns a scripted response, no vi.mock, no test-mode branch (#125).
+const scriptedRequester = (res: ODataResponse): ODataRequester => ({ request: async () => res });
+
+// A standard filter scenario (eq on an integer field). buildFilterUrl builds a query from
+// integerField + integerValueHigh, so this reaches the request path (not the skip branch).
+const scenario: FilterScenario = {
+  tag: 'filter-int-eq',
+  name: 'Integer eq',
+  category: 'filter',
+  dataType: 'integer',
+  op: 'eq',
+  fieldParam: 'integerField',
+  valueParam: 'integerValueHigh',
+  minVersion: '2.0.0'
+};
+const params: TestParams = {
+  resource: 'Property',
+  keyField: 'ListingKey',
+  keyValue: '1',
+  enumMode: 'string',
+  integerField: 'BedroomsTotal',
+  integerValueHigh: 3,
+  skippedTypes: [],
+  sampleComplete: true
+};
+
+const run = (requester: ODataRequester) =>
+  executeStandardScenario('http://x', 'Property', scenario, params, 'tok', 0, requester);
+
+// Characterization: locks executeStandardScenario's four outcomes. These assertions are the
+// same ones that were green under vi.mock before the refactor — now the runner takes its client
+// by injection, and behaviour is identical. That equality IS the proof the refactor is safe.
+describe('executeStandardScenario (characterization — injected test client)', () => {
+  it('200 with matching data → accepted + passed', async () => {
+    const out = await run(scriptedRequester(response(200, [{ ListingKey: '1', BedroomsTotal: 3 }])));
+    expect(out).toMatchObject({ accepted: true, rejected: false, retryable: false });
+    expect(out.result.passed).toBe(true);
+    expect(out.result.skipped).toBe(false);
+  });
+
+  it('non-200 → rejected (the server refused the operator), retryable', async () => {
+    const out = await run(scriptedRequester(response(400)));
+    expect(out).toMatchObject({ accepted: false, rejected: true, retryable: true });
+    expect(out.result.passed).toBe(false);
+  });
+
+  it('200 empty → accepted, but the eq-on-sampled-value empty verdict is a determinate fail', async () => {
+    const out = await run(scriptedRequester(response(200, [])));
+    expect(out).toMatchObject({ accepted: true, rejected: false, retryable: false });
+    expect(out.result.passed).toBe(false);
+    expect(out.result.skipped).toBe(false);
+  });
+
+  it('request failure → errored, indeterminate (neither accepted nor rejected), retryable', async () => {
+    // A malformed/absent response makes the runner's own response processing throw, which its
+    // try/catch converts to an errored result — the same branch a transport error hits.
+    const out = await run(scriptedRequester(undefined as unknown as ODataResponse));
+    expect(out).toMatchObject({ accepted: false, rejected: false, retryable: true });
+    expect(out.result.errored).toBe(true);
+    expect(out.result.passed).toBe(false);
+  });
+});

--- a/reso-certification/tests/web-api-core/paging-scenario.test.ts
+++ b/reso-certification/tests/web-api-core/paging-scenario.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import type { ODataRequester } from '../../src/test-runner/requester.js';
+import type { ODataResponse } from '../../src/test-runner/types.js';
+import type { TestParams } from '../../src/web-api-core/sampling.js';
+import { runPagingScenario } from '../../src/web-api-core/test-runner.js';
+
+const response = (status: number, value: unknown[] = [], nextLink?: string): ODataResponse => ({
+  status,
+  headers: { 'odata-version': '4.01' },
+  body: { value, ...(nextLink ? { '@odata.nextLink': nextLink } : {}) },
+  rawBody: ''
+});
+
+// The injected test client — returns the scripted responses in order (one per page fetch).
+const queuedRequester = (responses: readonly ODataResponse[]): ODataRequester => {
+  const queue = [...responses];
+  return {
+    request: async () => {
+      const next = queue.shift();
+      if (!next) throw new Error('requester queue exhausted');
+      return next;
+    }
+  };
+};
+
+const params: TestParams = {
+  resource: 'Property',
+  keyField: 'ListingKey',
+  keyValue: '1',
+  enumMode: 'string',
+  integerValueHigh: 0,
+  skippedTypes: [],
+  sampleComplete: true
+};
+
+const run = (requester: ODataRequester) => runPagingScenario('http://x', 'Property', params, 'tok', 0, requester);
+
+// Characterization: locks runPagingScenario's outcomes, exercised through an injected test
+// client (no vi.mock). Behaviour is unchanged by the injection — the default requester is the
+// production one, and the full suite stays green.
+describe('runPagingScenario (characterization — injected test client)', () => {
+  it('multiple pages then no nextLink → passes', async () => {
+    const out = await run(
+      queuedRequester([
+        response(200, [{ ListingKey: '1' }], 'http://x/Property?$skiptoken=2'),
+        response(200, [{ ListingKey: '2' }])
+      ])
+    );
+    expect(out.tag).toBe('server-driven-paging');
+    expect(out.passed).toBe(true);
+    expect(out.skipped).toBe(false);
+  });
+
+  it('single page with no nextLink → valid (fewer records than the page size) → passes', async () => {
+    const out = await run(queuedRequester([response(200, [{ ListingKey: '1' }])]));
+    expect(out.passed).toBe(true);
+  });
+
+  it('a non-200 page → fails', async () => {
+    const out = await run(queuedRequester([response(400)]));
+    expect(out.passed).toBe(false);
+  });
+
+  it('a malformed/failed response → errored → fails (caught, not thrown)', async () => {
+    const out = await run(queuedRequester([undefined as unknown as ODataResponse]));
+    expect(out.passed).toBe(false);
+  });
+});

--- a/reso-client/src/http/client.ts
+++ b/reso-client/src/http/client.ts
@@ -6,8 +6,21 @@
 import type { ClientConfig, ODataClient, ODataResponse } from '../types.js';
 import { SDK_VERSION } from '../version.js';
 import { createTokenProvider } from './auth.js';
+import { resilientSend } from './resilience/resilient-send.js';
+import { createResilienceSession } from './resilience/session.js';
 
 const HTTP_UNAUTHORIZED = 401;
+
+/** Derives the governor/breaker key from a request URL: `host|resource`. */
+const resilienceKey = (url: string): string => {
+  try {
+    const parsed = new URL(url);
+    const firstSegment = parsed.pathname.split('/').filter(Boolean)[0] ?? '';
+    return `${parsed.host}|${firstSegment.split('(')[0]}`;
+  } catch {
+    return url;
+  }
+};
 
 /**
  * Parse a fetch Response into a normalized ODataResponse.
@@ -59,7 +72,8 @@ export const createClient = async (config: ClientConfig): Promise<ODataClient> =
     options?: {
       readonly body?: unknown;
       readonly headers?: Readonly<Record<string, string>>;
-    }
+    },
+    signal?: AbortSignal
   ): Promise<Response> => {
     const headers: Record<string, string> = {
       Accept: 'application/json',
@@ -93,8 +107,11 @@ export const createClient = async (config: ClientConfig): Promise<ODataClient> =
       headers,
       body: options?.body ? JSON.stringify(options.body) : undefined,
       keepalive: true,
+      signal
     });
   };
+
+  const session = config.session ?? createResilienceSession(config.resilience);
 
   const request = async (
     method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
@@ -104,22 +121,25 @@ export const createClient = async (config: ClientConfig): Promise<ODataClient> =
       readonly headers?: Readonly<Record<string, string>>;
     }
   ): Promise<ODataResponse> => {
-    const token = await tokenProvider();
-    const response = await doFetch(method, url, token, options);
-
-    if (response.status === HTTP_UNAUTHORIZED) {
-      const freshToken = await tokenProvider(true);
-      if (freshToken !== token) {
-        const retryResponse = await doFetch(method, url, freshToken, options);
-        return parseResponse(retryResponse);
+    // One physical attempt: token -> fetch -> one-shot 401 refresh -> normalized response.
+    // The resilient send layers timeout, pacing, retry/backoff, and the breaker around it.
+    const send = async (signal: AbortSignal): Promise<ODataResponse> => {
+      const token = await tokenProvider();
+      const response = await doFetch(method, url, token, options, signal);
+      if (response.status === HTTP_UNAUTHORIZED) {
+        const freshToken = await tokenProvider(true);
+        if (freshToken !== token) {
+          return parseResponse(await doFetch(method, url, freshToken, options, signal));
+        }
       }
-    }
+      return parseResponse(response);
+    };
 
-    return parseResponse(response);
+    return resilientSend(send, method, resilienceKey(url), session);
   };
 
   return {
     baseUrl: config.baseUrl,
-    request,
+    request
   };
 };

--- a/reso-client/src/http/client.ts
+++ b/reso-client/src/http/client.ts
@@ -11,12 +11,21 @@ import { createResilienceSession } from './resilience/session.js';
 
 const HTTP_UNAUTHORIZED = 401;
 
-/** Derives the governor/breaker key from a request URL: `host|resource`. */
-const resilienceKey = (url: string): string => {
+/**
+ * Derives the governor/breaker key from a request URL: `host|resource-path`.
+ *
+ * The whole path is used (minus any key predicate and query), NOT just the first
+ * segment: a path-prefixed service root — `https://host/odata/Property`,
+ * `https://host/odata/Member` — must not collapse every resource onto one
+ * `host|odata` key, or a burst on one resource would pace/trip the breaker for all
+ * of them. Key predicates are stripped wherever they appear, so `Property('123')`
+ * shares the `Property` collection's key (same resource), while a navigation segment
+ * like `Property('1')/Media` keeps its own — it is a different resource.
+ */
+export const resilienceKey = (url: string): string => {
   try {
     const parsed = new URL(url);
-    const firstSegment = parsed.pathname.split('/').filter(Boolean)[0] ?? '';
-    return `${parsed.host}|${firstSegment.split('(')[0]}`;
+    return `${parsed.host}|${parsed.pathname.replace(/\([^)]*\)/g, '')}`;
   } catch {
     return url;
   }

--- a/reso-client/src/http/resilience/backoff.ts
+++ b/reso-client/src/http/resilience/backoff.ts
@@ -1,0 +1,60 @@
+/**
+ * Exponential backoff with full jitter, and the method-aware retry decision.
+ *
+ * Backoff is the fallback wait when a failure carries no usable Retry-After.
+ * The retry decision layers method safety on top of the failure classification:
+ * an idempotent request can always be retried on a retryable failure, but a
+ * non-idempotent one (POST/PATCH) must only be retried when the server
+ * demonstrably did NOT process it — otherwise a timeout or ambiguous 5xx could
+ * cause a duplicate create/update.
+ */
+
+import type { FailureClassification } from './errors.js';
+
+export interface BackoffConfig {
+  /** Backoff step for the first retry; doubles each attempt. */
+  readonly baseMs: number;
+  /** Ceiling for a single backoff wait. */
+  readonly maxMs: number;
+  /** Maximum retries beyond the initial attempt. */
+  readonly maxRetries: number;
+}
+
+export const DEFAULT_BACKOFF: BackoffConfig = { baseMs: 500, maxMs: 30_000, maxRetries: 5 };
+
+/**
+ * Full-jitter exponential backoff: a random value in `[0, min(maxMs, baseMs * 2^attempt))`.
+ * `attempt` is 0-based (0 = the wait before the first retry). Full jitter (rather
+ * than fixed or equal jitter) is what keeps many parallel fetchers from resyncing
+ * into a thundering herd. `random` is injectable for deterministic tests.
+ */
+export const backoffMs = (
+  attempt: number,
+  config: BackoffConfig = DEFAULT_BACKOFF,
+  random: () => number = Math.random
+): number => {
+  const ceiling = Math.min(config.maxMs, config.baseMs * 2 ** attempt);
+  return Math.floor(random() * ceiling);
+};
+
+/** Methods whose repetition is safe by HTTP semantics even when a failure is ambiguous. */
+const IDEMPOTENT_METHODS: ReadonlySet<string> = new Set(['GET', 'HEAD', 'PUT', 'DELETE', 'OPTIONS']);
+
+/** Statuses that prove the server did NOT act on the request, so even a mutation is safe to retry. */
+const NOT_PROCESSED_STATUSES: ReadonlySet<number> = new Set([429, 503]);
+
+/**
+ * Whether to retry a failure, given the request method.
+ *
+ * - Non-retryable failures (terminal-4xx, fatal-auth): never.
+ * - Idempotent methods: retry any retryable failure — repetition is safe.
+ * - Non-idempotent methods (POST/PATCH): retry only when the failure proves the
+ *   request was not processed (429 Too Many Requests, 503 Service Unavailable).
+ *   Never on a timeout, a network drop, or an ambiguous 5xx (500/502/504), where
+ *   the mutation may already have landed.
+ */
+export const shouldRetry = (classification: FailureClassification, method: string): boolean => {
+  if (!classification.retryable) return false;
+  if (IDEMPOTENT_METHODS.has(method.toUpperCase())) return true;
+  return classification.status !== undefined && NOT_PROCESSED_STATUSES.has(classification.status);
+};

--- a/reso-client/src/http/resilience/circuit-breaker.ts
+++ b/reso-client/src/http/resilience/circuit-breaker.ts
@@ -1,0 +1,95 @@
+/**
+ * Per-key circuit breaker.
+ *
+ * Keyed by `host|resource` (same as the governor), so one unhealthy resource
+ * trips only its own breaker, not the whole host. After `threshold` CONSECUTIVE
+ * health-relevant failures the breaker opens and requests fail fast; after
+ * `cooldownMs` it half-opens to admit a single probe, which closes it on success
+ * or re-opens it on failure.
+ *
+ * The counter is CONSECUTIVE (reset on any success) — the legacy client's was
+ * cumulative, so a handful of scattered blips over a long healthy run would kill
+ * it. The caller feeds only health-relevant outcomes: a 2xx is a success; a
+ * transient-5xx / network / timeout / exhausted-throttle is a failure. Terminal
+ * client errors (4xx) and fatal auth are NOT fed here — they say nothing about
+ * host health.
+ *
+ * `now` is injectable so cooldown transitions are deterministic in tests.
+ */
+
+export interface BreakerConfig {
+  /** Consecutive health-relevant failures that trip the breaker open. */
+  readonly threshold: number;
+  /** How long the breaker stays open before admitting a probe. */
+  readonly cooldownMs: number;
+}
+
+export const DEFAULT_BREAKER: BreakerConfig = { threshold: 5, cooldownMs: 30_000 };
+
+export type BreakerState = 'closed' | 'open' | 'half-open';
+
+export interface BreakerDeps {
+  readonly now: () => number;
+}
+
+const realBreakerDeps: BreakerDeps = { now: () => Date.now() };
+
+export interface CircuitBreaker {
+  /** Whether a request to `key` may proceed now; transitions open→half-open once the cooldown elapses. */
+  canProceed(key: string): boolean;
+  onSuccess(key: string): void;
+  onFailure(key: string): void;
+  stateOf(key: string): BreakerState;
+}
+
+interface Entry {
+  failures: number;
+  state: BreakerState;
+  openedAtMs: number;
+}
+
+export const createCircuitBreaker = (
+  config: BreakerConfig = DEFAULT_BREAKER,
+  deps: BreakerDeps = realBreakerDeps
+): CircuitBreaker => {
+  const entries = new Map<string, Entry>();
+
+  const entryFor = (key: string): Entry => {
+    const existing = entries.get(key);
+    if (existing) return existing;
+    const fresh: Entry = { failures: 0, state: 'closed', openedAtMs: 0 };
+    entries.set(key, fresh);
+    return fresh;
+  };
+
+  const canProceed = (key: string): boolean => {
+    const entry = entryFor(key);
+    if (entry.state === 'open') {
+      if (deps.now() - entry.openedAtMs >= config.cooldownMs) {
+        entry.state = 'half-open'; // admit a single probe
+        return true;
+      }
+      return false;
+    }
+    return true; // closed, or half-open (probe in flight)
+  };
+
+  const onSuccess = (key: string): void => {
+    const entry = entryFor(key);
+    entry.failures = 0;
+    entry.state = 'closed';
+  };
+
+  const onFailure = (key: string): void => {
+    const entry = entryFor(key);
+    entry.failures += 1;
+    if (entry.state === 'half-open' || entry.failures >= config.threshold) {
+      entry.state = 'open';
+      entry.openedAtMs = deps.now();
+    }
+  };
+
+  const stateOf = (key: string): BreakerState => entryFor(key).state;
+
+  return { canProceed, onSuccess, onFailure, stateOf };
+};

--- a/reso-client/src/http/resilience/circuit-breaker.ts
+++ b/reso-client/src/http/resilience/circuit-breaker.ts
@@ -1,18 +1,19 @@
 /**
  * Per-key circuit breaker.
  *
- * Keyed by `host|resource` (same as the governor), so one unhealthy resource
+ * Keyed by `host|resource` (same as the governor), so one unreachable resource
  * trips only its own breaker, not the whole host. After `threshold` CONSECUTIVE
- * health-relevant failures the breaker opens and requests fail fast; after
- * `cooldownMs` it half-opens to admit a single probe, which closes it on success
- * or re-opens it on failure.
+ * failures the breaker opens and requests fail fast; after `cooldownMs` it
+ * half-opens to admit a single probe, which closes it on success or re-opens it
+ * on failure.
  *
  * The counter is CONSECUTIVE (reset on any success) — the legacy client's was
  * cumulative, so a handful of scattered blips over a long healthy run would kill
- * it. The caller feeds only health-relevant outcomes: a 2xx is a success; a
- * transient-5xx / network / timeout / exhausted-throttle is a failure. Terminal
- * client errors (4xx) and fatal auth are NOT fed here — they say nothing about
- * host health.
+ * it. The breaker tracks REACHABILITY, so the caller (see resilient-send) feeds it
+ * that way: any HTTP response — 2xx, 4xx, or 5xx — is a success (the endpoint
+ * answered), and ONLY a transport death with no response (a network drop or a
+ * timeout that exhausts retries) is a failure. A server that responds with errors
+ * is reachable and must not trip the breaker.
  *
  * `now` is injectable so cooldown transitions are deterministic in tests.
  */

--- a/reso-client/src/http/resilience/continue-on-error.ts
+++ b/reso-client/src/http/resilience/continue-on-error.ts
@@ -1,0 +1,135 @@
+/**
+ * Continue-on-error, as an async generator (the primitive) plus a thin collector.
+ *
+ * The generator owns the CONTROL policy and the consumer owns the STATE — the split
+ * the legacy replication iterator got right, minus the bugs it earned by making the
+ * parent also implement the stop logic (a cumulative-not-consecutive counter,
+ * swallowed errors). `settle` runs each item, yields its outcome, and stops itself
+ * on a fatal error or on any failure under `fail-fast`; the consumer just drives the
+ * `for await` and accumulates whatever shape it wants.
+ *
+ * Why a generator: seeding/replication is millions of records — an all-at-once result
+ * would hold every outcome in memory. A generator streams (yield a page, the consumer
+ * processes and discards it, pulls the next) with natural backpressure, so the consumer
+ * can checkpoint each unit to disk before pulling the next. `runSettled` layers on top
+ * for the bounded case that just wants a summary.
+ *
+ * Sequential for now; a parallel variant (a pool pulling from a shared queue) is the
+ * parallel-fetchers work.
+ */
+
+import { isResilienceError } from './errors.js';
+
+export type OnError = 'continue' | 'fail-fast';
+
+export type UnitOutcome<T, R> =
+  | { readonly item: T; readonly status: 'ok'; readonly value: R }
+  | { readonly item: T; readonly status: 'failed'; readonly error: unknown; readonly fatal: boolean }
+  | { readonly item: T; readonly status: 'skipped'; readonly reason: string };
+
+export interface SettleOptions {
+  /** Default `'continue'`. */
+  readonly onError?: OnError;
+  /** Whether an error stops the whole run. Default: a ResilienceError of kind `fatal-auth`. */
+  readonly isFatal?: (error: unknown) => boolean;
+}
+
+interface SkipSignal extends Error {
+  readonly resilientSkip: string;
+}
+
+/** Throw from a `run` callback to record the current item as skipped (not failed). */
+export const skip = (reason: string): never => {
+  throw Object.assign(new Error(`skipped: ${reason}`), { resilientSkip: reason });
+};
+
+const isSkip = (err: unknown): err is SkipSignal =>
+  err instanceof Error && typeof (err as { resilientSkip?: unknown }).resilientSkip === 'string';
+
+const defaultIsFatal = (error: unknown): boolean =>
+  isResilienceError(error) && error.resilienceKind === 'fatal-auth';
+
+/**
+ * The primitive. Runs each item through `run` and yields its outcome. Stops (ends the
+ * generator) on a fatal error, and on any failure when `onError` is `'fail-fast'` —
+ * so the consumer never re-implements the stop logic. Returns `true` when it stopped
+ * early, `false` when it ran every item.
+ *
+ * NOTE — resume (we will likely need this): this is a ONE-WAY generator; it only yields.
+ * Resumable replication wants a TWO-WAY generator, where the consumer sends a value back
+ * in via `.next(cursor)` — a persisted resume cursor, or a "stop after this" — so a
+ * killed run picks up where it left off instead of restarting. Deferred for now (DD 2.2 /
+ * the iterator port). When it lands, widen the generator's third type parameter (today
+ * `void`, the `.next()` input type) to the feedback type and read it from the `yield`
+ * expression. Keeping the surface one-way until resume actually forces the change.
+ */
+export async function* settle<T, R>(
+  items: Iterable<T>,
+  run: (item: T) => Promise<R>,
+  options: SettleOptions = {}
+): AsyncGenerator<UnitOutcome<T, R>, boolean, void> {
+  const onError = options.onError ?? 'continue';
+  const isFatal = options.isFatal ?? defaultIsFatal;
+
+  for (const item of items) {
+    try {
+      const value = await run(item);
+      yield { item, status: 'ok', value };
+    } catch (err) {
+      if (isSkip(err)) {
+        yield { item, status: 'skipped', reason: err.resilientSkip };
+        continue;
+      }
+      const fatal = isFatal(err);
+      yield { item, status: 'failed', error: err, fatal };
+      if (fatal || onError === 'fail-fast') return true;
+    }
+  }
+  return false;
+}
+
+export interface SettledResult<T, R> {
+  readonly outcomes: ReadonlyArray<UnitOutcome<T, R>>;
+  readonly succeeded: ReadonlyArray<R>;
+  readonly failed: ReadonlyArray<{ readonly item: T; readonly error: unknown }>;
+  readonly skipped: ReadonlyArray<{ readonly item: T; readonly reason: string }>;
+  /** True when a fatal error or a fail-fast failure stopped the run before all items ran. */
+  readonly stoppedEarly: boolean;
+  readonly fatalError?: unknown;
+}
+
+export interface RunSettledOptions<T, R> extends SettleOptions {
+  /** Fires as each unit settles — the checkpoint-as-you-go hook. */
+  readonly onOutcome?: (outcome: UnitOutcome<T, R>) => void;
+}
+
+/** Drains `settle` into a structured summary — for the bounded case that just wants the totals. */
+export const runSettled = async <T, R>(
+  items: Iterable<T>,
+  run: (item: T) => Promise<R>,
+  options: RunSettledOptions<T, R> = {}
+): Promise<SettledResult<T, R>> => {
+  const outcomes: UnitOutcome<T, R>[] = [];
+  const generator = settle(items, run, options);
+
+  let step = await generator.next();
+  while (!step.done) {
+    outcomes.push(step.value);
+    options.onOutcome?.(step.value);
+    step = await generator.next();
+  }
+  const stoppedEarly = step.value;
+
+  const fatalOutcome = outcomes.find(
+    (o): o is Extract<UnitOutcome<T, R>, { status: 'failed' }> => o.status === 'failed' && o.fatal
+  );
+
+  return {
+    outcomes,
+    succeeded: outcomes.flatMap((o) => (o.status === 'ok' ? [o.value] : [])),
+    failed: outcomes.flatMap((o) => (o.status === 'failed' ? [{ item: o.item, error: o.error }] : [])),
+    skipped: outcomes.flatMap((o) => (o.status === 'skipped' ? [{ item: o.item, reason: o.reason }] : [])),
+    stoppedEarly,
+    ...(fatalOutcome ? { fatalError: fatalOutcome.error } : {})
+  };
+};

--- a/reso-client/src/http/resilience/errors.ts
+++ b/reso-client/src/http/resilience/errors.ts
@@ -1,0 +1,100 @@
+/**
+ * Failure classification for the resilient request path.
+ *
+ * Every failed request — an HTTP error response or a thrown transport error —
+ * is classified into the single category that drives the recovery decision, so
+ * the retry and circuit-breaker logic key off one taxonomy instead of scattered
+ * status checks. This widens the legacy client's HTTP-vs-transport split into
+ * the distinctions that actually matter for recovery.
+ */
+
+/** The recovery-relevant category of a request failure. */
+export type FailureKind =
+  | 'terminal-4xx' // client error the server won't reconsider (400/403/404/409/422/501…) — do not retry
+  | 'throttle-429' // rate limited — wait (Retry-After / backoff) and retry
+  | 'transient-5xx' // server-side transient (500/502/503/504…) — retry with backoff
+  | 'network' // fetch threw before a response (DNS/reset/refused/broken pipe) — usually transient, retry
+  | 'timeout' // the request's own AbortController fired — no response in time, retry
+  | 'fatal-auth'; // authentication failed and a token refresh cannot fix it (401) — stop, never retry
+
+/** A classified failure carrying whatever detail the retry / breaker / report layers need. */
+export interface FailureClassification {
+  readonly kind: FailureKind;
+  /** Whether the retry loop should re-attempt this failure (in principle — method-safety is decided by the caller). */
+  readonly retryable: boolean;
+  /** Whether this failure should stop the whole run (fatal), rather than just this request (terminal / unit-level). */
+  readonly fatal: boolean;
+  /** HTTP status, when the failure came from a response. */
+  readonly status?: number;
+  /** Transport error code (ECONNRESET, ETIMEDOUT, ENOTFOUND…), when the failure came from a thrown error. */
+  readonly code?: string;
+  readonly message: string;
+}
+
+const httpFailure = (
+  kind: FailureKind,
+  retryable: boolean,
+  fatal: boolean,
+  status: number,
+  label: string
+): FailureClassification => ({ kind, retryable, fatal, status, message: `HTTP ${status} ${label}` });
+
+/**
+ * Classifies an HTTP error status. Intended for responses with `status >= 400`
+ * (call `classifyResponse` to guard on `status`). A 401 reaching here is treated
+ * as fatal because the caller's token-refresh retry has already been exhausted.
+ *
+ * 401 is fatal (not authenticated — the whole run is doomed); 403 is terminal
+ * (authenticated but forbidden for this request — skip the unit, keep going).
+ * 501 Not Implemented is terminal even though it is a 5xx.
+ */
+export const classifyStatus = (status: number): FailureClassification => {
+  if (status === 429) return httpFailure('throttle-429', true, false, status, 'Too Many Requests');
+  if (status === 401) return httpFailure('fatal-auth', false, true, status, 'Unauthorized');
+  if (status === 403) return httpFailure('terminal-4xx', false, false, status, 'Forbidden');
+  if (status === 501) return httpFailure('terminal-4xx', false, false, status, 'Not Implemented');
+  if (status >= 500) return httpFailure('transient-5xx', true, false, status, 'Server Error');
+  return httpFailure('terminal-4xx', false, false, status, 'Client Error');
+};
+
+/** Classifies a response: `null` when it is not an error (`status < 400`), otherwise a classification. */
+export const classifyResponse = (response: { readonly status: number }): FailureClassification | null =>
+  response.status >= 400 ? classifyStatus(response.status) : null;
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+/**
+ * Extracts name / code / message from a thrown value WITHOUT spreading it.
+ *
+ * A `{...err}` spread copies only enumerable own properties, so `Error.message`,
+ * `Error.stack`, and `err.code` (all non-enumerable) are silently lost — the exact
+ * detail (e.g. `ECONNRESET`) the retry layer needs. `fetch`/undici also nest the
+ * transport code under `err.cause.code`, so both locations are checked.
+ */
+const extractErrorFields = (err: unknown): { name?: string; code?: string; message: string } => {
+  if (err instanceof Error) {
+    const ownCode = (err as { code?: unknown }).code;
+    const cause = (err as { cause?: unknown }).cause;
+    const causeCode = isRecord(cause) ? cause.code : undefined;
+    const code =
+      typeof ownCode === 'string' ? ownCode : typeof causeCode === 'string' ? causeCode : undefined;
+    return { name: err.name, code, message: err.message || err.name };
+  }
+  if (typeof err === 'string') return { message: err };
+  return { message: 'Unknown error' };
+};
+
+/**
+ * Classifies a thrown transport error. An `AbortError` (our timeout) is `timeout`;
+ * anything else that threw before a response is `network`. Both are retryable in
+ * principle — the caller applies method-safety (a mutation must not be retried on
+ * an ambiguous timeout/drop where it may already have landed).
+ */
+export const classifyThrown = (err: unknown): FailureClassification => {
+  const { name, code, message } = extractErrorFields(err);
+  if (name === 'AbortError' || name === 'TimeoutError' || code === 'ABORT_ERR') {
+    return { kind: 'timeout', retryable: true, fatal: false, code, message: message || 'Request timed out' };
+  }
+  return { kind: 'network', retryable: true, fatal: false, code, message: message || 'Network error' };
+};

--- a/reso-client/src/http/resilience/errors.ts
+++ b/reso-client/src/http/resilience/errors.ts
@@ -125,3 +125,11 @@ export const resilienceError = (
 
 export const isResilienceError = (err: unknown): err is ResilienceError =>
   err instanceof Error && typeof (err as { resilienceKind?: unknown }).resilienceKind === 'string';
+
+/**
+ * True when `err` is the resilient send giving up because the run's total-timeout
+ * budget is spent. Consumers use it to distinguish "we ran out of time" (stop
+ * gracefully, mark the rest not-tested) from an ordinary request failure.
+ */
+export const isDeadlineError = (err: unknown): boolean =>
+  isResilienceError(err) && err.resilienceKind === 'deadline-exceeded';

--- a/reso-client/src/http/resilience/errors.ts
+++ b/reso-client/src/http/resilience/errors.ts
@@ -100,7 +100,12 @@ export const classifyThrown = (err: unknown): FailureClassification => {
 };
 
 /** The kind of an unrecoverable failure the resilient send surfaces by throwing. */
-export type ResilienceErrorKind = 'fatal-auth' | 'exhausted' | 'circuit-open' | 'retry-wait-exceeded';
+export type ResilienceErrorKind =
+  | 'fatal-auth'
+  | 'exhausted'
+  | 'circuit-open'
+  | 'retry-wait-exceeded'
+  | 'deadline-exceeded'; // the run's total-timeout budget is spent — stop rather than wait/retry further
 
 /**
  * A thrown error the resilient send could not recover from. It is a plain `Error`

--- a/reso-client/src/http/resilience/errors.ts
+++ b/reso-client/src/http/resilience/errors.ts
@@ -98,3 +98,25 @@ export const classifyThrown = (err: unknown): FailureClassification => {
   }
   return { kind: 'network', retryable: true, fatal: false, code, message: message || 'Network error' };
 };
+
+/** The kind of an unrecoverable failure the resilient send surfaces by throwing. */
+export type ResilienceErrorKind = 'fatal-auth' | 'exhausted' | 'circuit-open' | 'retry-wait-exceeded';
+
+/**
+ * A thrown error the resilient send could not recover from. It is a plain `Error`
+ * with marker fields rather than a subclass (this codebase does not use classes),
+ * so consumers narrow with `isResilienceError` and branch on `resilienceKind`.
+ */
+export interface ResilienceError extends Error {
+  readonly resilienceKind: ResilienceErrorKind;
+  readonly classification?: FailureClassification;
+}
+
+export const resilienceError = (
+  resilienceKind: ResilienceErrorKind,
+  message: string,
+  classification?: FailureClassification
+): ResilienceError => Object.assign(new Error(message), { resilienceKind, classification });
+
+export const isResilienceError = (err: unknown): err is ResilienceError =>
+  err instanceof Error && typeof (err as { resilienceKind?: unknown }).resilienceKind === 'string';

--- a/reso-client/src/http/resilience/rate-governor.ts
+++ b/reso-client/src/http/resilience/rate-governor.ts
@@ -1,0 +1,99 @@
+/**
+ * Per-key token-bucket rate governor.
+ *
+ * One shared budget per key (the caller keys by `host|resource`): `acquire` waits
+ * until a token is available, then consumes it, so the aggregate request rate never
+ * exceeds the configured rate no matter how many callers draw from the same key —
+ * a single fetcher today, parallel fetchers later. Acquires for a key are serialized
+ * through a promise chain so token accounting is never interleaved (correct under
+ * concurrency without a thread lock — see the single-threaded model).
+ *
+ * A freshly-seen key starts with a full bucket, so an isolated/first request is not
+ * penalized; only sustained traffic beyond the rate waits. Clock and sleep are
+ * injectable so tests run instantly with no real waits.
+ */
+
+export interface GovernorConfig {
+  /** Sustained rate in requests per second. `0` disables the governor (no pacing). */
+  readonly ratePerSec: number;
+  /** Bucket capacity — how many requests may burst before pacing engages. */
+  readonly burst: number;
+}
+
+/** RESO-safe default: ~1 req/sec, no burst beyond the first. */
+export const DEFAULT_GOVERNOR: GovernorConfig = { ratePerSec: 1, burst: 1 };
+
+export interface GovernorDeps {
+  readonly now: () => number;
+  readonly sleep: (ms: number) => Promise<void>;
+}
+
+const realDeps: GovernorDeps = {
+  now: () => Date.now(),
+  sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+};
+
+export interface Governor {
+  /** Waits until a token is available for `key`, then consumes it. */
+  acquire(key: string): Promise<void>;
+}
+
+interface Bucket {
+  tokens: number;
+  lastRefillMs: number;
+  /** Tail of the serialize-acquires promise chain for this key. */
+  tail: Promise<void>;
+}
+
+const deferred = (): { promise: Promise<void>; resolve: () => void } => {
+  // The executor runs synchronously, so `resolve` is assigned before this returns.
+  let resolve: () => void = () => undefined;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+};
+
+export const createGovernor = (
+  config: GovernorConfig = DEFAULT_GOVERNOR,
+  deps: GovernorDeps = realDeps
+): Governor => {
+  const buckets = new Map<string, Bucket>();
+
+  const bucketFor = (key: string): Bucket => {
+    const existing = buckets.get(key);
+    if (existing) return existing;
+    const fresh: Bucket = { tokens: config.burst, lastRefillMs: deps.now(), tail: Promise.resolve() };
+    buckets.set(key, fresh);
+    return fresh;
+  };
+
+  const refill = (bucket: Bucket): void => {
+    const now = deps.now();
+    const gained = ((now - bucket.lastRefillMs) / 1000) * config.ratePerSec;
+    bucket.tokens = Math.min(config.burst, bucket.tokens + gained);
+    bucket.lastRefillMs = now;
+  };
+
+  const acquire = async (key: string): Promise<void> => {
+    if (config.ratePerSec <= 0) return; // disabled — no pacing
+    const bucket = bucketFor(key);
+    const previous = bucket.tail;
+    const gate = deferred();
+    bucket.tail = gate.promise;
+    await previous; // serialize acquires for this key
+    try {
+      refill(bucket);
+      if (bucket.tokens < 1) {
+        const waitMs = ((1 - bucket.tokens) / config.ratePerSec) * 1000;
+        await deps.sleep(waitMs);
+        refill(bucket);
+      }
+      bucket.tokens -= 1;
+    } finally {
+      gate.resolve();
+    }
+  };
+
+  return { acquire };
+};

--- a/reso-client/src/http/resilience/resilient-send.ts
+++ b/reso-client/src/http/resilience/resilient-send.ts
@@ -1,0 +1,111 @@
+/**
+ * The resilient send — orchestrates one logical request end to end:
+ *
+ *   circuit check → governor (pace) → timeout(send) → classify →
+ *     success        → feed breaker, return the response
+ *     terminal 4xx   → return the response (the consumer inspects it; not a health signal)
+ *     fatal auth     → throw (never retry; stop the run)
+ *     health failure → retry (Retry-After for throttles, backoff for transients),
+ *                      or, once exhausted, return the response / throw exhausted
+ *
+ * The breaker is fed once per LOGICAL request (its final outcome), not per retry,
+ * so it tracks host/resource health across requests rather than within one. Sleep,
+ * jitter, and clock are injectable so tests run instantly and deterministically.
+ */
+
+import type { ODataResponse } from '../../types.js';
+import { backoffMs, shouldRetry } from './backoff.js';
+import { type FailureClassification, classifyResponse, classifyThrown, resilienceError } from './errors.js';
+import { parseRetryAfterMs } from './retry-after.js';
+import type { ResilienceSession } from './session.js';
+import { withTimeout } from './timeout.js';
+
+export interface SendDeps {
+  readonly sleep: (ms: number) => Promise<void>;
+  readonly random: () => number;
+  readonly now: () => number;
+}
+
+const realSendDeps: SendDeps = {
+  sleep: (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)),
+  random: Math.random,
+  now: () => Date.now()
+};
+
+type Attempt = { readonly response: ODataResponse } | { readonly thrown: FailureClassification };
+
+export const resilientSend = async (
+  send: (signal: AbortSignal) => Promise<ODataResponse>,
+  method: string,
+  key: string,
+  session: ResilienceSession,
+  deps: SendDeps = realSendDeps
+): Promise<ODataResponse> => {
+  const { governor, breaker, config } = session;
+
+  const attempt = async (retriesUsed: number): Promise<ODataResponse> => {
+    if (!breaker.canProceed(key)) {
+      throw resilienceError('circuit-open', `Circuit open for ${key}; failing fast.`);
+    }
+    await governor.acquire(key);
+
+    const outcome: Attempt = await (async () => {
+      try {
+        return { response: await withTimeout(config.timeoutMs, send) };
+      } catch (err) {
+        return { thrown: classifyThrown(err) };
+      }
+    })();
+
+    // ── A response came back ──
+    if ('response' in outcome) {
+      const { response } = outcome;
+      const classification = classifyResponse(response);
+
+      if (classification === null) {
+        breaker.onSuccess(key);
+        return response;
+      }
+      if (classification.kind === 'fatal-auth') {
+        throw resilienceError('fatal-auth', classification.message, classification);
+      }
+      if (classification.kind === 'terminal-4xx') {
+        return response; // a client error the consumer inspects — not retried, not a health signal
+      }
+
+      // health-relevant response failure (throttle-429 / transient-5xx)
+      const canRetry = shouldRetry(classification, method) && retriesUsed < config.backoff.maxRetries;
+      if (!canRetry) {
+        breaker.onFailure(key);
+        return response; // exhausted — surface the 429/5xx for the consumer to judge
+      }
+      const retryAfterMs = parseRetryAfterMs(response.headers['retry-after'], deps.now());
+      if (retryAfterMs !== null && retryAfterMs > config.maxRetryWaitMs) {
+        breaker.onFailure(key);
+        throw resilienceError(
+          'retry-wait-exceeded',
+          `Retry-After exceeds the ${config.maxRetryWaitMs}ms ceiling.`,
+          classification
+        );
+      }
+      const fallback =
+        classification.kind === 'throttle-429'
+          ? config.defaultRetryWaitMs // rate-limit windows are long; a short backoff just re-trips
+          : backoffMs(retriesUsed, config.backoff, deps.random);
+      await deps.sleep(retryAfterMs ?? fallback);
+      return attempt(retriesUsed + 1);
+    }
+
+    // ── The request threw (network / timeout) — no response ──
+    const classification = outcome.thrown;
+    const canRetry = shouldRetry(classification, method) && retriesUsed < config.backoff.maxRetries;
+    if (!canRetry) {
+      breaker.onFailure(key);
+      throw resilienceError('exhausted', classification.message, classification);
+    }
+    await deps.sleep(backoffMs(retriesUsed, config.backoff, deps.random));
+    return attempt(retriesUsed + 1);
+  };
+
+  return attempt(0);
+};

--- a/reso-client/src/http/resilience/resilient-send.ts
+++ b/reso-client/src/http/resilience/resilient-send.ts
@@ -2,15 +2,19 @@
  * The resilient send — orchestrates one logical request end to end:
  *
  *   circuit check → governor (pace) → timeout(send) → classify →
- *     success        → feed breaker, return the response
- *     terminal 4xx   → return the response (the consumer inspects it; not a health signal)
- *     fatal auth     → throw (never retry; stop the run)
+ *     success        → mark reachable, return the response
+ *     terminal 4xx   → mark reachable, return the response (the consumer inspects it)
+ *     fatal auth     → mark reachable, throw (never retry; stop the run)
  *     health failure → retry (Retry-After for throttles, backoff for transients),
- *                      or, once exhausted, return the response / throw exhausted
+ *                      or, once exhausted, mark reachable and return the response
+ *     transport death→ retry, or once exhausted mark UNREACHABLE and throw exhausted
  *
- * The breaker is fed once per LOGICAL request (its final outcome), not per retry,
- * so it tracks host/resource health across requests rather than within one. Sleep,
- * jitter, and clock are injectable so tests run instantly and deterministically.
+ * The breaker tracks REACHABILITY, not error rate: any HTTP response — a 5xx
+ * included — proves the endpoint answered, so it resets the breaker; only a network
+ * drop or timeout (no response) counts against it. A server that merely errors on a
+ * request therefore never trips the breaker, which matters both for replication (one
+ * bad row can't halt the rest) and for certification (a 5xx is a result to record).
+ * Sleep, jitter, and clock are injectable so tests run instantly and deterministically.
  */
 
 import type { ODataResponse } from '../../types.js';
@@ -43,7 +47,26 @@ export const resilientSend = async (
 ): Promise<ODataResponse> => {
   const { governor, breaker, config } = session;
 
+  // A status allowlist (when configured) further gates the method-aware retry decision:
+  // only failures whose status is listed may retry. A failure with no status — a network
+  // drop or a timeout — is therefore never retried under an allowlist. Undefined = no
+  // restriction (retry every retryable failure the method permits).
+  const statusAllowsRetry = (classification: FailureClassification): boolean =>
+    config.retryableStatuses === undefined ||
+    (classification.status !== undefined && config.retryableStatuses.includes(classification.status));
+
+  // The run's absolute wall-clock deadline (or undefined for no total cap). Once now is at
+  // or past it, we stop rather than issue another request or wait out another retry.
+  const deadlineMs =
+    config.totalTimeoutMs !== undefined ? session.startedAtMs + config.totalTimeoutMs : undefined;
+  const pastDeadline = (now: number): boolean => deadlineMs !== undefined && now >= deadlineMs;
+  const wouldOverrunDeadline = (waitMs: number, now: number): boolean =>
+    deadlineMs !== undefined && now + waitMs >= deadlineMs;
+
   const attempt = async (retriesUsed: number): Promise<ODataResponse> => {
+    if (pastDeadline(deps.now())) {
+      throw resilienceError('deadline-exceeded', `Total run timeout of ${config.totalTimeoutMs}ms exceeded.`);
+    }
     if (!breaker.canProceed(key)) {
       throw resilienceError('circuit-open', `Circuit open for ${key}; failing fast.`);
     }
@@ -57,7 +80,9 @@ export const resilientSend = async (
       }
     })();
 
-    // ── A response came back ──
+    // ── A response came back — the endpoint is reachable, so the breaker is healthy
+    // regardless of status. A 5xx means "responding, but erroring", not "unreachable":
+    // only a transport death (below) counts against the breaker. ──
     if ('response' in outcome) {
       const { response } = outcome;
       const classification = classifyResponse(response);
@@ -67,21 +92,26 @@ export const resilientSend = async (
         return response;
       }
       if (classification.kind === 'fatal-auth') {
+        breaker.onSuccess(key); // the server answered (401) — reachable; the auth failure is orthogonal
         throw resilienceError('fatal-auth', classification.message, classification);
       }
       if (classification.kind === 'terminal-4xx') {
-        return response; // a client error the consumer inspects — not retried, not a health signal
+        breaker.onSuccess(key);
+        return response; // a client error the consumer inspects — not retried
       }
 
       // health-relevant response failure (throttle-429 / transient-5xx)
-      const canRetry = shouldRetry(classification, method) && retriesUsed < config.backoff.maxRetries;
+      const canRetry =
+        shouldRetry(classification, method) &&
+        statusAllowsRetry(classification) &&
+        retriesUsed < config.backoff.maxRetries;
       if (!canRetry) {
-        breaker.onFailure(key);
-        return response; // exhausted — surface the 429/5xx for the consumer to judge
+        breaker.onSuccess(key); // the server responded (429/5xx) — reachable, just erroring
+        return response; // exhausted or not retryable — surface the 429/5xx for the consumer to judge
       }
       const retryAfterMs = parseRetryAfterMs(response.headers['retry-after'], deps.now());
       if (retryAfterMs !== null && retryAfterMs > config.maxRetryWaitMs) {
-        breaker.onFailure(key);
+        breaker.onSuccess(key); // still a live response — the wait is just too long to hold open
         throw resilienceError(
           'retry-wait-exceeded',
           `Retry-After exceeds the ${config.maxRetryWaitMs}ms ceiling.`,
@@ -92,18 +122,34 @@ export const resilientSend = async (
         classification.kind === 'throttle-429'
           ? config.defaultRetryWaitMs // rate-limit windows are long; a short backoff just re-trips
           : backoffMs(retriesUsed, config.backoff, deps.random);
-      await deps.sleep(retryAfterMs ?? fallback);
+      const waitMs = retryAfterMs ?? fallback;
+      if (wouldOverrunDeadline(waitMs, deps.now())) {
+        breaker.onSuccess(key); // reachable — we just can't afford to wait out the retry
+        throw resilienceError('deadline-exceeded', `Total run timeout would be exceeded by a ${waitMs}ms wait.`);
+      }
+      await deps.sleep(waitMs);
       return attempt(retriesUsed + 1);
     }
 
     // ── The request threw (network / timeout) — no response ──
     const classification = outcome.thrown;
-    const canRetry = shouldRetry(classification, method) && retriesUsed < config.backoff.maxRetries;
+    // A thrown failure has no HTTP status, so an allowlist (which lists statuses) never
+    // admits it — a caller that restricts retries to specific statuses does not retry
+    // network drops or timeouts.
+    const canRetry =
+      shouldRetry(classification, method) &&
+      statusAllowsRetry(classification) &&
+      retriesUsed < config.backoff.maxRetries;
     if (!canRetry) {
       breaker.onFailure(key);
       throw resilienceError('exhausted', classification.message, classification);
     }
-    await deps.sleep(backoffMs(retriesUsed, config.backoff, deps.random));
+    const waitMs = backoffMs(retriesUsed, config.backoff, deps.random);
+    if (wouldOverrunDeadline(waitMs, deps.now())) {
+      breaker.onFailure(key); // no response, and we're out of budget to keep trying
+      throw resilienceError('deadline-exceeded', `Total run timeout would be exceeded by a ${waitMs}ms wait.`);
+    }
+    await deps.sleep(waitMs);
     return attempt(retriesUsed + 1);
   };
 

--- a/reso-client/src/http/resilience/retry-after.ts
+++ b/reso-client/src/http/resilience/retry-after.ts
@@ -1,0 +1,39 @@
+/**
+ * Retry-After header parsing and validation per RFC 9110 §10.2.3:
+ *
+ *   Retry-After  = HTTP-date / delay-seconds
+ *   delay-seconds = 1*DIGIT   (a non-negative integer, in seconds)
+ *
+ * HTTP-date is RFC 9110 §5.6.7 (IMF-fixdate plus the obsolete forms). Validation
+ * is separate from resolution: the client honors a valid header for backoff, while
+ * the certification layer separately judges whether a server's header is spec-legal.
+ */
+
+/**
+ * Whether a Retry-After value is well-formed. A numeric value that is not a
+ * non-negative integer (negative, decimal) is rejected as malformed delay-seconds
+ * rather than being rescued by the lenient date parser.
+ */
+export const isValidRetryAfter = (value: string): boolean => {
+  const trimmed = value.trim();
+  if (trimmed === '') return false;
+  if (/^\d+$/.test(trimmed)) return true;
+  if (/^[+-]?\d*\.?\d+$/.test(trimmed)) return false;
+  return !Number.isNaN(Date.parse(trimmed));
+};
+
+/**
+ * Resolves a Retry-After header into a wait in milliseconds, or `null` when the
+ * header is absent or unparseable (the caller then falls back to its backoff).
+ * delay-seconds → that many seconds; HTTP-date → the interval until that date
+ * (never negative). `now` is injectable so the HTTP-date branch is deterministic
+ * in tests.
+ */
+export const parseRetryAfterMs = (value: string | undefined, now: number = Date.now()): number | null => {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (/^\d+$/.test(trimmed)) return Number(trimmed) * 1000;
+  const dateMs = Date.parse(trimmed);
+  if (Number.isNaN(dateMs)) return null;
+  return Math.max(0, dateMs - now);
+};

--- a/reso-client/src/http/resilience/session.ts
+++ b/reso-client/src/http/resilience/session.ts
@@ -24,6 +24,23 @@ export interface ResilienceConfig {
   readonly timeoutMs?: number;
   readonly defaultRetryWaitMs?: number;
   readonly maxRetryWaitMs?: number;
+  /**
+   * When set, restricts retries to failures whose HTTP status is in this list — a
+   * response-status allowlist layered on top of the method-aware retry decision. A
+   * failure with no status (a network drop or timeout) is therefore never retried
+   * when this is set. Omit for the default: retry every retryable failure the method
+   * permits. A caller that wants "retry only when the server told us to come back"
+   * (429 / 503) passes `[429, 503]`.
+   */
+  readonly retryableStatuses?: ReadonlyArray<number>;
+  /**
+   * Wall-clock budget for the WHOLE run (all requests sharing this session), in ms.
+   * Once it is spent, a request fails fast with `deadline-exceeded` rather than issuing
+   * or waiting further — the client's own equivalent of a job-scheduler kill, so a
+   * direct consumer caught in a 429 flood gets a graceful stop instead of an unbounded
+   * hang. Omit for no total cap (the per-request `timeoutMs` still bounds each request).
+   */
+  readonly totalTimeoutMs?: number;
 }
 
 export interface ResolvedResilienceConfig {
@@ -31,12 +48,18 @@ export interface ResolvedResilienceConfig {
   readonly timeoutMs: number;
   readonly defaultRetryWaitMs: number;
   readonly maxRetryWaitMs: number;
+  /** Response-status retry allowlist; undefined = retry every retryable failure the method permits. */
+  readonly retryableStatuses?: ReadonlyArray<number>;
+  /** Wall-clock budget for the whole run in ms; undefined = no total cap. */
+  readonly totalTimeoutMs?: number;
 }
 
 export interface ResilienceSession {
   readonly governor: Governor;
   readonly breaker: CircuitBreaker;
   readonly config: ResolvedResilienceConfig;
+  /** Wall-clock ms when the run began; with `config.totalTimeoutMs` it bounds the whole run. */
+  readonly startedAtMs: number;
 }
 
 /**
@@ -46,14 +69,17 @@ export interface ResilienceSession {
  */
 export const createResilienceSession = (
   config: ResilienceConfig = {},
-  parts?: { readonly governor?: Governor; readonly breaker?: CircuitBreaker }
+  parts?: { readonly governor?: Governor; readonly breaker?: CircuitBreaker; readonly now?: () => number }
 ): ResilienceSession => ({
   governor: parts?.governor ?? createGovernor(config.governor),
   breaker: parts?.breaker ?? createCircuitBreaker(config.breaker),
+  startedAtMs: parts?.now?.() ?? Date.now(),
   config: {
     backoff: config.backoff ?? DEFAULT_BACKOFF,
     timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
     defaultRetryWaitMs: config.defaultRetryWaitMs ?? DEFAULT_RETRY_WAIT_MS,
-    maxRetryWaitMs: config.maxRetryWaitMs ?? MAX_RETRY_WAIT_MS
+    maxRetryWaitMs: config.maxRetryWaitMs ?? MAX_RETRY_WAIT_MS,
+    retryableStatuses: config.retryableStatuses,
+    totalTimeoutMs: config.totalTimeoutMs
   }
 });

--- a/reso-client/src/http/resilience/session.ts
+++ b/reso-client/src/http/resilience/session.ts
@@ -1,0 +1,59 @@
+/**
+ * The resilience session — the injected, per-run service that holds the
+ * cross-call state (rate governors + circuit breakers, keyed per host|resource)
+ * and the resolved config. One session is created per run and shared by every
+ * request, so the per-call client model stays untouched while pacing and breaker
+ * state persist across requests (and, later, across parallel fetchers).
+ */
+
+import { type BackoffConfig, DEFAULT_BACKOFF } from './backoff.js';
+import { type BreakerConfig, type CircuitBreaker, createCircuitBreaker } from './circuit-breaker.js';
+import { type Governor, type GovernorConfig, createGovernor } from './rate-governor.js';
+
+/** Per-request timeout: 15 min, long enough to tolerate legitimately slow pages. */
+export const DEFAULT_TIMEOUT_MS = 15 * 60_000;
+/** Fallback wait when a 429/503 carries no usable Retry-After: 15 min. */
+export const DEFAULT_RETRY_WAIT_MS = 15 * 60_000;
+/** Ceiling: a Retry-After beyond this surfaces rather than blocking the run: 90 min. */
+export const MAX_RETRY_WAIT_MS = 90 * 60_000;
+
+export interface ResilienceConfig {
+  readonly governor?: GovernorConfig;
+  readonly breaker?: BreakerConfig;
+  readonly backoff?: BackoffConfig;
+  readonly timeoutMs?: number;
+  readonly defaultRetryWaitMs?: number;
+  readonly maxRetryWaitMs?: number;
+}
+
+export interface ResolvedResilienceConfig {
+  readonly backoff: BackoffConfig;
+  readonly timeoutMs: number;
+  readonly defaultRetryWaitMs: number;
+  readonly maxRetryWaitMs: number;
+}
+
+export interface ResilienceSession {
+  readonly governor: Governor;
+  readonly breaker: CircuitBreaker;
+  readonly config: ResolvedResilienceConfig;
+}
+
+/**
+ * Builds a resilience session. `governor`/`breaker` may be supplied pre-built
+ * (tests inject fake-clock or spy instances); otherwise they are created from the
+ * config with real deps.
+ */
+export const createResilienceSession = (
+  config: ResilienceConfig = {},
+  parts?: { readonly governor?: Governor; readonly breaker?: CircuitBreaker }
+): ResilienceSession => ({
+  governor: parts?.governor ?? createGovernor(config.governor),
+  breaker: parts?.breaker ?? createCircuitBreaker(config.breaker),
+  config: {
+    backoff: config.backoff ?? DEFAULT_BACKOFF,
+    timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    defaultRetryWaitMs: config.defaultRetryWaitMs ?? DEFAULT_RETRY_WAIT_MS,
+    maxRetryWaitMs: config.maxRetryWaitMs ?? MAX_RETRY_WAIT_MS
+  }
+});

--- a/reso-client/src/http/resilience/timeout.ts
+++ b/reso-client/src/http/resilience/timeout.ts
@@ -1,0 +1,33 @@
+/**
+ * Per-request timeout via AbortController.
+ *
+ * The legacy client had no timeout — a server that connects but never responds
+ * hangs the whole run forever. `withTimeout` races the request against a deadline;
+ * on expiry it aborts the underlying fetch (freeing the socket) and the promise
+ * rejects with an AbortError, which the classifier treats as a retryable `timeout`.
+ *
+ * The setTimeout here is a genuine deadline, not a synchronization hack — it is the
+ * timeout mechanism itself, and it is always cleared once the request settles.
+ */
+
+/**
+ * Runs `fn` with an abort signal that fires after `timeoutMs`. A non-finite or
+ * non-positive `timeoutMs` disables the timeout (the signal never fires) so callers
+ * can turn it off. The timer is always cleared in `finally`, so no timer lingers
+ * after the request settles.
+ */
+export const withTimeout = async <T>(
+  timeoutMs: number,
+  fn: (signal: AbortSignal) => Promise<T>
+): Promise<T> => {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return fn(new AbortController().signal);
+  }
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fn(controller.signal);
+  } finally {
+    clearTimeout(timer);
+  }
+};

--- a/reso-client/src/index.ts
+++ b/reso-client/src/index.ts
@@ -121,3 +121,29 @@ export type { VariationCsvRow, ParseVariationsCsvResult, ParseVariationsCsvError
 // Utilities — variation key (composite identifier)
 export { VARIATION_KEY_SEP, buildVariationKey, parseVariationKey } from './utils/variation-key.js';
 export type { ParsedVariationKey } from './utils/variation-key.js';
+
+// Resilience — per-request timeout, retry/backoff+jitter, Retry-After, pacing governor,
+// circuit breaker, and continue-on-error. See reso-tools #270.
+export {
+  createResilienceSession,
+  DEFAULT_TIMEOUT_MS,
+  DEFAULT_RETRY_WAIT_MS,
+  MAX_RETRY_WAIT_MS
+} from './http/resilience/session.js';
+export type { ResilienceConfig, ResilienceSession, ResolvedResilienceConfig } from './http/resilience/session.js';
+export { DEFAULT_GOVERNOR } from './http/resilience/rate-governor.js';
+export type { GovernorConfig } from './http/resilience/rate-governor.js';
+export { DEFAULT_BREAKER } from './http/resilience/circuit-breaker.js';
+export type { BreakerConfig, BreakerState } from './http/resilience/circuit-breaker.js';
+export { DEFAULT_BACKOFF } from './http/resilience/backoff.js';
+export type { BackoffConfig } from './http/resilience/backoff.js';
+export { isResilienceError } from './http/resilience/errors.js';
+export type { FailureClassification, FailureKind, ResilienceError, ResilienceErrorKind } from './http/resilience/errors.js';
+export { runSettled, settle, skip } from './http/resilience/continue-on-error.js';
+export type {
+  UnitOutcome,
+  SettledResult,
+  OnError,
+  SettleOptions,
+  RunSettledOptions
+} from './http/resilience/continue-on-error.js';

--- a/reso-client/src/index.ts
+++ b/reso-client/src/index.ts
@@ -137,7 +137,7 @@ export { DEFAULT_BREAKER } from './http/resilience/circuit-breaker.js';
 export type { BreakerConfig, BreakerState } from './http/resilience/circuit-breaker.js';
 export { DEFAULT_BACKOFF } from './http/resilience/backoff.js';
 export type { BackoffConfig } from './http/resilience/backoff.js';
-export { isResilienceError } from './http/resilience/errors.js';
+export { isDeadlineError, isResilienceError } from './http/resilience/errors.js';
 export type { FailureClassification, FailureKind, ResilienceError, ResilienceErrorKind } from './http/resilience/errors.js';
 export { runSettled, settle, skip } from './http/resilience/continue-on-error.js';
 export type {

--- a/reso-client/src/types.ts
+++ b/reso-client/src/types.ts
@@ -5,6 +5,8 @@
  * TypeScript with discriminated unions and immutable interfaces.
  */
 
+import type { ResilienceConfig, ResilienceSession } from './http/resilience/session.js';
+
 // ---------------------------------------------------------------------------
 // Query options
 // ---------------------------------------------------------------------------
@@ -132,6 +134,14 @@ export interface ClientConfig {
   readonly baseUrl: string;
   readonly auth: AuthConfig;
   readonly defaultHeaders?: Readonly<Record<string, string>>;
+  /** Resilience tunables (per-request timeout, retry/backoff, pacing, circuit breaker). Safe defaults apply when omitted. */
+  readonly resilience?: ResilienceConfig;
+  /**
+   * A shared resilience session to inject. Create one per run and pass it to every
+   * client so per-call clients share pacing and breaker state (and, later, parallel
+   * fetchers share one budget). When omitted, a per-client session is created.
+   */
+  readonly session?: ResilienceSession;
 }
 
 /** Prefer header options for write operations. */

--- a/reso-client/tests/client-resilience-integration.test.ts
+++ b/reso-client/tests/client-resilience-integration.test.ts
@@ -1,0 +1,76 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { createClient } from '../src/http/client.js';
+import { isResilienceError } from '../src/http/resilience/errors.js';
+import type { ClientConfig } from '../src/types.js';
+import { type MockServer, startMockServer } from './helpers/mock-server.js';
+
+// Pacing off + tiny waits so the real-fetch retry path runs fast.
+const fastResilience: ClientConfig['resilience'] = {
+  governor: { ratePerSec: 0, burst: 0 },
+  backoff: { baseMs: 1, maxMs: 5, maxRetries: 3 },
+  defaultRetryWaitMs: 5,
+  maxRetryWaitMs: 10_000,
+  timeoutMs: 200
+};
+
+describe('createClient — resilience integration (real fetch, misbehaving server)', () => {
+  let server: MockServer;
+
+  beforeAll(async () => {
+    server = await startMockServer();
+  });
+  afterAll(async () => {
+    await server.close();
+  });
+  beforeEach(() => server.reset());
+
+  const makeClient = () =>
+    createClient({
+      baseUrl: server.url,
+      auth: { mode: 'token', authToken: 'test' },
+      resilience: fastResilience
+    });
+
+  it('returns a 200 through the resilient path', async () => {
+    server.enqueue({ status: 200, body: { value: [1] } });
+    const client = await makeClient();
+    const res = await client.request('GET', `${server.url}/Property`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ value: [1] });
+  });
+
+  it('retries a real 429, then succeeds', async () => {
+    server.enqueue({ status: 429, headers: { 'retry-after': '0' } }, { status: 200, body: { value: [] } });
+    const client = await makeClient();
+    const res = await client.request('GET', `${server.url}/Property`);
+    expect(res.status).toBe(200);
+    expect(server.requests.length).toBe(2);
+  });
+
+  it('retries a real dropped connection, then succeeds', async () => {
+    server.enqueue({ drop: true }, { status: 200, body: { value: [] } });
+    const client = await makeClient();
+    const res = await client.request('GET', `${server.url}/Property`);
+    expect(res.status).toBe(200);
+    expect(server.requests.length).toBe(2);
+  });
+
+  it('returns a terminal 404 without retrying', async () => {
+    server.enqueue({ status: 404 });
+    const client = await makeClient();
+    const res = await client.request('GET', `${server.url}/Media`);
+    expect(res.status).toBe(404);
+    expect(server.requests.length).toBe(1);
+  });
+
+  it('times out a persistently hung endpoint and exhausts retries', async () => {
+    server.setHandler(() => ({ hang: true }));
+    const client = await makeClient();
+    try {
+      await client.request('GET', `${server.url}/Property`);
+      expect.unreachable('a hung endpoint should have timed out and exhausted');
+    } catch (err) {
+      expect(isResilienceError(err) && err.resilienceKind === 'exhausted').toBe(true);
+    }
+  }, 10_000);
+});

--- a/reso-client/tests/helpers/mock-server.ts
+++ b/reso-client/tests/helpers/mock-server.ts
@@ -1,0 +1,122 @@
+/**
+ * A programmable, deliberately-misbehaving local HTTP server for rigorously
+ * testing the resilient request path against realistic server behavior:
+ * scripted status sequences, Retry-After headers, latency, hung sockets
+ * (for timeout tests), and dropped connections (for network-error tests).
+ *
+ * Listens on an ephemeral loopback port. Tests script behavior via `enqueue`
+ * (FIFO, consumed one per request) or `setHandler` (per-request decision),
+ * and assert against the recorded request log.
+ */
+
+import { createServer, type Server } from 'node:http';
+import type { Socket } from 'node:net';
+
+export interface MockReply {
+  readonly status?: number;
+  readonly headers?: Readonly<Record<string, string>>;
+  /** JSON-serialized as the body unless `rawBody` is given. */
+  readonly body?: unknown;
+  /** Exact response body; overrides `body` (use for malformed/non-JSON payloads). */
+  readonly rawBody?: string;
+  /** Wait this many ms before replying (simulate a slow server). */
+  readonly delayMs?: number;
+  /** Never reply — leave the socket open (simulate a hang, to exercise client timeouts). */
+  readonly hang?: boolean;
+  /** Destroy the socket instead of replying (simulate a dropped connection / network error). */
+  readonly drop?: boolean;
+}
+
+export interface RecordedRequest {
+  readonly method: string;
+  readonly url: string;
+  readonly headers: Readonly<Record<string, string | readonly string[] | undefined>>;
+  /** Wall-clock ms when the request was received (for pacing/concurrency assertions). */
+  readonly at: number;
+}
+
+export interface MockServer {
+  readonly url: string;
+  readonly requests: readonly RecordedRequest[];
+  /** Queue replies consumed FIFO, one per request. */
+  enqueue(...replies: readonly MockReply[]): void;
+  /** Fallback decision used when the queue is empty. */
+  setHandler(handler: (req: RecordedRequest) => MockReply): void;
+  reset(): void;
+  close(): Promise<void>;
+}
+
+const DEFAULT_REPLY: MockReply = { status: 200, body: { value: [] } };
+
+export const startMockServer = async (): Promise<MockServer> => {
+  const requests: RecordedRequest[] = [];
+  const queue: MockReply[] = [];
+  const sockets = new Set<Socket>();
+  const state: { handler?: (req: RecordedRequest) => MockReply } = {};
+
+  const server: Server = createServer((req, res) => {
+    const recorded: RecordedRequest = {
+      method: req.method ?? 'GET',
+      url: req.url ?? '/',
+      headers: req.headers,
+      at: Date.now()
+    };
+    requests.push(recorded);
+    req.resume(); // drain any request body so POST/PATCH sockets don't stall
+
+    const reply = queue.shift() ?? state.handler?.(recorded) ?? DEFAULT_REPLY;
+
+    const send = (): void => {
+      if (reply.drop) {
+        req.socket.destroy();
+        return;
+      }
+      if (reply.hang) {
+        return; // never respond
+      }
+      const headers = { 'content-type': 'application/json', ...reply.headers };
+      res.writeHead(reply.status ?? 200, headers);
+      res.end(reply.rawBody ?? JSON.stringify(reply.body ?? {}));
+    };
+
+    if (reply.delayMs && reply.delayMs > 0) {
+      setTimeout(send, reply.delayMs);
+    } else {
+      send();
+    }
+  });
+
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  if (address === null || typeof address === 'string') {
+    throw new Error('mock server did not bind to a TCP port');
+  }
+  const url = `http://127.0.0.1:${address.port}`;
+
+  return {
+    url,
+    get requests() {
+      return requests;
+    },
+    enqueue(...replies) {
+      queue.push(...replies);
+    },
+    setHandler(handler) {
+      state.handler = handler;
+    },
+    reset() {
+      requests.length = 0;
+      queue.length = 0;
+      state.handler = undefined;
+    },
+    async close() {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  };
+};

--- a/reso-client/tests/mock-server.test.ts
+++ b/reso-client/tests/mock-server.test.ts
@@ -1,0 +1,66 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { type MockServer, startMockServer } from './helpers/mock-server.js';
+
+describe('mock server harness', () => {
+  let server: MockServer;
+
+  beforeAll(async () => {
+    server = await startMockServer();
+  });
+  afterAll(async () => {
+    await server.close();
+  });
+  beforeEach(() => server.reset());
+
+  it('serves queued replies FIFO and records requests in order', async () => {
+    server.enqueue({ status: 200, body: { value: [1] } }, { status: 200, body: { value: [2] } });
+    const a = await (await fetch(`${server.url}/Property`)).json();
+    const b = await (await fetch(`${server.url}/Member`)).json();
+    expect(a).toEqual({ value: [1] });
+    expect(b).toEqual({ value: [2] });
+    expect(server.requests.map((r) => r.url)).toEqual(['/Property', '/Member']);
+  });
+
+  it('serves a scripted 429 with a Retry-After header', async () => {
+    server.enqueue({ status: 429, headers: { 'retry-after': '2' } });
+    const res = await fetch(`${server.url}/Property`);
+    expect(res.status).toBe(429);
+    expect(res.headers.get('retry-after')).toBe('2');
+  });
+
+  it('can return a malformed (non-JSON) 200 body', async () => {
+    server.enqueue({ status: 200, rawBody: '<html>gateway error</html>' });
+    const res = await fetch(`${server.url}/Property`);
+    expect(res.status).toBe(200);
+    await expect(res.json()).rejects.toThrow();
+  });
+
+  it('delays a response by the configured ms', async () => {
+    server.enqueue({ delayMs: 40, body: { value: [] } });
+    const start = Date.now();
+    const res = await fetch(`${server.url}/Property`);
+    expect(res.status).toBe(200);
+    expect(Date.now() - start).toBeGreaterThanOrEqual(25);
+  });
+
+  it('drops the socket → the client sees a transport error', async () => {
+    server.enqueue({ drop: true });
+    await expect(fetch(`${server.url}/Property`)).rejects.toThrow();
+  });
+
+  it('hangs → a client AbortController can time it out', async () => {
+    server.enqueue({ hang: true });
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 30);
+    await expect(fetch(`${server.url}/Property`, { signal: controller.signal })).rejects.toMatchObject({
+      name: 'AbortError'
+    });
+    clearTimeout(timer);
+  });
+
+  it('falls back to a handler when the queue is empty', async () => {
+    server.setHandler((req) => (req.url === '/Media' ? { status: 404 } : { status: 200 }));
+    expect((await fetch(`${server.url}/Media`)).status).toBe(404);
+    expect((await fetch(`${server.url}/Property`)).status).toBe(200);
+  });
+});

--- a/reso-client/tests/resilience-backoff.test.ts
+++ b/reso-client/tests/resilience-backoff.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { type BackoffConfig, backoffMs, shouldRetry } from '../src/http/resilience/backoff.js';
+import type { FailureClassification } from '../src/http/resilience/errors.js';
+
+const cls = (
+  over: Partial<FailureClassification> & Pick<FailureClassification, 'kind' | 'retryable'>
+): FailureClassification => ({ fatal: false, message: 'x', ...over });
+
+describe('backoffMs', () => {
+  const cfg: BackoffConfig = { baseMs: 100, maxMs: 1000, maxRetries: 5 };
+
+  it('is zero when the jitter roll is zero', () => {
+    expect(backoffMs(0, cfg, () => 0)).toBe(0);
+  });
+
+  it('grows exponentially from baseMs and is capped at maxMs', () => {
+    expect(backoffMs(0, cfg, () => 0.9999)).toBeLessThanOrEqual(100);
+    expect(backoffMs(3, cfg, () => 0.9999)).toBeLessThanOrEqual(800); // 100 * 2^3 = 800 < cap
+    expect(backoffMs(10, cfg, () => 0.9999)).toBeLessThanOrEqual(1000); // capped at maxMs
+  });
+
+  it('stays within [0, ceiling) for any jitter roll', () => {
+    for (const r of [0, 0.25, 0.5, 0.75, 0.999]) {
+      const v = backoffMs(2, cfg, () => r); // ceiling = min(1000, 100 * 4) = 400
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(400);
+    }
+  });
+});
+
+describe('shouldRetry', () => {
+  it('never retries non-retryable failures', () => {
+    expect(shouldRetry(cls({ kind: 'terminal-4xx', retryable: false, status: 404 }), 'GET')).toBe(false);
+    expect(shouldRetry(cls({ kind: 'fatal-auth', retryable: false, fatal: true, status: 401 }), 'GET')).toBe(false);
+  });
+
+  it('retries any retryable failure for idempotent methods', () => {
+    for (const m of ['GET', 'HEAD', 'PUT', 'DELETE', 'OPTIONS']) {
+      expect(shouldRetry(cls({ kind: 'network', retryable: true }), m)).toBe(true);
+      expect(shouldRetry(cls({ kind: 'timeout', retryable: true }), m)).toBe(true);
+      expect(shouldRetry(cls({ kind: 'transient-5xx', retryable: true, status: 500 }), m)).toBe(true);
+    }
+  });
+
+  it('retries a mutation only when the server proved it did not process it (429/503)', () => {
+    expect(shouldRetry(cls({ kind: 'throttle-429', retryable: true, status: 429 }), 'POST')).toBe(true);
+    expect(shouldRetry(cls({ kind: 'transient-5xx', retryable: true, status: 503 }), 'PATCH')).toBe(true);
+  });
+
+  it('does NOT retry a mutation on an ambiguous failure (timeout / network / 500 / 502)', () => {
+    expect(shouldRetry(cls({ kind: 'transient-5xx', retryable: true, status: 500 }), 'POST')).toBe(false);
+    expect(shouldRetry(cls({ kind: 'transient-5xx', retryable: true, status: 502 }), 'POST')).toBe(false);
+    expect(shouldRetry(cls({ kind: 'network', retryable: true }), 'POST')).toBe(false);
+    expect(shouldRetry(cls({ kind: 'timeout', retryable: true }), 'PATCH')).toBe(false);
+  });
+});

--- a/reso-client/tests/resilience-circuit-breaker.test.ts
+++ b/reso-client/tests/resilience-circuit-breaker.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import { type BreakerDeps, createCircuitBreaker } from '../src/http/resilience/circuit-breaker.js';
+
+const fakeClock = (): BreakerDeps & { advance: (ms: number) => void } => {
+  const state = { now: 0 };
+  return {
+    now: () => state.now,
+    advance: (ms: number) => {
+      state.now += ms;
+    }
+  };
+};
+
+describe('createCircuitBreaker', () => {
+  it('starts closed and admits requests', () => {
+    const b = createCircuitBreaker({ threshold: 3, cooldownMs: 1000 }, fakeClock());
+    expect(b.stateOf('k')).toBe('closed');
+    expect(b.canProceed('k')).toBe(true);
+  });
+
+  it('opens after threshold consecutive failures, then fails fast', () => {
+    const b = createCircuitBreaker({ threshold: 3, cooldownMs: 1000 }, fakeClock());
+    b.onFailure('k');
+    b.onFailure('k');
+    expect(b.stateOf('k')).toBe('closed');
+    b.onFailure('k'); // 3rd consecutive → open
+    expect(b.stateOf('k')).toBe('open');
+    expect(b.canProceed('k')).toBe(false);
+  });
+
+  it('resets the counter on success (consecutive, not cumulative — the legacy bug)', () => {
+    const b = createCircuitBreaker({ threshold: 3, cooldownMs: 1000 }, fakeClock());
+    b.onFailure('k');
+    b.onFailure('k');
+    b.onSuccess('k'); // reset
+    b.onFailure('k');
+    b.onFailure('k'); // only 2 consecutive since the success
+    expect(b.stateOf('k')).toBe('closed');
+    expect(b.canProceed('k')).toBe(true);
+  });
+
+  it('half-opens after the cooldown to admit a probe', () => {
+    const clock = fakeClock();
+    const b = createCircuitBreaker({ threshold: 1, cooldownMs: 1000 }, clock);
+    b.onFailure('k'); // open at t=0
+    expect(b.canProceed('k')).toBe(false);
+    clock.advance(1000);
+    expect(b.canProceed('k')).toBe(true);
+    expect(b.stateOf('k')).toBe('half-open');
+  });
+
+  it('closes on a successful probe', () => {
+    const clock = fakeClock();
+    const b = createCircuitBreaker({ threshold: 1, cooldownMs: 1000 }, clock);
+    b.onFailure('k');
+    clock.advance(1000);
+    b.canProceed('k'); // → half-open
+    b.onSuccess('k'); // probe succeeded
+    expect(b.stateOf('k')).toBe('closed');
+    expect(b.canProceed('k')).toBe(true);
+  });
+
+  it('re-opens on a failed probe with a fresh cooldown', () => {
+    const clock = fakeClock();
+    const b = createCircuitBreaker({ threshold: 1, cooldownMs: 1000 }, clock);
+    b.onFailure('k'); // open at t=0
+    clock.advance(1000);
+    b.canProceed('k'); // → half-open at t=1000
+    b.onFailure('k'); // probe failed → re-open, openedAt=1000
+    expect(b.stateOf('k')).toBe('open');
+    expect(b.canProceed('k')).toBe(false); // still within the fresh cooldown
+    clock.advance(1000);
+    expect(b.canProceed('k')).toBe(true); // half-open again at t=2000
+  });
+
+  it('keys breakers independently', () => {
+    const b = createCircuitBreaker({ threshold: 1, cooldownMs: 1000 }, fakeClock());
+    b.onFailure('A');
+    expect(b.canProceed('A')).toBe(false);
+    expect(b.canProceed('B')).toBe(true);
+  });
+});

--- a/reso-client/tests/resilience-continue-on-error.test.ts
+++ b/reso-client/tests/resilience-continue-on-error.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { runSettled, settle, skip, type UnitOutcome } from '../src/http/resilience/continue-on-error.js';
+import { isResilienceError, resilienceError } from '../src/http/resilience/errors.js';
+
+type Behavior = 'ok' | 'fail' | 'skip' | 'fatal';
+
+/** A `run` over string items whose behavior is looked up per item; records what actually ran. */
+const runner =
+  (behaviors: Record<string, Behavior> = {}, ran?: string[]) =>
+  async (item: string): Promise<string> => {
+    ran?.push(item);
+    const behavior = behaviors[item] ?? 'ok';
+    if (behavior === 'fail') throw new Error(`fail:${item}`);
+    if (behavior === 'skip') return skip(`skip:${item}`);
+    if (behavior === 'fatal') throw resilienceError('fatal-auth', `fatal:${item}`);
+    return `ok:${item}`;
+  };
+
+describe('settle (generator primitive)', () => {
+  it('is lazy — breaking early leaves later items un-run (streaming/backpressure)', async () => {
+    const ran: string[] = [];
+    const seen: string[] = [];
+    for await (const outcome of settle(['a', 'b', 'c', 'd', 'e'], runner({}, ran))) {
+      seen.push(outcome.item);
+      if (seen.length === 2) break; // pull only two
+    }
+    expect(seen).toEqual(['a', 'b']);
+    expect(ran).toEqual(['a', 'b']); // c/d/e never ran — proof of pull semantics
+  });
+
+  it('returns stoppedEarly=false when every item runs', async () => {
+    const generator = settle(['a', 'b'], runner({}));
+    let step = await generator.next();
+    while (!step.done) step = await generator.next();
+    expect(step.value).toBe(false);
+  });
+
+  it('yields the fatal failure, then stops without running the rest', async () => {
+    const ran: string[] = [];
+    const outcomes: UnitOutcome<string, string>[] = [];
+    const generator = settle(['a', 'b', 'c'], runner({ b: 'fatal' }, ran));
+    let step = await generator.next();
+    while (!step.done) {
+      outcomes.push(step.value);
+      step = await generator.next();
+    }
+    expect(step.value).toBe(true); // stopped early
+    expect(ran).toEqual(['a', 'b']); // c never ran
+    expect(outcomes.map((o) => o.status)).toEqual(['ok', 'failed']);
+  });
+});
+
+describe('runSettled (collector)', () => {
+  it('collects all successes', async () => {
+    const r = await runSettled(['a', 'b', 'c'], runner({}));
+    expect(r.succeeded).toEqual(['ok:a', 'ok:b', 'ok:c']);
+    expect(r.failed).toEqual([]);
+    expect(r.stoppedEarly).toBe(false);
+  });
+
+  it('continues past a per-unit failure, recording it', async () => {
+    const ran: string[] = [];
+    const r = await runSettled(['a', 'b', 'c'], runner({ b: 'fail' }, ran), { onError: 'continue' });
+    expect(ran).toEqual(['a', 'b', 'c']); // all ran
+    expect(r.succeeded).toEqual(['ok:a', 'ok:c']);
+    expect(r.failed.map((f) => f.item)).toEqual(['b']);
+    expect(r.stoppedEarly).toBe(false);
+  });
+
+  it('stops at the first failure under fail-fast', async () => {
+    const ran: string[] = [];
+    const r = await runSettled(['a', 'b', 'c'], runner({ b: 'fail' }, ran), { onError: 'fail-fast' });
+    expect(ran).toEqual(['a', 'b']); // c not run
+    expect(r.failed.map((f) => f.item)).toEqual(['b']);
+    expect(r.stoppedEarly).toBe(true);
+  });
+
+  it('always stops on a fatal, even under continue', async () => {
+    const ran: string[] = [];
+    const r = await runSettled(['a', 'b', 'c'], runner({ b: 'fatal' }, ran), { onError: 'continue' });
+    expect(ran).toEqual(['a', 'b']); // c not run
+    expect(r.stoppedEarly).toBe(true);
+    expect(isResilienceError(r.fatalError) && r.fatalError.resilienceKind).toBe('fatal-auth');
+  });
+
+  it('records skips distinctly and keeps going', async () => {
+    const r = await runSettled(['a', 'b', 'c'], runner({ b: 'skip' }));
+    expect(r.succeeded).toEqual(['ok:a', 'ok:c']);
+    expect(r.skipped).toEqual([{ item: 'b', reason: 'skip:b' }]);
+    expect(r.failed).toEqual([]);
+  });
+
+  it('fires onOutcome as each unit settles (checkpoint hook)', async () => {
+    const seen: string[] = [];
+    await runSettled(['a', 'b'], runner({ b: 'fail' }), {
+      onOutcome: (o) => seen.push(`${o.status}:${o.item}`)
+    });
+    expect(seen).toEqual(['ok:a', 'failed:b']);
+  });
+
+  it('honors a custom isFatal', async () => {
+    const r = await runSettled(['a', 'b', 'c'], runner({ b: 'fail' }), { isFatal: () => true });
+    expect(r.stoppedEarly).toBe(true);
+    expect(r.fatalError).toBeDefined();
+  });
+});

--- a/reso-client/tests/resilience-errors.test.ts
+++ b/reso-client/tests/resilience-errors.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { classifyResponse, classifyStatus, classifyThrown } from '../src/http/resilience/errors.js';
+
+describe('classifyStatus', () => {
+  it('classifies 429 as a retryable throttle', () => {
+    const c = classifyStatus(429);
+    expect(c.kind).toBe('throttle-429');
+    expect(c.retryable).toBe(true);
+    expect(c.fatal).toBe(false);
+  });
+
+  it('classifies 401 as fatal auth, never retryable (whole run is doomed)', () => {
+    const c = classifyStatus(401);
+    expect(c.kind).toBe('fatal-auth');
+    expect(c.retryable).toBe(false);
+    expect(c.fatal).toBe(true);
+  });
+
+  it('classifies 403 as terminal (unit-level), never retryable', () => {
+    const c = classifyStatus(403);
+    expect(c.kind).toBe('terminal-4xx');
+    expect(c.retryable).toBe(false);
+    expect(c.fatal).toBe(false);
+  });
+
+  it('classifies other 4xx as terminal', () => {
+    for (const s of [400, 404, 405, 409, 422]) {
+      expect(classifyStatus(s).kind).toBe('terminal-4xx');
+      expect(classifyStatus(s).retryable).toBe(false);
+    }
+  });
+
+  it('classifies 501 as terminal even though it is a 5xx', () => {
+    expect(classifyStatus(501).kind).toBe('terminal-4xx');
+    expect(classifyStatus(501).retryable).toBe(false);
+  });
+
+  it('classifies 500/502/503/504 as retryable transient', () => {
+    for (const s of [500, 502, 503, 504]) {
+      const c = classifyStatus(s);
+      expect(c.kind).toBe('transient-5xx');
+      expect(c.retryable).toBe(true);
+      expect(c.fatal).toBe(false);
+    }
+  });
+});
+
+describe('classifyResponse', () => {
+  it('returns null for a non-error status', () => {
+    expect(classifyResponse({ status: 200 })).toBeNull();
+    expect(classifyResponse({ status: 204 })).toBeNull();
+  });
+
+  it('classifies an error status', () => {
+    expect(classifyResponse({ status: 503 })?.kind).toBe('transient-5xx');
+    expect(classifyResponse({ status: 404 })?.kind).toBe('terminal-4xx');
+  });
+});
+
+describe('classifyThrown', () => {
+  it('classifies an AbortError as a retryable timeout', () => {
+    const err = new Error('aborted');
+    err.name = 'AbortError';
+    const c = classifyThrown(err);
+    expect(c.kind).toBe('timeout');
+    expect(c.retryable).toBe(true);
+  });
+
+  it('classifies a generic transport error as network and preserves err.code', () => {
+    const err = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    const c = classifyThrown(err);
+    expect(c.kind).toBe('network');
+    expect(c.retryable).toBe(true);
+    expect(c.code).toBe('ECONNRESET');
+    expect(c.message).toBe('socket hang up');
+  });
+
+  it('recovers a transport code nested under err.cause (undici shape)', () => {
+    const err = Object.assign(new Error('fetch failed'), { cause: { code: 'ENOTFOUND' } });
+    const c = classifyThrown(err);
+    expect(c.kind).toBe('network');
+    expect(c.code).toBe('ENOTFOUND');
+  });
+
+  it('recovers detail a {...err} spread would silently drop', () => {
+    const err = Object.assign(new Error('boom'), { code: 'ETIMEDOUT' });
+    // Documents the legacy bug: Error.message is non-enumerable, so the spread loses it.
+    expect({ ...err }).toEqual({ code: 'ETIMEDOUT' });
+    const c = classifyThrown(err);
+    expect(c.message).toBe('boom');
+    expect(c.code).toBe('ETIMEDOUT');
+  });
+
+  it('handles a thrown string', () => {
+    const c = classifyThrown('nope');
+    expect(c.kind).toBe('network');
+    expect(c.message).toBe('nope');
+  });
+});

--- a/reso-client/tests/resilience-key.test.ts
+++ b/reso-client/tests/resilience-key.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { resilienceKey } from '../src/http/client.js';
+
+/**
+ * The governor/breaker key must identify a RESOURCE, not just a host — otherwise a
+ * path-prefixed service root collapses every resource onto one key and a burst on one
+ * resource paces/trips the breaker for all of them (the bug the #273 review surfaced).
+ */
+describe('resilienceKey', () => {
+  it('keys per full resource path, so a path-prefixed root keeps resources distinct', () => {
+    const property = resilienceKey('https://host/odata/Property?$top=1');
+    const member = resilienceKey('https://host/odata/Member?$top=1');
+    expect(property).toBe('host|/odata/Property');
+    expect(member).toBe('host|/odata/Member');
+    expect(property).not.toBe(member); // before the fix both were `host|odata`
+  });
+
+  it('folds a key predicate onto its collection (they are the same resource)', () => {
+    expect(resilienceKey("https://host/odata/Property('123')")).toBe('host|/odata/Property');
+    expect(resilienceKey('https://host/odata/Property')).toBe('host|/odata/Property');
+  });
+
+  it('keeps a navigation segment distinct — it strips only the key predicate, not the tail', () => {
+    expect(resilienceKey("https://host/odata/Property('1')/Media")).toBe('host|/odata/Property/Media');
+    expect(resilienceKey("https://host/odata/Property('1')/Media")).not.toBe('host|/odata/Property');
+  });
+
+  it('keeps resources distinct at a bare service root as well', () => {
+    expect(resilienceKey('https://host/Property')).toBe('host|/Property');
+    expect(resilienceKey('https://host/Member')).toBe('host|/Member');
+  });
+
+  it('falls back to the raw string when the url will not parse', () => {
+    expect(resilienceKey('not a url')).toBe('not a url');
+  });
+});

--- a/reso-client/tests/resilience-rate-governor.test.ts
+++ b/reso-client/tests/resilience-rate-governor.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { createGovernor, type GovernorDeps } from '../src/http/resilience/rate-governor.js';
+
+/** A fake clock whose `sleep` advances virtual time and resolves instantly — no real waits. */
+const fakeClock = (): GovernorDeps & { elapsed: () => number } => {
+  const state = { now: 0 };
+  return {
+    now: () => state.now,
+    sleep: async (ms: number) => {
+      state.now += ms;
+    },
+    elapsed: () => state.now
+  };
+};
+
+describe('createGovernor', () => {
+  it('does not pace when disabled (ratePerSec 0)', async () => {
+    const clock = fakeClock();
+    const gov = createGovernor({ ratePerSec: 0, burst: 1 }, clock);
+    await gov.acquire('k');
+    await gov.acquire('k');
+    await gov.acquire('k');
+    expect(clock.elapsed()).toBe(0);
+  });
+
+  it('lets an isolated/first request through immediately (bucket starts full)', async () => {
+    const clock = fakeClock();
+    const gov = createGovernor({ ratePerSec: 1, burst: 1 }, clock);
+    await gov.acquire('k');
+    expect(clock.elapsed()).toBe(0);
+  });
+
+  it('paces sustained requests to the configured rate', async () => {
+    const clock = fakeClock();
+    const gov = createGovernor({ ratePerSec: 1, burst: 1 }, clock);
+    await gov.acquire('k'); // immediate
+    await gov.acquire('k'); // +1000
+    await gov.acquire('k'); // +1000
+    expect(clock.elapsed()).toBe(2000);
+  });
+
+  it('keys buckets independently — one key does not pace another', async () => {
+    const clock = fakeClock();
+    const gov = createGovernor({ ratePerSec: 1, burst: 1 }, clock);
+    await gov.acquire('A'); // immediate
+    await gov.acquire('A'); // +1000
+    const before = clock.elapsed();
+    await gov.acquire('B'); // fresh bucket → immediate
+    expect(clock.elapsed()).toBe(before);
+  });
+
+  it('serializes concurrent acquires on one key (shared budget, parallelism-safe)', async () => {
+    const clock = fakeClock();
+    const gov = createGovernor({ ratePerSec: 1, burst: 1 }, clock);
+    // Five acquires fired without awaiting each — they must queue and space out.
+    await Promise.all([0, 1, 2, 3, 4].map(() => gov.acquire('k')));
+    expect(clock.elapsed()).toBe(4000); // first immediate, then 4 × 1000ms
+  });
+
+  it('allows a burst up to capacity before pacing engages', async () => {
+    const clock = fakeClock();
+    const gov = createGovernor({ ratePerSec: 1, burst: 3 }, clock);
+    await gov.acquire('k'); // 3 → 2
+    await gov.acquire('k'); // 2 → 1
+    await gov.acquire('k'); // 1 → 0
+    expect(clock.elapsed()).toBe(0);
+    await gov.acquire('k'); // 0 → wait 1000
+    expect(clock.elapsed()).toBe(1000);
+  });
+});

--- a/reso-client/tests/resilience-resilient-send.test.ts
+++ b/reso-client/tests/resilience-resilient-send.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import type { BreakerState, CircuitBreaker } from '../src/http/resilience/circuit-breaker.js';
+import { type BreakerState, type CircuitBreaker, createCircuitBreaker } from '../src/http/resilience/circuit-breaker.js';
 import { isResilienceError } from '../src/http/resilience/errors.js';
 import type { Governor } from '../src/http/resilience/rate-governor.js';
 import { resilientSend, type SendDeps } from '../src/http/resilience/resilient-send.js';
@@ -69,16 +69,29 @@ const fakeDeps = (): SendDeps & { waits: number[] } => {
   };
 };
 
-const sessionWith = (governor: Governor, breaker: CircuitBreaker): ResilienceSession => ({
+const sessionWith = (
+  governor: Governor,
+  breaker: CircuitBreaker,
+  configOverrides: Partial<ResilienceSession['config']> = {},
+  startedAtMs = 0
+): ResilienceSession => ({
   governor,
   breaker,
+  startedAtMs,
   config: {
     backoff: { baseMs: 100, maxMs: 1000, maxRetries: 3 },
     timeoutMs: 1000,
     defaultRetryWaitMs: 5000,
-    maxRetryWaitMs: 60_000
+    maxRetryWaitMs: 60_000,
+    ...configOverrides
   }
 });
+
+// Deps with a fixed clock reading, for exercising the run deadline deterministically.
+const fakeDepsAt = (nowValue: number): SendDeps & { waits: number[] } => {
+  const waits: number[] = [];
+  return { sleep: async (ms: number) => { waits.push(ms); }, random: () => 0, now: () => nowValue, waits };
+};
 
 const networkError = (code: string): Error => Object.assign(new Error('boom'), { code });
 
@@ -121,18 +134,18 @@ describe('resilientSend', () => {
     expect(deps.waits).toEqual([5000]); // defaultRetryWaitMs
   });
 
-  it('returns a terminal 4xx unchanged, without retry or a breaker signal', async () => {
+  it('returns a terminal 4xx unchanged and marks the endpoint reachable (a response = alive)', async () => {
     const b = spyBreaker();
     const s = scriptedSend([{ response: res(404) }]);
     const deps = fakeDeps();
     const out = await resilientSend(s.send, 'GET', 'k', sessionWith(spyGovernor().governor, b.breaker), deps);
     expect(out.status).toBe(404);
     expect(s.calls()).toBe(1);
-    expect(b.events).toEqual([]);
+    expect(b.events).toEqual(['success:k']); // reachability breaker: any response resets it
     expect(deps.waits).toEqual([]);
   });
 
-  it('throws a typed fatal on a 401 and does not touch the breaker', async () => {
+  it('throws a typed fatal on a 401 but still marks the endpoint reachable (it answered)', async () => {
     const b = spyBreaker();
     const s = scriptedSend([{ response: res(401) }]);
     try {
@@ -142,7 +155,7 @@ describe('resilientSend', () => {
       expect(isResilienceError(err)).toBe(true);
       if (isResilienceError(err)) expect(err.resilienceKind).toBe('fatal-auth');
     }
-    expect(b.events).toEqual([]);
+    expect(b.events).toEqual(['success:k']); // the 401 is a response — the auth failure is orthogonal to reachability
   });
 
   it('retries a network error for a GET up to maxRetries, then throws exhausted', async () => {
@@ -187,7 +200,7 @@ describe('resilientSend', () => {
     expect(g.acquired).toEqual([]);
   });
 
-  it('surfaces a Retry-After beyond the ceiling instead of blocking', async () => {
+  it('surfaces a Retry-After beyond the ceiling instead of blocking (still a live response)', async () => {
     const b = spyBreaker();
     const s = scriptedSend([{ response: res(429, { 'retry-after': '999999' }) }]);
     try {
@@ -196,17 +209,17 @@ describe('resilientSend', () => {
     } catch (err) {
       expect(isResilienceError(err) && err.resilienceKind === 'retry-wait-exceeded').toBe(true);
     }
-    expect(b.events).toEqual(['failure:k']);
+    expect(b.events).toEqual(['success:k']); // the 429 is a response — reachable; we just won't hold that long
   });
 
-  it('returns the last 5xx once retries are exhausted (so the consumer can see it)', async () => {
+  it('returns the last 5xx once retries are exhausted, marking the endpoint reachable (not a breaker failure)', async () => {
     const b = spyBreaker();
     const s = scriptedSend(Array.from({ length: 4 }, () => ({ response: res(500) })));
     const deps = fakeDeps();
     const out = await resilientSend(s.send, 'GET', 'k', sessionWith(spyGovernor().governor, b.breaker), deps);
     expect(out.status).toBe(500);
     expect(s.calls()).toBe(4);
-    expect(b.events).toEqual(['failure:k']);
+    expect(b.events).toEqual(['success:k']); // a 5xx is "responding, but erroring" — reachable, so it must not trip the breaker
     expect(deps.waits).toEqual([0, 0, 0]);
   });
 
@@ -216,5 +229,152 @@ describe('resilientSend', () => {
     const out = await resilientSend(s.send, 'POST', 'k', sessionWith(spyGovernor().governor, spyBreaker().breaker), deps);
     expect(out.status).toBe(200);
     expect(deps.waits).toEqual([1000]);
+  });
+});
+
+describe('resilientSend with a retryableStatuses allowlist (retry only when the server says come back)', () => {
+  const allowlist = { retryableStatuses: [429, 503] as const };
+
+  it('retries a 429 (listed)', async () => {
+    const s = scriptedSend([{ response: res(429, { 'retry-after': '1' }) }, { response: res(200) }]);
+    const deps = fakeDeps();
+    const out = await resilientSend(
+      s.send, 'GET', 'k', sessionWith(spyGovernor().governor, spyBreaker().breaker, allowlist), deps
+    );
+    expect(out.status).toBe(200);
+    expect(s.calls()).toBe(2);
+  });
+
+  it('retries a 503 (listed)', async () => {
+    const s = scriptedSend([{ response: res(503, { 'retry-after': '1' }) }, { response: res(200) }]);
+    const deps = fakeDeps();
+    const out = await resilientSend(
+      s.send, 'GET', 'k', sessionWith(spyGovernor().governor, spyBreaker().breaker, allowlist), deps
+    );
+    expect(out.status).toBe(200);
+    expect(s.calls()).toBe(2);
+  });
+
+  it('does NOT retry a 500 (not listed) — returns it on the first attempt', async () => {
+    const s = scriptedSend([{ response: res(500) }]);
+    const deps = fakeDeps();
+    const out = await resilientSend(
+      s.send, 'GET', 'k', sessionWith(spyGovernor().governor, spyBreaker().breaker, allowlist), deps
+    );
+    expect(out.status).toBe(500);
+    expect(s.calls()).toBe(1); // no retry
+    expect(deps.waits).toEqual([]);
+  });
+
+  it('does NOT retry a network drop (no status can be in the allowlist) — throws exhausted on the first attempt', async () => {
+    const s = scriptedSend([{ throw: networkError('ECONNRESET') }]);
+    try {
+      await resilientSend(
+        s.send, 'GET', 'k', sessionWith(spyGovernor().governor, spyBreaker().breaker, allowlist), fakeDeps()
+      );
+      expect.unreachable('an unlisted network drop should not retry');
+    } catch (err) {
+      expect(isResilienceError(err) && err.resilienceKind === 'exhausted').toBe(true);
+    }
+    expect(s.calls()).toBe(1); // no retry
+  });
+
+  it('without an allowlist, a 500 still retries (default behavior preserved)', async () => {
+    const s = scriptedSend([{ response: res(500) }, { response: res(200) }]);
+    const out = await resilientSend(
+      s.send, 'GET', 'k', sessionWith(spyGovernor().governor, spyBreaker().breaker), fakeDeps()
+    );
+    expect(out.status).toBe(200);
+    expect(s.calls()).toBe(2); // retried
+  });
+});
+
+describe('resilientSend total run deadline (totalTimeoutMs)', () => {
+  it('fails fast with deadline-exceeded, without sending, once the run budget is spent', async () => {
+    const s = scriptedSend([{ response: res(200) }]);
+    // budget 1000ms from start=0; the clock already reads 1500 → past the deadline.
+    const session = sessionWith(spyGovernor().governor, spyBreaker().breaker, { totalTimeoutMs: 1000 }, 0);
+    try {
+      await resilientSend(s.send, 'GET', 'k', session, fakeDepsAt(1500));
+      expect.unreachable('a spent budget should fail fast');
+    } catch (err) {
+      expect(isResilienceError(err) && err.resilienceKind === 'deadline-exceeded').toBe(true);
+    }
+    expect(s.calls()).toBe(0); // never issued
+  });
+
+  it('proceeds normally while the run budget remains', async () => {
+    const s = scriptedSend([{ response: res(200) }]);
+    const session = sessionWith(spyGovernor().governor, spyBreaker().breaker, { totalTimeoutMs: 1000 }, 0);
+    const out = await resilientSend(s.send, 'GET', 'k', session, fakeDepsAt(500)); // within budget
+    expect(out.status).toBe(200);
+    expect(s.calls()).toBe(1);
+  });
+
+  it('refuses to wait out a retry it cannot afford (a 429 wait longer than the remaining budget)', async () => {
+    // A 429 asks for a 5s wait, but only 1s of run budget remains → do not sleep, stop instead.
+    const s = scriptedSend([{ response: res(429, { 'retry-after': '5' }) }, { response: res(200) }]);
+    const deps = fakeDepsAt(0);
+    const session = sessionWith(spyGovernor().governor, spyBreaker().breaker, { totalTimeoutMs: 1000 }, 0);
+    try {
+      await resilientSend(s.send, 'GET', 'k', session, deps);
+      expect.unreachable('an unaffordable retry wait should stop the run');
+    } catch (err) {
+      expect(isResilienceError(err) && err.resilienceKind === 'deadline-exceeded').toBe(true);
+    }
+    expect(s.calls()).toBe(1); // sent once, then stopped rather than sleeping 5s
+    expect(deps.waits).toEqual([]); // never slept
+  });
+
+  it('has no deadline when totalTimeoutMs is unset (default) — a far-future clock still proceeds', async () => {
+    const s = scriptedSend([{ response: res(200) }]);
+    const out = await resilientSend(
+      s.send, 'GET', 'k', sessionWith(spyGovernor().governor, spyBreaker().breaker), fakeDepsAt(9_999_999)
+    );
+    expect(out.status).toBe(200);
+  });
+});
+
+describe('resilientSend breaker feeding is reachability, not error rate', () => {
+  const allowlist = { retryableStatuses: [429, 503] as const }; // keeps each request to one attempt
+
+  // for...of over a fixed-length array: sequential awaits without leaking a loop counter.
+  const runN = async (n: number, once: () => Promise<void>): Promise<void> => {
+    for (const _ of Array.from({ length: n })) await once();
+  };
+
+  it('never opens the breaker on repeated 5xx responses (the endpoint is reachable, just erroring)', async () => {
+    const breaker = createCircuitBreaker(); // default threshold 5
+    const g = spyGovernor();
+    await runN(10, async () => {
+      const s = scriptedSend([{ response: res(500) }]);
+      await resilientSend(s.send, 'GET', 'k', sessionWith(g.governor, breaker, allowlist), fakeDeps());
+    });
+    expect(breaker.stateOf('k')).toBe('closed');
+    expect(breaker.canProceed('k')).toBe(true);
+  });
+
+  it('opens the breaker after threshold consecutive transport deaths (no response)', async () => {
+    const breaker = createCircuitBreaker(); // default threshold 5
+    const g = spyGovernor();
+    await runN(5, async () => {
+      const s = scriptedSend([{ throw: networkError('ECONNRESET') }]);
+      await resilientSend(s.send, 'GET', 'k', sessionWith(g.governor, breaker, allowlist), fakeDeps()).catch(() => {});
+    });
+    expect(breaker.stateOf('k')).toBe('open');
+  });
+
+  it('a single reachable response resets the consecutive transport-death count', async () => {
+    const breaker = createCircuitBreaker(); // default threshold 5
+    const g = spyGovernor();
+    const death = async () => {
+      const s = scriptedSend([{ throw: networkError('ECONNRESET') }]);
+      await resilientSend(s.send, 'GET', 'k', sessionWith(g.governor, breaker, allowlist), fakeDeps()).catch(() => {});
+    };
+    await runN(4, death); // one below threshold
+    const alive = scriptedSend([{ response: res(500) }]); // a 5xx still proves reachability → resets
+    await resilientSend(alive.send, 'GET', 'k', sessionWith(g.governor, breaker, allowlist), fakeDeps());
+    await runN(4, death); // 4 more deaths — count restarted, so still closed
+    expect(breaker.stateOf('k')).toBe('closed');
   });
 });

--- a/reso-client/tests/resilience-resilient-send.test.ts
+++ b/reso-client/tests/resilience-resilient-send.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from 'vitest';
+import type { BreakerState, CircuitBreaker } from '../src/http/resilience/circuit-breaker.js';
+import { isResilienceError } from '../src/http/resilience/errors.js';
+import type { Governor } from '../src/http/resilience/rate-governor.js';
+import { resilientSend, type SendDeps } from '../src/http/resilience/resilient-send.js';
+import type { ResilienceSession } from '../src/http/resilience/session.js';
+import type { ODataResponse } from '../src/types.js';
+
+const res = (status: number, headers: Record<string, string> = {}): ODataResponse => ({
+  status,
+  headers,
+  body: status < 300 ? { value: [] } : null,
+  rawBody: ''
+});
+
+const spyGovernor = (): { governor: Governor; acquired: string[] } => {
+  const acquired: string[] = [];
+  return {
+    governor: {
+      acquire: async (key: string) => {
+        acquired.push(key);
+      }
+    },
+    acquired
+  };
+};
+
+const spyBreaker = (canProceed = true): { breaker: CircuitBreaker; events: string[] } => {
+  const events: string[] = [];
+  return {
+    breaker: {
+      canProceed: () => canProceed,
+      onSuccess: (key: string) => events.push(`success:${key}`),
+      onFailure: (key: string) => events.push(`failure:${key}`),
+      stateOf: (): BreakerState => 'closed'
+    },
+    events
+  };
+};
+
+type Scripted = { response: ODataResponse } | { throw: unknown };
+
+const scriptedSend = (
+  outcomes: readonly Scripted[]
+): { send: (signal: AbortSignal) => Promise<ODataResponse>; calls: () => number } => {
+  const queue = [...outcomes];
+  const state = { calls: 0 };
+  return {
+    send: async () => {
+      state.calls += 1;
+      const next = queue.shift();
+      if (!next) throw new Error('scripted send exhausted');
+      if ('throw' in next) throw next.throw;
+      return next.response;
+    },
+    calls: () => state.calls
+  };
+};
+
+const fakeDeps = (): SendDeps & { waits: number[] } => {
+  const waits: number[] = [];
+  return {
+    sleep: async (ms: number) => {
+      waits.push(ms);
+    },
+    random: () => 0, // full-jitter backoff collapses to 0 → deterministic
+    now: () => 0,
+    waits
+  };
+};
+
+const sessionWith = (governor: Governor, breaker: CircuitBreaker): ResilienceSession => ({
+  governor,
+  breaker,
+  config: {
+    backoff: { baseMs: 100, maxMs: 1000, maxRetries: 3 },
+    timeoutMs: 1000,
+    defaultRetryWaitMs: 5000,
+    maxRetryWaitMs: 60_000
+  }
+});
+
+const networkError = (code: string): Error => Object.assign(new Error('boom'), { code });
+
+describe('resilientSend', () => {
+  it('returns a 2xx, paces once, and marks the breaker healthy', async () => {
+    const g = spyGovernor();
+    const b = spyBreaker();
+    const s = scriptedSend([{ response: res(200) }]);
+    const deps = fakeDeps();
+
+    const out = await resilientSend(s.send, 'GET', 'k', sessionWith(g.governor, b.breaker), deps);
+
+    expect(out.status).toBe(200);
+    expect(g.acquired).toEqual(['k']);
+    expect(b.events).toEqual(['success:k']);
+    expect(s.calls()).toBe(1);
+    expect(deps.waits).toEqual([]);
+  });
+
+  it('backs off a 429 by its Retry-After, then returns the retried success', async () => {
+    const g = spyGovernor();
+    const b = spyBreaker();
+    const s = scriptedSend([{ response: res(429, { 'retry-after': '2' }) }, { response: res(200) }]);
+    const deps = fakeDeps();
+
+    const out = await resilientSend(s.send, 'GET', 'k', sessionWith(g.governor, b.breaker), deps);
+
+    expect(out.status).toBe(200);
+    expect(s.calls()).toBe(2);
+    expect(deps.waits).toEqual([2000]); // 2s Retry-After
+    expect(b.events).toEqual(['success:k']); // breaker fed once, on the final outcome
+    expect(g.acquired).toEqual(['k', 'k']);
+  });
+
+  it('uses the default rate-limit wait when a 429 carries no Retry-After', async () => {
+    const s = scriptedSend([{ response: res(429) }, { response: res(200) }]);
+    const deps = fakeDeps();
+    const out = await resilientSend(s.send, 'GET', 'k', sessionWith(spyGovernor().governor, spyBreaker().breaker), deps);
+    expect(out.status).toBe(200);
+    expect(deps.waits).toEqual([5000]); // defaultRetryWaitMs
+  });
+
+  it('returns a terminal 4xx unchanged, without retry or a breaker signal', async () => {
+    const b = spyBreaker();
+    const s = scriptedSend([{ response: res(404) }]);
+    const deps = fakeDeps();
+    const out = await resilientSend(s.send, 'GET', 'k', sessionWith(spyGovernor().governor, b.breaker), deps);
+    expect(out.status).toBe(404);
+    expect(s.calls()).toBe(1);
+    expect(b.events).toEqual([]);
+    expect(deps.waits).toEqual([]);
+  });
+
+  it('throws a typed fatal on a 401 and does not touch the breaker', async () => {
+    const b = spyBreaker();
+    const s = scriptedSend([{ response: res(401) }]);
+    try {
+      await resilientSend(s.send, 'GET', 'k', sessionWith(spyGovernor().governor, b.breaker), fakeDeps());
+      expect.unreachable('401 should have thrown');
+    } catch (err) {
+      expect(isResilienceError(err)).toBe(true);
+      if (isResilienceError(err)) expect(err.resilienceKind).toBe('fatal-auth');
+    }
+    expect(b.events).toEqual([]);
+  });
+
+  it('retries a network error for a GET up to maxRetries, then throws exhausted', async () => {
+    const b = spyBreaker();
+    const s = scriptedSend(Array.from({ length: 4 }, () => ({ throw: networkError('ECONNRESET') })));
+    const deps = fakeDeps();
+    try {
+      await resilientSend(s.send, 'GET', 'k', sessionWith(spyGovernor().governor, b.breaker), deps);
+      expect.unreachable('exhausted network error should have thrown');
+    } catch (err) {
+      expect(isResilienceError(err)).toBe(true);
+      if (isResilienceError(err)) expect(err.resilienceKind).toBe('exhausted');
+    }
+    expect(s.calls()).toBe(4); // initial + 3 retries
+    expect(deps.waits).toEqual([0, 0, 0]); // 3 backoff sleeps
+    expect(b.events).toEqual(['failure:k']); // one health failure at the end
+  });
+
+  it('does NOT retry a mutation on an ambiguous network error', async () => {
+    const b = spyBreaker();
+    const s = scriptedSend([{ throw: networkError('ETIMEDOUT') }]);
+    try {
+      await resilientSend(s.send, 'POST', 'k', sessionWith(spyGovernor().governor, b.breaker), fakeDeps());
+      expect.unreachable();
+    } catch (err) {
+      expect(isResilienceError(err) && err.resilienceKind === 'exhausted').toBe(true);
+    }
+    expect(s.calls()).toBe(1);
+    expect(b.events).toEqual(['failure:k']);
+  });
+
+  it('fails fast when the circuit is open (no send, no pacing)', async () => {
+    const g = spyGovernor();
+    const s = scriptedSend([{ response: res(200) }]);
+    try {
+      await resilientSend(s.send, 'GET', 'k', sessionWith(g.governor, spyBreaker(false).breaker), fakeDeps());
+      expect.unreachable();
+    } catch (err) {
+      expect(isResilienceError(err) && err.resilienceKind === 'circuit-open').toBe(true);
+    }
+    expect(s.calls()).toBe(0);
+    expect(g.acquired).toEqual([]);
+  });
+
+  it('surfaces a Retry-After beyond the ceiling instead of blocking', async () => {
+    const b = spyBreaker();
+    const s = scriptedSend([{ response: res(429, { 'retry-after': '999999' }) }]);
+    try {
+      await resilientSend(s.send, 'GET', 'k', sessionWith(spyGovernor().governor, b.breaker), fakeDeps());
+      expect.unreachable();
+    } catch (err) {
+      expect(isResilienceError(err) && err.resilienceKind === 'retry-wait-exceeded').toBe(true);
+    }
+    expect(b.events).toEqual(['failure:k']);
+  });
+
+  it('returns the last 5xx once retries are exhausted (so the consumer can see it)', async () => {
+    const b = spyBreaker();
+    const s = scriptedSend(Array.from({ length: 4 }, () => ({ response: res(500) })));
+    const deps = fakeDeps();
+    const out = await resilientSend(s.send, 'GET', 'k', sessionWith(spyGovernor().governor, b.breaker), deps);
+    expect(out.status).toBe(500);
+    expect(s.calls()).toBe(4);
+    expect(b.events).toEqual(['failure:k']);
+    expect(deps.waits).toEqual([0, 0, 0]);
+  });
+
+  it('retries a mutation on a 503 (server proved it did not process it)', async () => {
+    const s = scriptedSend([{ response: res(503, { 'retry-after': '1' }) }, { response: res(200) }]);
+    const deps = fakeDeps();
+    const out = await resilientSend(s.send, 'POST', 'k', sessionWith(spyGovernor().governor, spyBreaker().breaker), deps);
+    expect(out.status).toBe(200);
+    expect(deps.waits).toEqual([1000]);
+  });
+});

--- a/reso-client/tests/resilience-retry-after.test.ts
+++ b/reso-client/tests/resilience-retry-after.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { isValidRetryAfter, parseRetryAfterMs } from '../src/http/resilience/retry-after.js';
+
+describe('isValidRetryAfter', () => {
+  it('accepts non-negative integer delay-seconds', () => {
+    expect(isValidRetryAfter('120')).toBe(true);
+    expect(isValidRetryAfter('0')).toBe(true);
+    expect(isValidRetryAfter('  120  ')).toBe(true);
+  });
+
+  it('accepts an HTTP-date', () => {
+    expect(isValidRetryAfter('Wed, 21 Oct 2026 07:28:00 GMT')).toBe(true);
+  });
+
+  it('rejects empty or whitespace-only values', () => {
+    expect(isValidRetryAfter('')).toBe(false);
+    expect(isValidRetryAfter('   ')).toBe(false);
+  });
+
+  it('rejects numeric values that are not non-negative integers', () => {
+    expect(isValidRetryAfter('-5')).toBe(false);
+    expect(isValidRetryAfter('3.5')).toBe(false);
+    expect(isValidRetryAfter('+2')).toBe(false);
+  });
+
+  it('rejects non-numeric, non-date garbage', () => {
+    expect(isValidRetryAfter('soon')).toBe(false);
+    expect(isValidRetryAfter('tomorrow')).toBe(false);
+  });
+});
+
+describe('parseRetryAfterMs', () => {
+  it('converts delay-seconds to milliseconds', () => {
+    expect(parseRetryAfterMs('120')).toBe(120_000);
+    expect(parseRetryAfterMs('0')).toBe(0);
+  });
+
+  it('returns null when absent or unparseable', () => {
+    expect(parseRetryAfterMs(undefined)).toBeNull();
+    expect(parseRetryAfterMs('soon')).toBeNull();
+  });
+
+  it('returns the interval until a future HTTP-date (injected now)', () => {
+    const now = Date.parse('Wed, 21 Oct 2026 07:28:00 GMT');
+    expect(parseRetryAfterMs('Wed, 21 Oct 2026 07:29:00 GMT', now)).toBe(60_000);
+  });
+
+  it('clamps a past HTTP-date to zero', () => {
+    const now = Date.parse('Wed, 21 Oct 2026 07:28:00 GMT');
+    expect(parseRetryAfterMs('Wed, 21 Oct 2026 07:27:00 GMT', now)).toBe(0);
+  });
+});

--- a/reso-client/tests/resilience-timeout.test.ts
+++ b/reso-client/tests/resilience-timeout.test.ts
@@ -1,0 +1,40 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { classifyThrown } from '../src/http/resilience/errors.js';
+import { withTimeout } from '../src/http/resilience/timeout.js';
+import { type MockServer, startMockServer } from './helpers/mock-server.js';
+
+describe('withTimeout', () => {
+  let server: MockServer;
+
+  beforeAll(async () => {
+    server = await startMockServer();
+  });
+  afterAll(async () => {
+    await server.close();
+  });
+  beforeEach(() => server.reset());
+
+  it('resolves normally when the request completes in time', async () => {
+    server.enqueue({ status: 200, body: { ok: true } });
+    const res = await withTimeout(1000, (signal) => fetch(`${server.url}/Property`, { signal }));
+    expect(res.status).toBe(200);
+  });
+
+  it('aborts a hung request, and the abort classifies as a retryable timeout', async () => {
+    server.enqueue({ hang: true });
+    try {
+      await withTimeout(30, (signal) => fetch(`${server.url}/Property`, { signal }));
+      expect.unreachable('the hung request should have timed out');
+    } catch (err) {
+      const c = classifyThrown(err);
+      expect(c.kind).toBe('timeout');
+      expect(c.retryable).toBe(true);
+    }
+  });
+
+  it('does not abort a slow-but-completing request when disabled (0)', async () => {
+    server.enqueue({ delayMs: 20, status: 200 });
+    const res = await withTimeout(0, (signal) => fetch(`${server.url}/Property`, { signal }));
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
**Draft — complete, adversarial review passed (one finding fixed), ready for a look** (part of the beta.6 cycle). The client portions are all in: reso-client resilience (**#270**), the shared-session injection, and the monadic-container adoption of the Core runner (**#125**). **#271** / **#272** are deferred follow-ups. Left as a draft for your review — un-draft when you're happy with it.

Everything here is green: full monorepo suite passes (common 16 · metadata-utils 108 · validation 98 · filter-parser 180 · client 194 · server 265 · certification 822 +2 expected-fail · mcp 21), `tsc --noEmit` clean.

## reso-client resilience (#270)

The request path is now resilient by default, all built with injectable deps (clock/sleep/random) so tests are instant and deterministic — no real waits, no live server:

- **Error taxonomy** — `terminal-4xx / throttle-429 / transient-5xx / network / timeout / fatal-auth`; fixes the legacy `{...err}` bug (recovers `err.code`).
- **Retry-After** (RFC 9110 §10.2.3) — validate + parse; tolerant (garbage → default wait), respects a valid header.
- **Backoff** — full-jitter exponential + **method-aware** retry (GET retries freely; POST/PATCH only on 429/503, never an ambiguous timeout/5xx that may have landed).
- **Per-request timeout** (`AbortController`) — closes the legacy hang-forever gap.
- **Token-bucket pacing governor**, per `(host,resource)`, concurrency-safe (serialized acquires) — the shared budget parallel fetchers will draw from.
- **Circuit breaker**, per `(host,resource)`, consecutive-failure (reset on success), open → cooldown → half-open probe.
- **Injected session** (`ResilienceSession`) composing them; `resilientSend` orchestration wired into `request()`; typed `ResilienceError` surfaced.
- **Continue-on-error** — `settle()` async generator (streams, so a million-row seed doesn't OOM) + `runSettled()` collector; severity split (per-unit → continue/fail-fast; fatal → always stop).
- A programmable **misbehaving-server test harness** (scripted statuses, Retry-After, hung sockets, dropped connections) for real end-to-end tests.

## Cert adoption

- **Core resource loop** now uses `runSettled` (continue-on-error): one bad resource is captured and the run keeps going; an **unsampleable resource → skipped** (inconclusive, not a compliance failure), fatal-auth aborts.
- **#125 first increment**: `executeStandardScenario` takes its client by **injection** (`ODataRequester` seam — a web client and a test client both implement it). Characterized its four outcomes first, then flipped the test from `vi.mock` to an injected test client — identical assertions before/after prove the refactor preserved behavior.

## Landed since opening (this was the "still to do")

- ✅ **Container injection widened across every Core scenario runner + sampling** — no request touches the free `odataRequest` anymore; the container test proves global `fetch` is never called (the whole resource runs through the injected client, zero real network).
- ✅ **`core.ts` builds a session-bound requester once per run** — sampling *and* every scenario share one `ResilienceSession` (the seam #271 parallel fetchers + DD 2.2 will draw a shared budget from). For cert the stateful layers are configured inert — see the operating model below.
- ✅ **Adversarial review pass done** — five refute-by-default lenses (threading completeness · session-coverage gaps · shared-session persistence · behavior preservation · test non-vacuity), each finding independently verified. See below.

## Review results

Eight agents, refute-by-default, each finding independently verified. **One confirmed defect — in code this branch added — now fixed; two refuted.**

- ✅ **CONFIRMED → fixed (`dcb39e2`): the run-shared circuit breaker false-failed handled scenarios.** At the default threshold (5 consecutive retryable failures) the shared breaker would open on a partially-working server — one that 5xx's on a run of `$filter` scenarios — and then short-circuit every *subsequent* required scenario on that key with `circuit-open`, recording them as **FAILED** even though the server handles them (server-driven-paging, the error-code checks). The breaker key is `host|<first-path-segment>`, so a path-prefixed service root (`host/odata/Property`, `host/odata/Member`, …) collapses every resource onto one key — a burst on one resource would block sampling of the others.
- 🚫 **Refuted: the `/$metadata` fetch bypasses the session.** True that it doesn't go through the requester, but its "hangs the whole run" scenario doesn't reproduce — undici's default 300s header timeout is *tighter* than the session's 15-min — and it's pre-existing, not introduced here. Noted as a follow-up, not a blocker.
- 🚫 **Refuted: a test-non-vacuity placeholder** — the lens returned a literal `a/b/c/d` stub; verification read all four test files and confirmed none are vacuous.

## Cert resilience operating model (`createCertSession`)

The fix settled what cert wants from resilience: **record whatever the server returns, and only retry when the server itself says "come back."** Every HTTP response — a 5xx included — is a *result to record*, so the stateful layers are inert and retries are narrow:

- **Breaker off** — a real breaker at an infinite threshold; never opens. (The bug above.)
- **Governor (pacing) off** — a bounded cert run stays fast; if a vendor rate-limits, the governor rate is the knob.
- **Retry only 429/503, twice** (`retryableStatuses: [429, 503]`, `maxRetries: 2`) — those two statuses mean "reachable, come back later," so a re-send can succeed. A 500/502/504 is the server's verdict (re-sending risks a duplicate-query block); a network drop / timeout is re-sent into the same wall — record and move on.
- **15-min per-request timeout kept**, declared explicitly so an SDK-default change can't silently shorten it.

"Endpoint unreachable" is handled by sampling → **SKIPPED**, not the breaker. Locked by `tests/cert-session.test.ts`.

## Graceful stop on the run deadline (dogfooding `totalTimeoutMs`)

Cert now sets a run-wide budget (`totalTimeoutMs`, default 55 min, overridable via `CoreConfig` — sits under a job scheduler's own kill so the client stops first and still writes a report). When it's spent the run stops **gracefully**, not hung and not hard-killed:

- Every remaining resource/scenario is marked **NOT TESTED** — reported *skipped* with "run deadline reached", **never failed** (the crown-jewel invariant: a truncated run can't misreport a compliant vendor). The six runner catches re-throw the deadline instead of swallowing it; `runCoreResourceScenarios` marks the rest not-tested.
- A **partial report still writes**, and the verdict is **`incomplete`** (distinct `◐`), exiting non-zero so a cut-short run can't read as a clean pass.

**Verdict correctness (from the adversarial passes).** Two pure, exhaustively-tested functions now own the run's status: `coreVerdict` (**failed > incomplete > passed** — a definitive failure is never softened to "incomplete" just because the run also ran out of time) and `reportVerdict` (`coreVerdict` plus two "the run didn't complete cleanly" guards — a failed upstream step, or a testing phase that produced no results, forces `failed`). The second closes a **pre-existing false-PASS** the review surfaced: on a fatal-auth abort or a failed metadata step, the report headline could read `passed` while the exit code was `failed`. A normal run trips neither guard and is unchanged.

Full suite **850 + 2 expected-fail**, tsc clean, 14 commits.

## Notes

- Held for adversarial review (cert-adjacent core) — nothing merged. Four refute-by-default passes run over this branch; every confirmed finding fixed with a regression test.
- **End-to-end guardrails added** (`c605c4a`) — a reusable fetch-level mock OData server (`tests/helpers/core-mock-server.ts`) + `core-e2e-guardrails.test.ts` run the whole `runCoreCompliance` and assert the written `report-detailed.json` outcome: fatal-auth → `failed`, invalid metadata → `failed`, deadline → `incomplete`. The fatal-auth and deadline cases are **red-green verified** (neutering the fix flips the report to a false `passed`), closing the wiring-coverage gap. (`priorStepFailed` isn't isolatable e2e — any upstream failure that lets testing proceed also fails scenarios — so it stays unit-covered in `core-verdict.test.ts`; noted honestly in the test.)
- **Open for the author:** the 55-min budget default (vs the real Batch kill), and whether `incomplete` should exit a distinct code from `failed`.
- Deferred, ticketed: **#271** parallel fetchers, **#272** resume via a two-way generator, plus a `maxFailures` error budget and the DD 2.2 sampling migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
