### PR TITLE
beta.7 — Core 2.1.0 declared-but-not-served carve-out + CLI shared-option builders

### DIFF
--- a/reso-certification/src/cli/index.ts
+++ b/reso-certification/src/cli/index.ts
@@ -42,6 +42,7 @@ import { runMetadataStep } from './metadata-command.js';
 import { fetchMetadataReportFromServer } from '../sdk/metadata-source.js';
 import { runRcf, resolveRcfExitCode } from './rcf-command.js';
 import type { ODataVersion } from '../xsd/validate-csdl.js';
+import { addAuthOptions, addOutputOptions } from './shared-options.js';
 import { runReplicate, REPLICATION_STRATEGY_VALUES } from './replicate-command.js';
 import { resolveAuthToken } from '../test-runner/auth.js';
 import { CURRENT_DD_VERSION, CERTIFIABLE_DD_VERSIONS, isCertifiableDDVersion, normalizeDDVersion } from '../sdk/dd-versions.js';
@@ -72,22 +73,10 @@ const program = new Command();
 
 program.name('reso-cert').description('RESO certification compliance testing tools').version('0.5.0');
 
-// ── Shared auth options ──
-
-const addAuthOptions = (cmd: Command): Command =>
-  cmd
-    .option('--auth-token <token>', 'Pre-fetched bearer token')
-    .option('--client-id <id>', 'OAuth2 client ID')
-    .option('--client-secret <secret>', 'OAuth2 client secret')
-    .option('--token-url <url>', 'OAuth2 token endpoint URL');
-
-// ── Shared output options ──
-
-const addOutputOptions = (cmd: Command): Command =>
-  cmd
-    .option('--verbose', 'Detailed line-by-line output')
-    .option('--output <format>', 'Output format: console or json', 'console')
-    .option('--output-dir <path>', 'Directory for compliance reports');
+// ── Shared option builders live in ./shared-options.ts ──
+// addAuthOptions (OAuth2/bearer cluster) and addOutputOptions (compliance-report
+// output bundle) are imported above, alongside addServerUrlOption / addReportDirOption
+// for standardizing the universal flags across commands.
 
 // ── Add/Edit Subcommand ──
 

--- a/reso-certification/src/cli/shared-options.ts
+++ b/reso-certification/src/cli/shared-options.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared Commander option builders for the `reso-cert` CLI.
+ *
+ * Rationale: the *subject* of each command (the payload, the RCF data, the
+ * metadata file) keeps a semantic, self-documenting flag — `--metadata`,
+ * `--payload`, `--input` — because those disambiguate multi-input commands and
+ * say what they are. The *universal* flags — the server URL, the OAuth2 auth
+ * cluster, the output directory — are standardized here so every command
+ * declares them identically (same flags, same base wording, same alias) and
+ * they can't drift. An optional `context` suffix keeps a command-specific hint
+ * (e.g. a `--from-server`-scoped auth block) without diverging the flag names.
+ */
+
+import type { Command } from 'commander';
+
+const suffix = (context?: string): string => (context ? ` ${context}` : '');
+
+/**
+ * The OAuth2 / bearer auth cluster, shared by every command that authenticates
+ * to a live server. `context` appends a scope hint to each description (e.g.
+ * `'for the --from-server endpoint'`) — the flag names and base wording never
+ * change, only the hint.
+ */
+export const addAuthOptions = (cmd: Command, context?: string): Command =>
+  cmd
+    .option('--auth-token <token>', `Pre-fetched bearer token${suffix(context)}`)
+    .option('--client-id <id>', `OAuth2 client ID${suffix(context)} (with --client-secret and --token-url)`)
+    .option('--client-secret <secret>', `OAuth2 client secret${suffix(context)}`)
+    .option('--token-url <url>', `OAuth2 token endpoint URL${suffix(context)}`);
+
+/**
+ * The canonical `-u, --url` server-root option. Required-ness varies by command
+ * (some servers are mandatory, some are `--from-server`-conditional) so it is a
+ * parameter; the `-u` alias and the base wording do not vary. `context` adds a
+ * command-specific hint (e.g. `'(no resource name or query)'`).
+ */
+export const addServerUrlOption = (
+  cmd: Command,
+  opts: { readonly required?: boolean; readonly context?: string } = {},
+): Command => {
+  const flags = '-u, --url <url>';
+  const description = `OData service root URL${suffix(opts.context)}`;
+  return opts.required ? cmd.requiredOption(flags, description) : cmd.option(flags, description);
+};
+
+/**
+ * The compliance-report output bundle: verbosity, console/json format, and the
+ * report directory. Used by the endorsement/compliance commands.
+ */
+export const addOutputOptions = (cmd: Command): Command =>
+  cmd
+    .option('--verbose', 'Detailed line-by-line output')
+    .option('--output <format>', 'Output format: console or json', 'console')
+    .option('--output-dir <path>', 'Directory for compliance reports');
+
+/**
+ * The artifact `--output-dir` — defaults to the current directory, `"-"` for
+ * stdout where a command supports it. Distinct from {@link addOutputOptions}:
+ * the report-generating steps (schema, metadata, rcf, variations) write a
+ * single artifact and do not take `--verbose`/`--output`.
+ */
+export const addReportDirOption = (
+  cmd: Command,
+  description = 'Directory for the report (created if missing); "-" for stdout',
+): Command => cmd.option('--output-dir <path>', description, '.');

--- a/reso-certification/src/sdk/core.ts
+++ b/reso-certification/src/sdk/core.ts
@@ -9,7 +9,8 @@ import { resolveAuthToken } from '../test-runner/auth.js';
 import { fetchMetadata, loadMetadataFromFile, parseMetadataXml, getEntityType, persistMetadataXml } from '../test-runner/metadata.js';
 import { validateMetadata, formatValidationSummary, collectValidationErrors } from './metadata-validation.js';
 import { buildStandardMap, resolveTestParams, WELL_KNOWN_RESOURCES } from '../web-api-core/index.js';
-import { runCoreResourceScenarios, type ResourceTestReport } from '../web-api-core/test-runner.js';
+import { runCoreResourceScenarios, runProviderScenarios, summarizeScenarios, type ResourceTestReport } from '../web-api-core/test-runner.js';
+import { resolveServingDecision } from '../web-api-core/serving.js';
 import { isDeadlineError, runSettled } from '@reso-standards/reso-client';
 import { createCertSession, createSessionRequester } from '../test-runner/requester.js';
 import type { BaseTestContext, CoreConfig, PipelineStep, StepResult } from './types.js';
@@ -146,6 +147,59 @@ export const deadlineResourceReport = (resource: string): ResourceTestReport => 
   deadlineReached: true,
 });
 
+/** The synthetic resource label under which the once-per-provider structural scenarios are reported. */
+export const PROVIDER_WIDE_LABEL = 'Service (provider-wide)';
+
+/** A minimal params stub for a report that never sampled (masked / provider-wide). */
+const stubParams = (resource: string): ResourceTestReport['params'] =>
+  ({ resource, keyField: '', keyValue: '', enumMode: 'string', integerValueHigh: 0, skippedTypes: [], sampleComplete: false });
+
+/**
+ * A REQUIRED resource (Property/Member/Office/Field/Lookup) that is determinately declared-but-not-served at
+ * the top level (Core 2.1.0 carve-out). One clean FAIL — NOT a 40-scenario 404 cascade — and no sampling
+ * request was issued. The single failed scenario drives the Core verdict to `failed`; it never sets
+ * `deadlineReached`.
+ */
+export const requiredResourceNotServedReport = (resource: string): ResourceTestReport => ({
+  resource,
+  params: stubParams(resource),
+  scenarios: [
+    {
+      tag: 'required-resource-not-served',
+      name: `${resource} is declared in $metadata but not served as a top-level resource`,
+      passed: false,
+      skipped: false,
+      assertions: [{ passed: false, message: `Required resource not served top level — ${resource} is declared in the metadata but is absent from both the service document and the served EntitySets, so it cannot be queried at the top level` }],
+      duration: 0,
+    },
+  ],
+  coverage: [],
+  summary: { total: 1, passed: 0, failed: 1, skipped: 0, optional: { passed: 0, notSupported: 0, notTested: 0 } },
+});
+
+/**
+ * A non-required well-known resource (Media, OpenHouse, Showing, …) that is determinately declared-but-not-
+ * served at the top level (Core 2.1.0 carve-out). Reported Not Applicable — a single SKIPPED scenario with a
+ * passed:true assertion (the clean-render skip pattern, so it shows as NA, not a failure). No sampling request
+ * was issued; it counts 0 failed and never sets `deadlineReached`.
+ */
+export const notServedNotApplicableReport = (resource: string): ResourceTestReport => ({
+  resource,
+  params: stubParams(resource),
+  scenarios: [
+    {
+      tag: 'resource-not-applicable',
+      name: `${resource} declared but not served at the top level — Not Applicable`,
+      passed: true,
+      skipped: true,
+      assertions: [{ passed: true, message: `Not Applicable — ${resource} is declared in the metadata but not served as a top-level resource; per the Core 2.1.0 carve-out this is permitted (it may be available only via $expand)` }],
+      duration: 0,
+    },
+  ],
+  coverage: [],
+  summary: { total: 1, passed: 0, failed: 0, skipped: 1, optional: { passed: 0, notSupported: 0, notTested: 0 } },
+});
+
 /**
  * The Core run verdict from the aggregate counts — the single source of truth for the run's
  * status, used by both the test step and the report writer so they can never diverge.
@@ -206,6 +260,13 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
     // (status → incomplete), so a partial report is still written rather than the process being killed.
     const session = createCertSession(config.totalTimeoutMs);
     const requester = createSessionRequester(session);
+
+    // Provider-wide structural pass — run ONCE for the whole provider, BEFORE the per-resource gate, so the
+    // metadata + service-document scenarios are always recorded even if every resource ends up masked. The
+    // service document doubles as Surface 1 of the serving detection, and the metadata response gives the
+    // OData version threaded into each resource's 4.01 gate.
+    const provider = await runProviderScenarios(ctx.serverUrl, ctx.authToken!, version, requester);
+
     // Continue-on-error across resources: one bad resource (e.g. a sampling network
     // failure) is captured and the run keeps going, so a walk-away run still yields a
     // full report. A fatal error (auth revoked) stops the run — surfaced below.
@@ -213,6 +274,25 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
       ctx.resources,
       async (resource): Promise<ResourceTestReport> => {
         const entityType = getEntityType(metadata, resource)!;
+
+        // Core 2.1.0 declared-but-not-served carve-out. Decide from the two authoritative surfaces BEFORE
+        // sampling — a masked resource issues NO sampling request. `run` (the default on any doubt) falls
+        // through to the normal sample-and-test path below.
+        const decision = resolveServingDecision({
+          resource,
+          entityType,
+          version,
+          servedEntitySets: provider.servedEntitySets,
+          declaredEntitySets: metadata.entitySets,
+        });
+        if (decision === 'fail') {
+          onProgress({ step: 'Run Core scenarios', status: 'running', message: `${resource}: required resource declared but not served top level — one clean failure` });
+          return requiredResourceNotServedReport(resource);
+        }
+        if (decision === 'na') {
+          onProgress({ step: 'Run Core scenarios', status: 'running', message: `${resource}: declared but not served top level — Not Applicable (may be expansion-only)` });
+          return notServedNotApplicableReport(resource);
+        }
 
         onProgress({
           step: 'Run Core scenarios',
@@ -260,6 +340,8 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
           ctx.authToken!,
           version,
           requester,
+          // Provider-wide scenarios already ran once above; thread the detected version for the 4.01 gate.
+          { excludeProviderWide: true, odataVersion: provider.odataVersion },
         );
 
         onProgress({
@@ -289,12 +371,28 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
       throw settled.fatalError; // fatal (e.g. auth revoked) — abort the whole Core run
     }
 
+    // The provider-wide scenarios (metadata + service document) fold into the report as a synthetic
+    // provider entry, PREPENDED so they read first and are counted exactly once. They survive an all-masked
+    // provider (they ran before the per-resource gate). A failed service document is a real Core failure and
+    // is counted here.
+    const providerReport: ResourceTestReport = {
+      resource: PROVIDER_WIDE_LABEL,
+      params: stubParams(PROVIDER_WIDE_LABEL),
+      scenarios: provider.scenarios,
+      coverage: [],
+      summary: summarizeScenarios(provider.scenarios),
+      ...(provider.deadlineReached ? { deadlineReached: true } : {}),
+    };
+
     // Preserve resource order; a resource we couldn't sample/test is reported as skipped.
-    const resourceReports: ResourceTestReport[] = settled.outcomes.map((outcome): ResourceTestReport =>
-      outcome.status === 'ok'
-        ? outcome.value
-        : skippedResourceReport(outcome.item, outcome.status === 'failed' ? outcome.error : new Error(outcome.reason)),
-    );
+    const resourceReports: ResourceTestReport[] = [
+      providerReport,
+      ...settled.outcomes.map((outcome): ResourceTestReport =>
+        outcome.status === 'ok'
+          ? outcome.value
+          : skippedResourceReport(outcome.item, outcome.status === 'failed' ? outcome.error : new Error(outcome.reason)),
+      ),
+    ];
 
     // Required scenarios drive the verdict. Optional ("Optional Tests")
     // results are tallied separately and never contribute to `totalFailed`.

--- a/reso-certification/src/test-runner/metadata.ts
+++ b/reso-certification/src/test-runner/metadata.ts
@@ -11,7 +11,7 @@ import { fetchRawMetadata, fetchRawMetadataWithVersion, parseCsdlXml } from '@re
 // cert callers import it from there directly — no pass-through re-export here.
 import type { CsdlEntityType, CsdlProperty, CsdlSchema } from '@reso-standards/reso-metadata-utils';
 import { type ResoField, type ValidationFailure, validateRecord } from '@reso-standards/reso-validation';
-import type { EntityProperty, EntityType, ParsedMetadata } from './types.js';
+import type { EntityProperty, EntityType, ParsedEntitySet, ParsedMetadata } from './types.js';
 
 // ── Type adapters (CsdlEntityType → EntityType) ──
 
@@ -33,13 +33,27 @@ const adaptEntityType = (et: CsdlEntityType): EntityType => ({
   properties: et.properties.map(adaptProperty)
 });
 
+/** The unqualified type name from a (possibly namespaced) CSDL type reference — `org.reso.metadata.Property`
+ *  → `Property`. An EntitySet's EntityType is never a Collection(), so a plain last-segment split suffices. */
+const unqualifiedTypeName = (fqType: string): string => fqType.split('.').pop() ?? fqType;
+
+/** Convert an EntityContainer's EntitySets to the test tool's ParsedEntitySet[] (name → underlying type). */
+const adaptEntitySet = (es: { readonly name: string; readonly entityType: string }): ParsedEntitySet => ({
+  name: es.name,
+  entityType: unqualifiedTypeName(es.entityType)
+});
+
 /** Convert a CsdlSchema to the test tool's ParsedMetadata. */
 const adaptSchema = (schema: CsdlSchema): ParsedMetadata => ({
   namespace: schema.namespace,
   entityTypes: schema.entityTypes.map(adaptEntityType),
   // Preserve the CSDL enum types (they carry IsFlags + members) so the enum abstraction can classify a
   // field by its real representation. Previously dropped here, which forced Core's name-shape heuristic.
-  enumTypes: schema.enumTypes
+  enumTypes: schema.enumTypes,
+  // Preserve the EntityContainer's EntitySet declarations (also previously dropped) so the serving
+  // detection can resolve top-level membership through each set's EntityType. Absent container ⇒ undefined
+  // (INDETERMINATE); a container with zero sets stays an empty array (likewise INDETERMINATE downstream).
+  ...(schema.entityContainer && { entitySets: schema.entityContainer.entitySets.map(adaptEntitySet) })
 });
 
 /**

--- a/reso-certification/src/test-runner/metadata.ts
+++ b/reso-certification/src/test-runner/metadata.ts
@@ -30,7 +30,18 @@ const adaptProperty = (prop: CsdlProperty): EntityProperty => ({
 const adaptEntityType = (et: CsdlEntityType): EntityType => ({
   name: et.name,
   keyProperties: [...et.key],
-  properties: et.properties.map(adaptProperty)
+  properties: et.properties.map(adaptProperty),
+  // Preserve the CSDL navigation properties (also previously dropped) so the Web API Core sampler can pick an
+  // expansion for the 2.1.0 $expand scenario. `targetType` is the unqualified target entity type name. Omitted
+  // when the entity type declares no navigation properties — the scenario then has nothing to expand and skips.
+  ...(et.navigationProperties &&
+    et.navigationProperties.length > 0 && {
+      navigationProperties: et.navigationProperties.map(np => ({
+        name: np.name,
+        isCollection: np.isCollection,
+        targetType: np.entityTypeName
+      }))
+    })
 });
 
 /** The unqualified type name from a (possibly namespaced) CSDL type reference — `org.reso.metadata.Property`

--- a/reso-certification/src/test-runner/types.ts
+++ b/reso-certification/src/test-runner/types.ts
@@ -47,6 +47,11 @@ export interface EntityType {
   readonly name: string;
   readonly keyProperties: ReadonlyArray<string>;
   readonly properties: ReadonlyArray<EntityProperty>;
+  /** Navigation properties ($expand targets) preserved from the CSDL entity type. Optional: present only when
+   *  the source entity type declared at least one (omitted otherwise). `targetType` is the unqualified target
+   *  entity type name. Consumed by the Web API Core sampler to select an expansion for the 2.1.0 $expand
+   *  scenario; a missing field simply means the scenario has nothing to expand and skips. */
+  readonly navigationProperties?: ReadonlyArray<{ readonly name: string; readonly isCollection: boolean; readonly targetType: string }>;
 }
 
 /** A top-level EntitySet declared in the EDMX EntityContainer, resolved to its underlying EntityType. */

--- a/reso-certification/src/test-runner/types.ts
+++ b/reso-certification/src/test-runner/types.ts
@@ -49,12 +49,26 @@ export interface EntityType {
   readonly properties: ReadonlyArray<EntityProperty>;
 }
 
+/** A top-level EntitySet declared in the EDMX EntityContainer, resolved to its underlying EntityType. */
+export interface ParsedEntitySet {
+  /** The EntitySet name (the segment a client GETs at the service root, e.g. `Property`). */
+  readonly name: string;
+  /** The unqualified EntityType name the set exposes (namespace stripped, e.g. `Property`). */
+  readonly entityType: string;
+}
+
 export interface ParsedMetadata {
   readonly namespace: string;
   readonly entityTypes: ReadonlyArray<EntityType>;
   /** CSDL enum types (with IsFlags + members), preserved so the enum abstraction can classify a field
    *  by its real representation rather than a name-shape heuristic. */
   readonly enumTypes: ReadonlyArray<CsdlEnumType>;
+  /** Top-level EntitySet declarations from the EDMX `<EntityContainer>` (name → underlying EntityType).
+   *  Preserved so the serving detection can tell a resource that is DECLARED as a top-level set from one
+   *  that only has an EntityType (declared shape) but no set. `undefined` when the document has no
+   *  `<EntityContainer>`; an empty array when a container is present but declares no sets. Both are treated
+   *  as INDETERMINATE by the detection (it can't prove absence from a surface that says nothing). */
+  readonly entitySets?: ReadonlyArray<ParsedEntitySet>;
 }
 
 // ── Test Results ──

--- a/reso-certification/src/web-api-core/index.ts
+++ b/reso-certification/src/web-api-core/index.ts
@@ -15,8 +15,10 @@ export { selectEnumCandidates, isSingleRep, isMultiRep } from './enum-selection.
 export type { EnumCandidate } from './enum-selection.js';
 export { buildScenarioQuery } from './queries.js';
 export type { QuerySpec } from './queries.js';
-export { runCoreResourceScenarios } from './test-runner.js';
-export type { ScenarioResult, ResourceTestReport, TypeCoverage } from './test-runner.js';
+export { runCoreResourceScenarios, runProviderScenarios, isProviderWideScenario, summarizeScenarios } from './test-runner.js';
+export type { ScenarioResult, ResourceTestReport, TypeCoverage, ProviderScenariosResult, CoreResourceScenarioOptions } from './test-runner.js';
+export { parseServiceDocument, servedPresence, declaredPresence, resolveServingDecision } from './serving.js';
+export type { Presence, ServingDecision } from './serving.js';
 export {
   assertScalarComparison,
   assertSortOrder,

--- a/reso-certification/src/web-api-core/sampling.ts
+++ b/reso-certification/src/web-api-core/sampling.ts
@@ -407,6 +407,12 @@ export const resolveTestParams = async (
   const stringField = stringSample?.field;
   const stringValue = stringSample?.value;
 
+  // Select an expansion for the 2.1.0 $expand scenario: the FIRST COLLECTION navigation property in
+  // declaration order. Deterministic (declaration order) so tests stay stable; a collection is what `$top=5`
+  // and the RRK child-collection check expect. No collection nav (or no navigation properties at all) ⇒
+  // expandField stays undefined ⇒ the $expand scenario skips gracefully, exactly as before.
+  const expandField = entityType.navigationProperties?.find(np => np.isCollection)?.name;
+
   // LookupName per candidate field (from the RESO.OData.Metadata.LookupName annotation — string lookups
   // only; enum-typed fields have no Lookup Resource) for the Lookup Resource validation scenario.
   const lookupNameByField: Record<string, string> = {};
@@ -463,6 +469,7 @@ export const resolveTestParams = async (
     multiLookupCandidates,
     stringField,
     stringValue,
+    expandField,
     lookupNameByField: Object.keys(lookupNameByField).length ? lookupNameByField : undefined,
     skippedTypes,
   };

--- a/reso-certification/src/web-api-core/sampling.ts
+++ b/reso-certification/src/web-api-core/sampling.ts
@@ -132,8 +132,14 @@ export const WELL_KNOWN_RESOURCES: ReadonlyArray<{ readonly resource: string; re
   { resource: 'Showing', keyField: 'ShowingKey' },
 ];
 
-/** Required resources for v2.1.0 compliance. */
-export const REQUIRED_RESOURCES_V21 = ['Property', 'Member', 'Office', 'Field', 'Lookup'];
+/**
+ * Resources that MUST be available at the top level for Core 2.1.0 — if a provider declares one, it MUST be
+ * served there (it MAY also be expanded). The original core standard resources (Property/Member/Office), the
+ * metadata resources (Field can replace OData `$metadata`; Lookup carries enumerations; Field → Lookup), and
+ * EntityEvent (change tracking). Drives the declared-but-not-served carve-out (see serving.ts): a resource in
+ * this set that is determinately declared-but-not-served is a clean FAIL; anything else is Not Applicable.
+ */
+export const REQUIRED_RESOURCES_V21 = ['Property', 'Member', 'Office', 'Field', 'Lookup', 'EntityEvent'];
 
 // ── Type matchers ──
 

--- a/reso-certification/src/web-api-core/scenarios.ts
+++ b/reso-certification/src/web-api-core/scenarios.ts
@@ -255,7 +255,10 @@ const pagingScenarios: ReadonlyArray<PagingScenario> = [
 ];
 
 const expandScenarios: ReadonlyArray<ExpandScenario> = [
-  { tag: 'expand', name: '$expand navigation property', category: 'expand', fieldParam: 'expandField', minVersion: '2.1.0' },
+  // Non-gating (optional): $expand fires when the resource has a collection nav (activating the RRK
+  // expanded-item warning), but a server that doesn't support expanding the chosen nav renders "Not
+  // Supported" rather than a hard failure — a specific unsupported expansion must not fail a compliant server.
+  { tag: 'expand', name: '$expand navigation property', category: 'expand', fieldParam: 'expandField', minVersion: '2.1.0', optional: true },
 ];
 
 // Runs first among string-enum tests; cascade-skip applies to dependent

--- a/reso-certification/src/web-api-core/serving.ts
+++ b/reso-certification/src/web-api-core/serving.ts
@@ -1,0 +1,122 @@
+/**
+ * Web API Core "declared-but-not-served" detection (the Core 2.1.0 carve-out).
+ *
+ * A resource may be DECLARED at the top level (an EntitySet in `<EntityContainer>`, or merely an
+ * EntityType in `$metadata`) yet NOT SERVED there (a GET 404s / is inaccessible). Per the workgroup
+ * carve-out — Core 2.1.0+ ONLY — declared-but-not-served is acceptable for most resources, but a fixed
+ * set (Property, Member, Office, Field, Lookup) must always be served if declared.
+ *
+ * The overriding rule is anti-false-PASS: we MASK a resource's scenarios only on positive, determinate
+ * evidence that it is absent from the served top-level set. That evidence must come from BOTH authoritative
+ * surfaces agreeing:
+ *   1. the OData **service document** (runtime truth of what is served), and
+ *   2. the EDMX **EntityContainer** EntitySets (declared truth), resolved through each set's EntityType.
+ * If either surface is indeterminate, or the two disagree (one says present, the other absent), we run the
+ * resource exactly as today — a declared-but-404ing resource then fails for real instead of being masked.
+ */
+
+import type { EntityType, ParsedEntitySet } from '../test-runner/types.js';
+import { REQUIRED_RESOURCES_V21, WELL_KNOWN_RESOURCES } from './sampling.js';
+
+/** Whether a resource is PRESENT / ABSENT in a served-top-level surface, or the surface is INDETERMINATE. */
+export type Presence = 'present' | 'absent' | 'indeterminate';
+
+/** What the serving detection dictates for a resource: run its scenarios as today, one clean FAIL, or NA. */
+export type ServingDecision = 'run' | 'fail' | 'na';
+
+/** Resources eligible for the carve-out: the always-top-level required set (P/M/O/F/L) plus the other
+ *  well-known resources (Media, OpenHouse, Showing). Anything outside this set always runs as today —
+ *  we never mask a resource we don't recognize. */
+const MASKABLE_RESOURCES: ReadonlySet<string> = new Set<string>([
+  ...WELL_KNOWN_RESOURCES.map(r => r.resource),
+  ...REQUIRED_RESOURCES_V21
+]);
+
+/**
+ * Parse an OData service document body into the set of served top-level EntitySet names.
+ *
+ * Returns `undefined` (INDETERMINATE) unless the body is a real, COMPLETE service document — only a
+ * trustworthy doc can prove a resource ABSENT:
+ *   - `@odata.context` is a string whose last path segment is `$metadata`,
+ *   - `value` is a NON-EMPTY array,
+ *   - there is NO `@odata.nextLink` (a paged/partial doc can't prove absence).
+ * Any other shape (non-object, missing/wrong context, absent/empty `value`, or a paged doc) ⇒ `undefined`.
+ *
+ * Non-EntitySet entries (singletons, function imports) are harmless to include: a stray match only makes a
+ * resource look PRESENT, which biases toward running it (never toward a false mask).
+ */
+export const parseServiceDocument = (body: unknown): ReadonlySet<string> | undefined => {
+  if (typeof body !== 'object' || body === null) return undefined;
+  const obj = body as Record<string, unknown>;
+
+  const context = obj['@odata.context'];
+  if (typeof context !== 'string' || context.split('/').pop() !== '$metadata') return undefined;
+
+  // A paged/incomplete doc lists only some sets — it can never prove a resource absent.
+  if (obj['@odata.nextLink'] != null) return undefined;
+
+  const value = obj.value;
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+
+  const names = value
+    .map(entry => (typeof entry === 'object' && entry !== null ? (entry as Record<string, unknown>).name : undefined))
+    .filter((n): n is string => typeof n === 'string' && n.length > 0);
+  // A non-empty `value` that yields no usable names is malformed — treat as INDETERMINATE, never as an
+  // empty served set (which would read every resource as ABSENT and risk a false mask).
+  return names.length === 0 ? undefined : new Set(names);
+};
+
+/** Surface 1 — the service document. `undefined` served-set ⇒ INDETERMINATE; else membership by set name. */
+export const servedPresence = (served: ReadonlySet<string> | undefined, resource: string): Presence =>
+  served === undefined ? 'indeterminate' : served.has(resource) ? 'present' : 'absent';
+
+/**
+ * Surface 2 — the EDMX EntityContainer's EntitySets, resolved through each set's underlying EntityType (NOT
+ * by set name). No container / zero sets ⇒ INDETERMINATE (the surface says nothing). Otherwise PRESENT iff
+ * some declared set exposes the resource's EntityType.
+ */
+export const declaredPresence = (
+  entitySets: ReadonlyArray<ParsedEntitySet> | undefined,
+  entityType: EntityType
+): Presence =>
+  entitySets === undefined || entitySets.length === 0
+    ? 'indeterminate'
+    : entitySets.some(es => es.entityType === entityType.name)
+      ? 'present'
+      : 'absent';
+
+/**
+ * Decide how to handle a resource under the Core 2.1.0 declared-but-not-served carve-out.
+ *
+ * `run` — run the resource's scenarios exactly as today. This is the default and the ONLY safe answer on any
+ *   doubt: Core 2.0.0 (the carve-out is 2.1.0+ only), a resource we don't recognize, an indeterminate surface,
+ *   or the two surfaces disagreeing (the anti-false-PASS guard — a declared-but-404ing resource stays in the
+ *   run and fails for real).
+ * `fail` — a determinately declared-but-not-served REQUIRED resource (P/M/O/F/L): one clean failure.
+ * `na`   — a determinately declared-but-not-served non-required well-known resource (Media, …): Not Applicable
+ *   (it may be available only via `$expand`).
+ */
+export const resolveServingDecision = (args: {
+  readonly resource: string;
+  readonly entityType: EntityType;
+  readonly version: '2.0.0' | '2.1.0';
+  readonly servedEntitySets: ReadonlySet<string> | undefined;
+  readonly declaredEntitySets: ReadonlyArray<ParsedEntitySet> | undefined;
+}): ServingDecision => {
+  const { resource, entityType, version, servedEntitySets, declaredEntitySets } = args;
+
+  // The carve-out is gated to Core 2.1.0+; 2.0.0 behaves exactly as written today (declared ⇒ assumed served).
+  if (version === '2.0.0') return 'run';
+  // Only recognized (well-known / required) resources are eligible to be masked.
+  if (!MASKABLE_RESOURCES.has(resource)) return 'run';
+
+  const served = servedPresence(servedEntitySets, resource);
+  const declared = declaredPresence(declaredEntitySets, entityType);
+
+  // Mask ONLY when BOTH surfaces are determinate AND BOTH say ABSENT. Any indeterminate surface, or a
+  // disagreement (one present, one absent), keeps the resource in the run.
+  if (served !== 'absent' || declared !== 'absent') return 'run';
+
+  // Determinately declared-but-not-served: required resources are a clean FAIL; others are Not Applicable.
+  return REQUIRED_RESOURCES_V21.includes(resource) ? 'fail' : 'na';
+};

--- a/reso-certification/src/web-api-core/test-runner.ts
+++ b/reso-certification/src/web-api-core/test-runner.ts
@@ -14,6 +14,7 @@ import type { EnumCandidate } from './enum-selection.js';
 import { buildScenarioQuery } from './queries.js';
 import { emptyVerdict, type EmptyContext, type EmptyVerdict } from './empty-verdict.js';
 import { scenariosForVersion, type ComparisonOp, type CoreScenario } from './scenarios.js';
+import { parseServiceDocument } from './serving.js';
 import {
   assertODataResponse,
   assertHasResults,
@@ -130,6 +131,12 @@ export const summarizeScenarios = (
     },
   };
 };
+
+/** The two structural scenarios that describe the PROVIDER, not a resource — `metadata-validation`
+ *  ($metadata) and `service-document` (the service root). They are hoisted to run ONCE per provider
+ *  (see {@link runProviderScenarios}); the per-resource runner excludes them so they don't re-run N times. */
+export const isProviderWideScenario = (scenario: CoreScenario): boolean =>
+  scenario.category === 'structural' && (scenario.assertion === 'metadata' || scenario.assertion === 'service-document');
 
 /** Build coverage matrix from resolved test params. */
 const buildCoverage = (params: TestParams): ReadonlyArray<TypeCoverage> => [
@@ -864,7 +871,115 @@ export const runPagingScenario = async (
   return { tag: 'server-driven-paging', name: 'Server-driven paging', passed: allPassed, skipped: false, assertions, duration: Date.now() - start, requestUrl: initialUrl };
 };
 
+// ── Provider-wide pass ──
+
+/** The outcome of the once-per-provider structural pass. */
+export interface ProviderScenariosResult {
+  /** The `metadata-validation` + `service-document` scenario results (in that order), to fold into the report. */
+  readonly scenarios: ReadonlyArray<ScenarioResult>;
+  /** The OData-Version detected from the `$metadata` response — threaded into the per-resource 4.01 gate. */
+  readonly odataVersion: string | undefined;
+  /** Served top-level EntitySet names from a TRUSTWORTHY service document, else undefined (INDETERMINATE).
+   *  Surface 1 of the serving detection. */
+  readonly servedEntitySets: ReadonlySet<string> | undefined;
+  /** True when the run's total-timeout budget was spent during the provider pass. */
+  readonly deadlineReached: boolean;
+}
+
+/** A minimal params stub for the provider-wide structural scenarios (they ignore per-resource params). */
+const providerParamsStub: TestParams = {
+  resource: '', keyField: '', keyValue: '', enumMode: 'string', integerValueHigh: 0, skippedTypes: [], sampleComplete: false,
+};
+
+/**
+ * GET the service document once. Returns the `service-document` scenario result (mirroring the structural
+ * runner's else-branch: 200 + non-empty) AND the parsed served EntitySet set (Surface 1). A non-2xx / bad
+ * shape yields `served: undefined` (INDETERMINATE) so the detection can never mask on a doubtful doc.
+ */
+const runServiceDocumentProbe = async (
+  serverUrl: string,
+  authToken: string,
+  start: number,
+  requester: ODataRequester,
+): Promise<{ readonly result: ScenarioResult; readonly served: ReadonlySet<string> | undefined }> => {
+  const url = serverUrl;
+  const assertions: AssertionResult[] = [];
+  try {
+    const response = await requester.request({ method: 'GET', url, authToken });
+    assertions.push(assertODataResponse(response, 200));
+    assertions.push(assertHasResults(response.body));
+    // Only a determinately GOOD service doc (200 shape) feeds the detection surface; a failed response
+    // leaves the surface INDETERMINATE (undefined), never a false "absent".
+    const served = assertions.every(a => a.passed) ? parseServiceDocument(response.body) : undefined;
+    return { result: { tag: 'service-document', name: 'service-document', passed: assertions.every(a => a.passed), skipped: false, assertions, duration: Date.now() - start, requestUrl: url }, served };
+  } catch (err) {
+    if (isDeadlineError(err)) throw err; // out of run budget — propagate so the run stops gracefully
+    assertions.push({ passed: false, message: `Error: ${err instanceof Error ? err.message : String(err)}` });
+    return { result: { tag: 'service-document', name: 'service-document', passed: false, skipped: false, assertions, duration: Date.now() - start, requestUrl: url }, served: undefined };
+  }
+};
+
+/**
+ * Run the provider-wide structural scenarios ONCE for the whole provider: `metadata-validation` (which also
+ * detects the OData version) and `service-document` (which also yields Surface 1 of the serving detection).
+ * Hoisted out of the per-resource loop so they are always recorded — even when every resource is masked.
+ *
+ * A run-deadline during the pass is handled gracefully: the not-yet-run provider scenarios are recorded as
+ * NOT-TESTED (deadline skips, never failed) and `deadlineReached` is set so the run becomes `incomplete`.
+ */
+export const runProviderScenarios = async (
+  serverUrl: string,
+  authToken: string,
+  version: '2.0.0' | '2.1.0' = '2.0.0',
+  requester: ODataRequester = webRequester,
+): Promise<ProviderScenariosResult> => {
+  const provWide = scenariosForVersion(version).filter(isProviderWideScenario);
+  const metaScenario = provWide.find(s => s.category === 'structural' && s.assertion === 'metadata');
+  const svcScenario = provWide.find(s => s.category === 'structural' && s.assertion === 'service-document');
+  const scenarios: ScenarioResult[] = [];
+  let odataVersion: string | undefined;
+
+  // metadata-validation (delegates the fetch + version detection to the shared structural runner).
+  try {
+    if (metaScenario) {
+      const start = Date.now();
+      const result = await runStructuralScenario(serverUrl, '', 'metadata', { url: `${serverUrl}/$metadata`, selectFields: [] }, providerParamsStub, authToken, start, requester);
+      scenarios.push(result);
+      odataVersion = result.odataVersion;
+    }
+  } catch (err) {
+    if (!isDeadlineError(err)) throw err;
+    for (const s of provWide) scenarios.push(deadlineSkipResult(s));
+    return { scenarios, odataVersion: undefined, servedEntitySets: undefined, deadlineReached: true };
+  }
+
+  // service-document (also parses Surface 1 of the serving detection).
+  try {
+    if (svcScenario) {
+      const start = Date.now();
+      const { result, served } = await runServiceDocumentProbe(serverUrl, authToken, start, requester);
+      scenarios.push(result);
+      return { scenarios, odataVersion, servedEntitySets: served, deadlineReached: false };
+    }
+    return { scenarios, odataVersion, servedEntitySets: undefined, deadlineReached: false };
+  } catch (err) {
+    if (!isDeadlineError(err)) throw err;
+    if (svcScenario) scenarios.push(deadlineSkipResult(svcScenario));
+    return { scenarios, odataVersion, servedEntitySets: undefined, deadlineReached: true };
+  }
+};
+
 // ── Main runner ──
+
+/** Options for {@link runCoreResourceScenarios} — used by the SDK to thread the provider pass in. */
+export interface CoreResourceScenarioOptions {
+  /** The OData-Version detected once in the provider pass — seeds the 4.01 `in`-operator gate so it no
+   *  longer depends on a per-resource metadata scenario. */
+  readonly odataVersion?: string;
+  /** Skip the provider-wide scenarios (`metadata-validation` + `service-document`) — they run ONCE in the
+   *  provider pass instead. Left off, they run inline as before (backward-compatible for direct callers). */
+  readonly excludeProviderWide?: boolean;
+}
 
 /**
  * Run all applicable Web API Core scenarios for a single resource.
@@ -876,13 +991,16 @@ export const runCoreResourceScenarios = async (
   authToken: string,
   version: '2.0.0' | '2.1.0' = '2.0.0',
   requester: ODataRequester = webRequester,
+  options?: CoreResourceScenarioOptions,
 ): Promise<ResourceTestReport> => {
-  const scenarios = scenariosForVersion(version);
+  const scenarios = scenariosForVersion(version)
+    .filter(s => (options?.excludeProviderWide ? !isProviderWideScenario(s) : true));
   const results: ScenarioResult[] = [];
 
-  // Track cross-scenario state for cascade-skip + OData-version gating.
+  // Track cross-scenario state for cascade-skip + OData-version gating. The version is pre-seeded from the
+  // provider pass when the provider-wide scenarios are hoisted out (else the inline metadata scenario sets it).
   let lookupResourceFailed = false;
-  let detectedODataVersion: string | undefined;
+  let detectedODataVersion: string | undefined = options?.odataVersion;
   let deadlineReached = false;
 
   for (const [i, scenario] of scenarios.entries()) {

--- a/reso-certification/src/web-api-core/test-runner.ts
+++ b/reso-certification/src/web-api-core/test-runner.ts
@@ -13,7 +13,7 @@ import type { TestParams } from './sampling.js';
 import type { EnumCandidate } from './enum-selection.js';
 import { buildScenarioQuery } from './queries.js';
 import { emptyVerdict, type EmptyContext, type EmptyVerdict } from './empty-verdict.js';
-import { scenariosForVersion, type ComparisonOp, type CoreScenario } from './scenarios.js';
+import { scenariosForVersion, type ComparisonOp, type CoreScenario, type ExpandScenario } from './scenarios.js';
 import { parseServiceDocument } from './serving.js';
 import {
   assertODataResponse,
@@ -54,6 +54,11 @@ export interface ScenarioResult {
    *  than an assertion failing. For optional scenarios this maps to
    *  "Not Tested", never "Not Supported". */
   readonly errored?: boolean;
+  /** Non-gating advisory notes for this scenario — surfaced in the report JSON but NEVER read by the verdict
+   *  logic ({@link summarizeScenarios} / `coreVerdict`) or any pass/fail count. Currently the $expand RRK
+   *  expanded-item warning (see {@link expandRrkWarnings}). "Warning now, fail later": it rides alongside a
+   *  still-`passed:true` result, so a warning can never flip a compliant server's verdict. */
+  readonly warnings?: ReadonlyArray<string>;
 }
 
 /** Coverage of a data type category for a resource. */
@@ -293,6 +298,49 @@ export const emptyOutcome = (
   }
 };
 
+/** The field carried on each expanded child item that should echo the parent record's primary key. */
+const RESOURCE_RECORD_KEY_FIELD = 'ResourceRecordKey';
+
+/**
+ * RRK expanded-item warning (WG-approved — transport#22 / RCP-039). In an `$expand` response, each expanded
+ * child item's `ResourceRecordKey` SHOULD equal the primary-key value of the PARENT record it was expanded
+ * into — e.g. an expanded Media's `ResourceRecordKey` should match the parent Property's `ListingKey`. A
+ * mismatch yields a NON-GATING warning ("warning now, fail later"): it instruments a suspected pain point
+ * without failing anyone, so it rides on {@link ScenarioResult.warnings} and never touches `passed` or any
+ * assertion — a compliant server's verdict can't move because of it.
+ *
+ * Scope is strictly a PRESENT-BUT-MISMATCHED value. These deliberately produce NO warning:
+ *   - the expanded value is absent / empty / not an array (nothing expanded to check);
+ *   - a child item with no `ResourceRecordKey` at all (a DIFFERENT concern — absence, not mismatch);
+ *   - a parent record with no primary-key value (nothing to compare against).
+ * Keys are compared as strings. Returns `[]` for a non-expand scenario or when the field/key can't resolve.
+ */
+export const expandRrkWarnings = (
+  records: ReadonlyArray<Record<string, unknown>>,
+  scenario: ExpandScenario,
+  params: TestParams,
+): ReadonlyArray<string> => {
+  const expandField = (params as unknown as Record<string, string | undefined>)[scenario.fieldParam];
+  const keyField = params.keyField;
+  if (!expandField || !keyField) return [];
+
+  return records.flatMap((record) => {
+    const parentKey = record[keyField];
+    if (parentKey == null) return []; // parent has no primary-key value — nothing to compare against
+    const expanded = record[expandField];
+    if (!Array.isArray(expanded)) return []; // absent / single object / scalar — not a child collection to check
+    const items: ReadonlyArray<unknown> = expanded; // narrowed to any[]; re-bind to keep `unknown` element typing
+    return items.flatMap((child) => {
+      if (child == null || typeof child !== 'object') return [];
+      const rrk = (child as Record<string, unknown>)[RESOURCE_RECORD_KEY_FIELD];
+      if (rrk == null) return []; // no ResourceRecordKey present — absence is out of scope (a different concern)
+      return String(rrk) === String(parentKey)
+        ? []
+        : [`Expanded ${expandField} item ${RESOURCE_RECORD_KEY_FIELD} ${JSON.stringify(String(rrk))} does not match the parent ${keyField} ${JSON.stringify(String(parentKey))} it was expanded into — an expanded item's ${RESOURCE_RECORD_KEY_FIELD} should equal the parent record's primary key (RCP-039 / transport#22)`];
+    });
+  });
+};
+
 /**
  * Execute the standard request→validate→assert flow for one scenario against `params`. Returns the
  * result plus `retryable`: true when the field couldn't be assessed (missing params, non-200, or an
@@ -344,7 +392,11 @@ export const executeStandardScenario = async (
     const dataAssertion = assertData(records, scenario, params);
     if (dataAssertion) assertions.push(dataAssertion);
     const allPassed = assertions.every(a => a.passed);
-    return { result: { tag: scenario.tag, name: scenario.name, passed: allPassed, skipped: false, assertions, duration: Date.now() - start, requestLatency, requestUrl: query.url }, retryable: false, rejected: false, accepted: true };
+    // Non-gating RRK expanded-item warning (WG/RCP-039): computed ONLY for the $expand scenario and carried on
+    // ScenarioResult.warnings — never on `passed` or an assertion — so it can't flip a compliant server. `[]`
+    // for every other category, so the spread adds nothing outside expand.
+    const warnings = scenario.category === 'expand' ? expandRrkWarnings(records, scenario, params) : [];
+    return { result: { tag: scenario.tag, name: scenario.name, passed: allPassed, skipped: false, assertions, duration: Date.now() - start, requestLatency, requestUrl: query.url, ...(warnings.length > 0 ? { warnings } : {}) }, retryable: false, rejected: false, accepted: true };
   } catch (err) {
     if (isDeadlineError(err)) throw err; // out of run budget — propagate so the run stops gracefully
     // A transport/parse error is indeterminate — UNTESTABLE, neither a rejection nor an acceptance.

--- a/reso-certification/tests/metadata.test.ts
+++ b/reso-certification/tests/metadata.test.ts
@@ -74,6 +74,45 @@ describe('getEntityType', () => {
   });
 });
 
+// adaptEntityType (via parseMetadataXml) must PRESERVE navigation properties — previously dropped — so the
+// Web API Core sampler can pick an expansion for the 2.1.0 $expand scenario.
+describe('parseMetadataXml — navigation property preservation', () => {
+  const navXml = `<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="org.reso.metadata" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Property">
+        <Key><PropertyRef Name="ListingKey"/></Key>
+        <Property Name="ListingKey" Type="Edm.String"/>
+        <NavigationProperty Name="Media" Type="Collection(org.reso.metadata.Media)"/>
+        <NavigationProperty Name="ListOffice" Type="org.reso.metadata.Office"/>
+      </EntityType>
+      <EntityType Name="Media">
+        <Key><PropertyRef Name="MediaKey"/></Key>
+        <Property Name="MediaKey" Type="Edm.String"/>
+      </EntityType>
+      <EntityType Name="Lookup">
+        <Key><PropertyRef Name="LookupKey"/></Key>
+        <Property Name="LookupKey" Type="Edm.String"/>
+      </EntityType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>`;
+
+  it('preserves navigation properties with name, isCollection, and targetType (incl. a Collection() nav)', () => {
+    const property = getEntityType(parseMetadataXml(navXml), 'Property')!;
+    expect(property.navigationProperties).toEqual([
+      { name: 'Media', isCollection: true, targetType: 'Media' },
+      { name: 'ListOffice', isCollection: false, targetType: 'Office' },
+    ]);
+  });
+
+  it('omits navigationProperties on an entity type that declares none', () => {
+    const lookup = getEntityType(parseMetadataXml(navXml), 'Lookup')!;
+    expect(lookup.navigationProperties).toBeUndefined();
+  });
+});
+
 describe('validatePayloadAgainstMetadata', () => {
   const metadata = parseMetadataXml(sampleXml);
   const entityType = getEntityType(metadata, 'Property')!;

--- a/reso-certification/tests/web-api-core/declared-not-served.test.ts
+++ b/reso-certification/tests/web-api-core/declared-not-served.test.ts
@@ -1,0 +1,229 @@
+/**
+ * End-to-end guardrails for the Core 2.1.0 "declared-but-not-served" carve-out.
+ *
+ * A whole `runCoreCompliance` against a fetch-level mock, asserting the masking DECISION and — critically —
+ * that a masked resource issues NO sampling request, while a resource under any doubt (surfaces disagree,
+ * 2.0.0) is sampled and run exactly as today. The overriding rule is anti-false-PASS.
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PROVIDER_WIDE_LABEL, runCoreCompliance } from '../../src/sdk/core.js';
+import type { CoreConfig } from '../../src/sdk/types.js';
+import type { ResourceTestReport } from '../../src/web-api-core/test-runner.js';
+
+const BASE = 'http://mask.local';
+
+// ── Custom EDMX + service-document mock ──
+
+const RESOURCE_NS = 'org.reso.metadata';
+const entityTypeXml = (name: string, keyField: string): string =>
+  `      <EntityType Name="${name}">
+        <Key><PropertyRef Name="${keyField}"/></Key>
+        <Property Name="${keyField}" Type="Edm.String" MaxLength="255" Nullable="false"/>
+        <Property Name="ListPrice" Type="Edm.Int64"/>
+      </EntityType>`;
+const entitySetXml = (name: string, type: string): string =>
+  `        <EntitySet Name="${name}" EntityType="${RESOURCE_NS}.${type}"/>`;
+
+/** Build a minimal, XSD/semantically-valid EDMX from a list of entity types + entity sets. */
+const buildEdmx = (
+  entityTypes: ReadonlyArray<readonly [string, string]>,
+  entitySets: ReadonlyArray<readonly [string, string]>,
+): string => `<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="${RESOURCE_NS}">
+${entityTypes.map(([n, k]) => entityTypeXml(n, k)).join('\n')}
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="Default">
+      <EntityContainer Name="Container">
+${entitySets.map(([n, t]) => entitySetXml(n, t)).join('\n')}
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>`;
+
+const serviceDoc = (names: ReadonlyArray<string>): unknown => ({
+  '@odata.context': `${BASE}/$metadata`,
+  value: names.map(n => ({ name: n, kind: 'EntitySet', url: n })),
+});
+
+const SAMPLE_ROW = { ListingKey: '1', MediaKey: '1', OfficeKey: '1', MemberKey: '1', FieldKey: '1', LookupKey: '1', ListPrice: 100 };
+
+interface MockOptions {
+  readonly edmx: string;
+  readonly serviceDoc: unknown;
+  /** Resource names whose queries 404 (declared-but-not-served at the wire level). */
+  readonly notFound?: ReadonlySet<string>;
+}
+
+interface InstalledMock {
+  readonly calls: ReadonlyArray<string>;
+  restore(): void;
+}
+
+const odataJson = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json', 'odata-version': '4.01' } });
+
+/** The resource segment of a path like `Property?$top=1000` / `Property('1')` / `Property/x`. */
+const resourceOf = (path: string): string => path.split(/[?(/]/)[0];
+
+const installMock = (opts: MockOptions): InstalledMock => {
+  const calls: string[] = [];
+  const notFound = opts.notFound ?? new Set<string>();
+  const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input: string | URL | Request) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    calls.push(url);
+
+    if (url.includes('/$metadata')) {
+      return new Response(opts.edmx, { status: 200, headers: { 'content-type': 'application/xml', 'odata-version': '4.01' } });
+    }
+    const path = url.startsWith(BASE) ? url.slice(BASE.length).replace(/^\//, '') : url;
+    if (path === '' || path.startsWith('?')) return odataJson(opts.serviceDoc);
+
+    const res = resourceOf(path);
+    if (res === 'ResourceNotFound' || notFound.has(res)) return odataJson({ value: [] }, 404);
+    return odataJson({ value: [SAMPLE_ROW], '@odata.count': 1 });
+  });
+  return { calls, restore: () => spy.mockRestore() };
+};
+
+const makeConfig = (outputDir: string, over: Partial<CoreConfig>): CoreConfig => ({
+  endorsement: 'core',
+  version: '2.1.0',
+  server: { url: BASE, auth: { mode: 'token', authToken: 'test' } },
+  options: { outputDir },
+  ...over,
+});
+
+const reportFor = (result: Awaited<ReturnType<typeof runCoreCompliance>>, resource: string): ResourceTestReport | undefined =>
+  (result.context.resourceReports as ReadonlyArray<ResourceTestReport> | undefined)?.find(r => r.resource === resource);
+
+const sampledResources = (calls: ReadonlyArray<string>): ReadonlyArray<string> =>
+  calls.filter(u => u.includes('?$top=1000')).map(u => resourceOf(u.slice(BASE.length).replace(/^\//, '')));
+
+describe('Core 2.1.0 declared-but-not-served carve-out (end-to-end)', () => {
+  let outputDir = '';
+  let mock: InstalledMock | undefined;
+
+  beforeEach(async () => {
+    outputDir = await mkdtemp(join(tmpdir(), 'core-mask-'));
+  });
+  afterEach(async () => {
+    mock?.restore();
+    mock = undefined;
+    vi.restoreAllMocks();
+    await rm(outputDir, { recursive: true, force: true });
+  });
+
+  it('2.1.0: a non-required well-known resource absent on BOTH surfaces → Not Applicable, NO sampling request', async () => {
+    // Property is served; Media has an EntityType (declared shape) but no EntitySet and is absent from the doc.
+    mock = installMock({
+      edmx: buildEdmx([['Property', 'ListingKey'], ['Media', 'MediaKey']], [['Property', 'Property']]),
+      serviceDoc: serviceDoc(['Property']),
+      notFound: new Set(['Media']),
+    });
+
+    const result = await runCoreCompliance(makeConfig(outputDir, { version: '2.1.0', resources: ['Property', 'Media'] }));
+
+    const media = reportFor(result, 'Media');
+    expect(media?.scenarios).toHaveLength(1);
+    expect(media?.scenarios[0].tag).toBe('resource-not-applicable');
+    expect(media?.scenarios[0].skipped).toBe(true);
+    expect(media?.scenarios[0].passed).toBe(true); // NA renders as a clean skip, never a failure
+    expect(media?.summary.failed).toBe(0);
+    expect(media?.deadlineReached).toBeUndefined();
+
+    // The proof: masking issued NO sampling request for Media, but Property (served) WAS sampled.
+    expect(sampledResources(mock.calls)).not.toContain('Media');
+    expect(sampledResources(mock.calls)).toContain('Property');
+  });
+
+  it('2.1.0: a REQUIRED resource absent on BOTH surfaces → one clean FAIL, NO sampling request', async () => {
+    mock = installMock({
+      edmx: buildEdmx([['Property', 'ListingKey'], ['Member', 'MemberKey']], [['Member', 'Member']]),
+      serviceDoc: serviceDoc(['Member']),
+    });
+
+    const result = await runCoreCompliance(makeConfig(outputDir, { version: '2.1.0', resources: ['Property'] }));
+
+    const property = reportFor(result, 'Property');
+    expect(property?.scenarios).toHaveLength(1); // ONE clean failure, not a 40-scenario 404 cascade
+    expect(property?.scenarios[0].tag).toBe('required-resource-not-served');
+    expect(property?.scenarios[0].passed).toBe(false);
+    expect(property?.scenarios[0].skipped).toBe(false);
+    expect(property?.summary.failed).toBe(1);
+    expect(sampledResources(mock.calls)).not.toContain('Property'); // no sampling request
+    expect(result.status).toBe('failed');
+  });
+
+  it('2.1.0: DECLARED as an EntitySet but 404ing + omitted from the service doc (surfaces DISAGREE) → runs + fails for real, never masked', async () => {
+    // The anti-false-PASS guard: Property is a declared EntitySet (Surface 2 present) but the service doc
+    // omits it (Surface 1 absent) and a GET 404s. It must stay in the run and fail for real.
+    mock = installMock({
+      edmx: buildEdmx([['Property', 'ListingKey'], ['Member', 'MemberKey']], [['Property', 'Property']]),
+      serviceDoc: serviceDoc(['Member']),
+      notFound: new Set(['Property']),
+    });
+
+    const result = await runCoreCompliance(makeConfig(outputDir, { version: '2.1.0', resources: ['Property'] }));
+
+    const property = reportFor(result, 'Property');
+    // It ran the full scenario set (not a 1-scenario masked stub) and produced real failures.
+    expect(property?.scenarios.length ?? 0).toBeGreaterThan(1);
+    expect(property?.scenarios.some(s => s.tag === 'resource-not-applicable' || s.tag === 'required-resource-not-served')).toBe(false);
+    expect(property?.summary.failed ?? 0).toBeGreaterThan(0);
+    expect(sampledResources(mock.calls)).toContain('Property'); // it WAS sampled — not masked
+    expect(result.status).toBe('failed');
+  });
+
+  it('2.0.0: behavior UNCHANGED — a declared-but-not-served resource is still sampled + run (never masked)', async () => {
+    // Identical topology to the NA test, but at 2.0.0 the carve-out is off: Media must be sampled as today.
+    mock = installMock({
+      edmx: buildEdmx([['Property', 'ListingKey'], ['Media', 'MediaKey']], [['Property', 'Property']]),
+      serviceDoc: serviceDoc(['Property']),
+      notFound: new Set(['Media']),
+    });
+
+    const result = await runCoreCompliance(makeConfig(outputDir, { version: '2.0.0', resources: ['Property', 'Media'] }));
+
+    const media = reportFor(result, 'Media');
+    // Media ran real scenarios (not the NA stub) and was sampled — exactly as before the carve-out.
+    expect(media?.scenarios.some(s => s.tag === 'resource-not-applicable')).toBe(false);
+    expect(media?.scenarios.length ?? 0).toBeGreaterThan(1);
+    expect(sampledResources(mock.calls)).toContain('Media');
+  });
+
+  it('2.1.0: the provider-wide scenarios run ONCE even when EVERY resource is masked', async () => {
+    // Only Office is served/declared; Property (required) and Media (well-known) are both absent on both
+    // surfaces → all requested resources are masked. The provider pass must still run + record its scenarios.
+    mock = installMock({
+      edmx: buildEdmx([['Property', 'ListingKey'], ['Media', 'MediaKey'], ['Office', 'OfficeKey']], [['Office', 'Office']]),
+      serviceDoc: serviceDoc(['Office']),
+    });
+
+    const result = await runCoreCompliance(makeConfig(outputDir, { version: '2.1.0', resources: ['Property', 'Media'] }));
+
+    // The provider-wide scenarios were hoisted into a single synthetic report and both passed.
+    const provider = reportFor(result, PROVIDER_WIDE_LABEL);
+    const providerTags = provider?.scenarios.map(s => s.tag) ?? [];
+    expect(providerTags).toContain('metadata');
+    expect(providerTags).toContain('service-document');
+    expect(provider?.scenarios.every(s => s.passed)).toBe(true);
+
+    // They ran ONCE — no per-resource report carries a metadata / service-document scenario.
+    const perResource = (result.context.resourceReports as ReadonlyArray<ResourceTestReport>).filter(r => r.resource !== PROVIDER_WIDE_LABEL);
+    for (const r of perResource) {
+      expect(r.scenarios.some(s => s.tag === 'metadata' || s.tag === 'service-document')).toBe(false);
+    }
+
+    // No masked resource was sampled; Property (required) forces the run to fail.
+    expect(sampledResources(mock.calls)).toHaveLength(0);
+    expect(reportFor(result, 'Property')?.scenarios[0].tag).toBe('required-resource-not-served');
+    expect(reportFor(result, 'Media')?.scenarios[0].tag).toBe('resource-not-applicable');
+    expect(result.status).toBe('failed');
+  });
+});

--- a/reso-certification/tests/web-api-core/expand-rrk-warning.test.ts
+++ b/reso-certification/tests/web-api-core/expand-rrk-warning.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+import type { ODataRequester } from '../../src/test-runner/requester.js';
+import type { ODataResponse } from '../../src/test-runner/types.js';
+import type { ExpandScenario } from '../../src/web-api-core/scenarios.js';
+import type { TestParams } from '../../src/web-api-core/sampling.js';
+import {
+  executeStandardScenario,
+  expandRrkWarnings,
+  summarizeScenarios,
+  type ScenarioResult,
+} from '../../src/web-api-core/test-runner.js';
+import { coreVerdict } from '../../src/sdk/core.js';
+
+// The WG rule (transport#22 / RCP-039): an expanded child's ResourceRecordKey should equal the primary key of
+// the parent record it was expanded into (e.g. an expanded Media's ResourceRecordKey == the parent Property's
+// ListingKey). A mismatch is a NON-GATING warning — it must never fail a compliant server.
+
+const expandScenario: ExpandScenario = {
+  tag: 'expand',
+  name: '$expand navigation property',
+  category: 'expand',
+  fieldParam: 'expandField',
+  minVersion: '2.1.0',
+};
+
+// Parent = Property (ListingKey), expanded nav property = Media.
+const params: TestParams = {
+  resource: 'Property',
+  keyField: 'ListingKey',
+  keyValue: 'P1',
+  enumMode: 'string',
+  expandField: 'Media',
+  integerValueHigh: 0,
+  skippedTypes: [],
+  sampleComplete: true,
+};
+
+// One parent Property whose expanded Media collection is exactly `children`.
+const parent = (children: unknown): Record<string, unknown> => ({ ListingKey: 'P1', Media: children });
+
+describe('expandRrkWarnings (unit — the RRK expanded-item rule)', () => {
+  it('mismatch → one warning that NAMES the offending ResourceRecordKey and the parent key', () => {
+    const warnings = expandRrkWarnings([parent([{ MediaKey: 'M1', ResourceRecordKey: 'WRONG' }])], expandScenario, params);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('WRONG'); // the offender
+    expect(warnings[0]).toContain('ListingKey'); // the parent key field
+    expect(warnings[0]).toContain('P1'); // the parent key value it should have matched
+    expect(warnings[0]).toContain('Media'); // the expanded nav property
+  });
+
+  it('match → no warning', () => {
+    const warnings = expandRrkWarnings([parent([{ MediaKey: 'M1', ResourceRecordKey: 'P1' }])], expandScenario, params);
+    expect(warnings).toEqual([]);
+  });
+
+  it('no expanded children (nav property absent) → no warning, no crash', () => {
+    expect(expandRrkWarnings([{ ListingKey: 'P1' }], expandScenario, params)).toEqual([]);
+  });
+
+  it('empty expanded array → no warning', () => {
+    expect(expandRrkWarnings([parent([])], expandScenario, params)).toEqual([]);
+  });
+
+  it('expanded value is not an array (single object) → no warning', () => {
+    expect(expandRrkWarnings([parent({ ResourceRecordKey: 'WRONG' })], expandScenario, params)).toEqual([]);
+  });
+
+  it('expanded value is a scalar (not an array) → no warning', () => {
+    expect(expandRrkWarnings([parent('nope' as unknown)], expandScenario, params)).toEqual([]);
+  });
+
+  it('child has no ResourceRecordKey → no warning (absence is a different concern, out of scope)', () => {
+    expect(expandRrkWarnings([parent([{ MediaKey: 'M1' }])], expandScenario, params)).toEqual([]);
+  });
+
+  it('parent has no primary-key value → no warning (nothing to compare against)', () => {
+    expect(expandRrkWarnings([{ Media: [{ ResourceRecordKey: 'WRONG' }] }], expandScenario, params)).toEqual([]);
+  });
+
+  it('multiple children, only one mismatched → exactly one warning naming that offender', () => {
+    const children = [
+      { MediaKey: 'M1', ResourceRecordKey: 'P1' }, // match
+      { MediaKey: 'M2', ResourceRecordKey: 'OFFENDER' }, // mismatch
+      { MediaKey: 'M3' }, // no RRK — out of scope
+      { MediaKey: 'M4', ResourceRecordKey: 'P1' }, // match
+    ];
+    const warnings = expandRrkWarnings([parent(children)], expandScenario, params);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('OFFENDER');
+  });
+
+  it('returns [] when the expand field cannot resolve (no expandField param)', () => {
+    const noExpand: TestParams = {
+      resource: 'Property',
+      keyField: 'ListingKey',
+      keyValue: 'P1',
+      enumMode: 'string',
+      integerValueHigh: 0,
+      skippedTypes: [],
+      sampleComplete: true,
+    };
+    expect(expandRrkWarnings([parent([{ ResourceRecordKey: 'WRONG' }])], expandScenario, noExpand)).toEqual([]);
+  });
+});
+
+// ── The non-gating proof, end-to-end through executeStandardScenario ──
+
+const response = (children: unknown): ODataResponse => ({
+  status: 200,
+  headers: { 'odata-version': '4.01' },
+  body: { value: [parent(children)] },
+  rawBody: JSON.stringify({ value: [parent(children)] }),
+});
+
+const scriptedRequester = (res: ODataResponse): ODataRequester => ({ request: async () => res });
+
+const runExpand = (children: unknown): Promise<{ readonly result: ScenarioResult }> =>
+  executeStandardScenario('http://x', 'Property', expandScenario, params, 'tok', 0, scriptedRequester(response(children)));
+
+describe('$expand RRK warning is NON-GATING (does not change passed / failed / verdict)', () => {
+  it('mismatch → scenario STILL passes, warning rides alongside on ScenarioResult.warnings', async () => {
+    const { result } = await runExpand([{ MediaKey: 'M1', ResourceRecordKey: 'WRONG' }]);
+    expect(result.passed).toBe(true); // expansion worked — the scenario passes
+    expect(result.skipped).toBe(false);
+    expect(result.warnings?.length ?? 0).toBeGreaterThan(0);
+    expect(result.warnings?.[0]).toContain('WRONG');
+    // The warning never entered the assertions (the pass/fail surface).
+    expect(result.assertions.every(a => a.passed)).toBe(true);
+  });
+
+  it('match → scenario passes with NO warnings field emitted', async () => {
+    const { result } = await runExpand([{ MediaKey: 'M1', ResourceRecordKey: 'P1' }]);
+    expect(result.passed).toBe(true);
+    expect(result.warnings).toBeUndefined();
+  });
+
+  it('THE PROOF: a warning changes neither the failed count nor the verdict vs. a clean match', async () => {
+    const mismatch = (await runExpand([{ MediaKey: 'M1', ResourceRecordKey: 'WRONG' }])).result;
+    const clean = (await runExpand([{ MediaKey: 'M1', ResourceRecordKey: 'P1' }])).result;
+
+    const mismatchSummary = summarizeScenarios([mismatch]);
+    const cleanSummary = summarizeScenarios([clean]);
+
+    // The verdict surface (passed/failed/skipped) is IDENTICAL — the only difference is the advisory warning.
+    expect(mismatchSummary).toEqual(cleanSummary);
+    expect(mismatchSummary.failed).toBe(0);
+    expect(mismatchSummary.passed).toBe(1);
+
+    // And the run verdict derived from those counts is `passed` in BOTH cases — the warning is inert to it.
+    const verdictArgs = (failed: number) => ({ totalFailed: failed, coverageFailed: false, deadlineReached: false });
+    expect(coreVerdict(verdictArgs(mismatchSummary.failed))).toBe('passed');
+    expect(coreVerdict(verdictArgs(cleanSummary.failed))).toBe('passed');
+  });
+});

--- a/reso-certification/tests/web-api-core/expand-sampling.test.ts
+++ b/reso-certification/tests/web-api-core/expand-sampling.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import type { ODataRequester } from '../../src/test-runner/requester.js';
+import type { EntityType } from '../../src/test-runner/types.js';
+import type { ODataResponse } from '../../src/test-runner/types.js';
+import { buildScenarioQuery } from '../../src/web-api-core/queries.js';
+import { resolveTestParams } from '../../src/web-api-core/sampling.js';
+import type { StandardMap } from '../../src/web-api-core/standard-map.js';
+import type { ExpandScenario } from '../../src/web-api-core/scenarios.js';
+
+// The 2.1.0 $expand scenario was dormant: resolveTestParams never populated `expandField`, so buildExpandUrl
+// returned undefined and the scenario always skipped. Selection = the FIRST COLLECTION navigation property of
+// the resource's entity type (a collection is what `$top=5` and the RRK child-collection check expect).
+
+// A StandardMap stub — expand selection is off the entity type's navigation properties, not the DD reference,
+// so nothing here needs a real DD map.
+const noopStandardMap: StandardMap = {
+  isStandardField: () => false,
+  isStandardValue: () => false,
+  standardValues: () => new Set<string>(),
+};
+
+// One record is enough that resolveTestParams doesn't take its no-records early return (which never reaches the
+// expand selection). expandField is chosen from the entity type, not the records.
+const oneRecordResponse: ODataResponse = {
+  status: 200,
+  headers: { 'odata-version': '4.01' },
+  body: { value: [{ ListingKey: 'P1', BedroomsTotal: 3 }] },
+  rawBody: JSON.stringify({ value: [{ ListingKey: 'P1', BedroomsTotal: 3 }] }),
+};
+
+const scriptedRequester: ODataRequester = { request: async () => oneRecordResponse };
+
+const makeEntityType = (
+  navigationProperties?: EntityType['navigationProperties'],
+): EntityType => ({
+  name: 'Property',
+  keyProperties: ['ListingKey'],
+  properties: [
+    { name: 'ListingKey', type: 'Edm.String' },
+    { name: 'BedroomsTotal', type: 'Edm.Int64' },
+  ],
+  ...(navigationProperties && { navigationProperties }),
+});
+
+const resolve = (entityType: EntityType) =>
+  resolveTestParams('http://x', 'Property', entityType, 'tok', [], noopStandardMap, undefined, scriptedRequester);
+
+// The exact 2.1.0 catalog entry (scenarios.ts) — dispatched through buildScenarioQuery to buildExpandUrl.
+const expandScenario: ExpandScenario = {
+  tag: 'expand',
+  name: '$expand navigation property',
+  category: 'expand',
+  fieldParam: 'expandField',
+  minVersion: '2.1.0',
+};
+
+describe('resolveTestParams — $expand navigation selection', () => {
+  it('sets expandField to the FIRST collection nav, skipping an earlier single-valued nav', async () => {
+    // ListOffice (single) is declared before Media (collection) — selection must skip it and pick Media.
+    const params = await resolve(
+      makeEntityType([
+        { name: 'ListOffice', isCollection: false, targetType: 'Office' },
+        { name: 'Media', isCollection: true, targetType: 'Media' },
+      ]),
+    );
+    expect(params.expandField).toBe('Media');
+  });
+
+  it('picks the FIRST collection nav in declaration order when several exist (deterministic)', async () => {
+    const params = await resolve(
+      makeEntityType([
+        { name: 'Media', isCollection: true, targetType: 'Media' },
+        { name: 'Rooms', isCollection: true, targetType: 'Room' },
+      ]),
+    );
+    expect(params.expandField).toBe('Media');
+  });
+
+  it('leaves expandField unset when only single-valued navs exist', async () => {
+    const params = await resolve(makeEntityType([{ name: 'ListOffice', isCollection: false, targetType: 'Office' }]));
+    expect(params.expandField).toBeUndefined();
+  });
+
+  it('leaves expandField unset when the entity type declares no navigation properties', async () => {
+    const params = await resolve(makeEntityType(undefined));
+    expect(params.expandField).toBeUndefined();
+  });
+});
+
+describe('$expand scenario activation — end to end through buildScenarioQuery', () => {
+  it('a resource WITH a collection nav runs: buildScenarioQuery emits the expand URL (not skipped)', async () => {
+    const params = await resolve(makeEntityType([{ name: 'Media', isCollection: true, targetType: 'Media' }]));
+    const query = buildScenarioQuery('http://x', 'Property', expandScenario, params);
+    expect(query).toBeDefined();
+    expect(query?.url).toBe('http://x/Property?$expand=Media&$top=5');
+  });
+
+  it('a resource WITHOUT a collection nav still skips: buildScenarioQuery returns undefined', async () => {
+    const params = await resolve(makeEntityType([{ name: 'ListOffice', isCollection: false, targetType: 'Office' }]));
+    expect(buildScenarioQuery('http://x', 'Property', expandScenario, params)).toBeUndefined();
+  });
+});

--- a/reso-certification/tests/web-api-core/optional-tests.test.ts
+++ b/reso-certification/tests/web-api-core/optional-tests.test.ts
@@ -111,10 +111,20 @@ describe('classification: string functions optional, Core required', () => {
     }
   });
 
-  it('only string-function scenarios carry optional', () => {
+  it('only string-function and $expand scenarios carry optional', () => {
+    // $expand is optional (non-gating): it fires to activate the RRK expanded-item warning, but a server
+    // that doesn't support expanding the chosen nav renders "Not Supported" rather than failing the cert.
     for (const s of allScenarios) {
-      if (s.optional) expect(s.category).toBe('string-function');
+      if (s.optional) expect(['string-function', 'expand']).toContain(s.category);
     }
+  });
+
+  it('a failed $expand scenario is non-gating — Not Supported, contributes 0 to the failed count', () => {
+    // A server that returns non-200 for the chosen expansion must NOT fail Core cert: as an optional
+    // scenario, a determinate expand failure renders "Not Supported" and adds nothing to the failed tally.
+    const expandFailed = r({ tag: 'expand', passed: false, skipped: false, optional: true });
+    expect(optionalOutcome(expandFailed)).toBe('Not Supported');
+    expect(summarizeScenarios([expandFailed]).failed).toBe(0);
   });
 });
 

--- a/reso-certification/tests/web-api-core/serving.test.ts
+++ b/reso-certification/tests/web-api-core/serving.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Serving detection — the Core 2.1.0 "declared-but-not-served" carve-out.
+ *
+ * These are the pure-function invariants behind the masking decision. A FALSE PASS (masking a resource that
+ * is actually broken) is worse than a FALSE FAIL, so every path that isn't determinately-absent-on-both-
+ * surfaces must resolve to `run`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  declaredPresence,
+  parseServiceDocument,
+  resolveServingDecision,
+  servedPresence,
+} from '../../src/web-api-core/serving.js';
+import type { EntityType, ParsedEntitySet } from '../../src/test-runner/types.js';
+
+const entityType = (name: string): EntityType => ({ name, keyProperties: [`${name}Key`], properties: [] });
+
+const goodDoc = (names: ReadonlyArray<string>): Record<string, unknown> => ({
+  '@odata.context': 'https://api.example.com/odata/$metadata',
+  value: names.map(n => ({ name: n, kind: 'EntitySet', url: n })),
+});
+
+// ── parseServiceDocument ──
+describe('parseServiceDocument', () => {
+  it('accepts a good, complete service document → the served EntitySet names', () => {
+    const served = parseServiceDocument(goodDoc(['Property', 'Member', 'Office']));
+    expect(served).toBeInstanceOf(Set);
+    expect([...(served ?? [])].sort()).toEqual(['Member', 'Office', 'Property']);
+  });
+
+  it('rejects a non-object body (string / null / number / array) → undefined', () => {
+    for (const bad of ['{}', null, 42, [], undefined]) {
+      expect(parseServiceDocument(bad)).toBeUndefined();
+    }
+  });
+
+  it('rejects a bad @odata.context (missing / non-string / not ending in $metadata) → undefined', () => {
+    expect(parseServiceDocument({ value: [{ name: 'Property' }] })).toBeUndefined(); // missing context
+    expect(parseServiceDocument({ '@odata.context': 123, value: [{ name: 'Property' }] })).toBeUndefined(); // non-string
+    expect(parseServiceDocument({ '@odata.context': 'https://x/odata/Property', value: [{ name: 'Property' }] })).toBeUndefined(); // wrong tail
+  });
+
+  it('rejects a non-array value → undefined', () => {
+    expect(parseServiceDocument({ '@odata.context': 'https://x/$metadata', value: { name: 'Property' } })).toBeUndefined();
+  });
+
+  it('rejects an EMPTY value[] → undefined (an empty doc can never prove a resource absent)', () => {
+    expect(parseServiceDocument({ '@odata.context': 'https://x/$metadata', value: [] })).toBeUndefined();
+  });
+
+  it('rejects a paged doc carrying @odata.nextLink → undefined (incomplete, can\'t prove absence)', () => {
+    expect(parseServiceDocument({
+      '@odata.context': 'https://x/$metadata',
+      value: [{ name: 'Property' }],
+      '@odata.nextLink': 'https://x/$metadata/next',
+    })).toBeUndefined();
+  });
+
+  it('rejects a non-empty value[] with no usable names → undefined (malformed, not an empty served set)', () => {
+    expect(parseServiceDocument({ '@odata.context': 'https://x/$metadata', value: [{ url: 'Property' }, { name: 42 }] })).toBeUndefined();
+  });
+});
+
+// ── the two surfaces ──
+describe('servedPresence (Surface 1 — service document)', () => {
+  it('undefined served-set ⇒ indeterminate', () => {
+    expect(servedPresence(undefined, 'Property')).toBe('indeterminate');
+  });
+  it('present when named, absent when not', () => {
+    const served = new Set(['Property', 'Member']);
+    expect(servedPresence(served, 'Property')).toBe('present');
+    expect(servedPresence(served, 'Media')).toBe('absent');
+  });
+});
+
+describe('declaredPresence (Surface 2 — EntityContainer, resolved through EntityType)', () => {
+  const sets: ReadonlyArray<ParsedEntitySet> = [
+    { name: 'Properties', entityType: 'Property' }, // set name ≠ type name — membership is by TYPE
+    { name: 'Member', entityType: 'Member' },
+  ];
+  it('undefined / empty entitySets ⇒ indeterminate', () => {
+    expect(declaredPresence(undefined, entityType('Property'))).toBe('indeterminate');
+    expect(declaredPresence([], entityType('Property'))).toBe('indeterminate');
+  });
+  it('present when a declared set exposes the resource\'s EntityType (NOT by set name)', () => {
+    expect(declaredPresence(sets, entityType('Property'))).toBe('present');
+    expect(declaredPresence(sets, entityType('Member'))).toBe('present');
+  });
+  it('absent when no declared set exposes the resource\'s EntityType', () => {
+    expect(declaredPresence(sets, entityType('Media'))).toBe('absent');
+  });
+});
+
+// ── resolveServingDecision truth table ──
+describe('resolveServingDecision', () => {
+  const served = (...names: string[]) => new Set(names);
+  const sets = (...pairs: Array<[string, string]>): ReadonlyArray<ParsedEntitySet> =>
+    pairs.map(([name, type]) => ({ name, entityType: type }));
+
+  const decide = (
+    resource: string,
+    version: '2.0.0' | '2.1.0',
+    servedEntitySets: ReadonlySet<string> | undefined,
+    declaredEntitySets: ReadonlyArray<ParsedEntitySet> | undefined,
+  ) => resolveServingDecision({ resource, entityType: entityType(resource), version, servedEntitySets, declaredEntitySets });
+
+  it('2.0.0 ALWAYS runs — the carve-out is 2.1.0+ only (even both-absent)', () => {
+    expect(decide('Property', '2.0.0', served('Member'), sets(['Member', 'Member']))).toBe('run');
+    expect(decide('Media', '2.0.0', served('Member'), sets(['Member', 'Member']))).toBe('run');
+  });
+
+  it('a resource we do not recognize always runs (never masked)', () => {
+    expect(decide('InternetTracking', '2.1.0', served('Property'), sets(['Property', 'Property']))).toBe('run');
+  });
+
+  it('both surfaces determinate + ABSENT → FAIL for a required resource (P/M/O/F/L + EntityEvent)', () => {
+    for (const req of ['Property', 'Member', 'Office', 'Field', 'Lookup', 'EntityEvent']) {
+      expect(decide(req, '2.1.0', served('Other'), sets(['Other', 'Other']))).toBe('fail');
+    }
+  });
+
+  it('both surfaces determinate + ABSENT → NA for a non-required well-known resource', () => {
+    for (const wk of ['Media', 'OpenHouse', 'Showing']) {
+      expect(decide(wk, '2.1.0', served('Property'), sets(['Property', 'Property']))).toBe('na');
+    }
+  });
+
+  it('surfaces DISAGREE (served present / declared absent) → run (anti-false-PASS)', () => {
+    expect(decide('Property', '2.1.0', served('Property'), sets(['Member', 'Member']))).toBe('run');
+  });
+
+  it('surfaces DISAGREE (served absent / declared present) → run — the drifted-service-doc 404 case', () => {
+    // Declared as an EntitySet but omitted from the service document: stays in the run and fails for real.
+    expect(decide('Property', '2.1.0', served('Member'), sets(['Property', 'Property']))).toBe('run');
+  });
+
+  it('either surface INDETERMINATE → run', () => {
+    expect(decide('Property', '2.1.0', undefined, sets(['Member', 'Member']))).toBe('run'); // served indeterminate
+    expect(decide('Property', '2.1.0', served('Member'), undefined)).toBe('run'); // declared indeterminate (no container)
+    expect(decide('Property', '2.1.0', served('Member'), [])).toBe('run'); // declared indeterminate (zero sets)
+    expect(decide('Property', '2.1.0', undefined, undefined)).toBe('run'); // both indeterminate
+  });
+
+  it('both surfaces PRESENT → run (the normal served resource)', () => {
+    expect(decide('Property', '2.1.0', served('Property'), sets(['Property', 'Property']))).toBe('run');
+  });
+});


### PR DESCRIPTION
Draft for review — the reso-certification work feeding the **desktop beta.7** release.

## 1. Core 2.1.0 declared-but-not-served carve-out (`69d5279`)

Fixes the false 404 cascade seen in the desktop client when a provider does **not** serve a resource (e.g. Media) as a top-level resource. A Web API Core resource may be *declared* at the top level (an OData EntitySet) but not *served* there; per the RCP-039 workgroup carve-out (**Core 2.1.0+ only**), that's acceptable for most resources, but a fixed set must always be served if declared.

- **2.1.0+:** a resource determinately declared-but-not-served top level → one clean **FAIL** if in the always-top-level set **{Property, Member, Office, Field, Lookup, EntityEvent}**, else **Not Applicable** (e.g. Media may be expansion-only).
- **2.0.0:** unchanged — declared implies assumed-available, as written.

**Always-top-level rationale:** core standard resources (P/M/O) + metadata resources (Field replaces OData `$metadata`; Lookup carries enumerations; Field→Lookup) + EntityEvent (RCP-027 defines it at the top level). All may *also* be expanded once served top level. Authoritative source is the transport #22 (RCP-039) discussion — the rule was never transcribed into the ratified spec (a separate cleanup, cf. #211).

**Safety:** detection (`src/web-api-core/serving.ts`) masks **only** on positive determinate evidence from **both** surfaces agreeing absent — the OData service document (hardened against empty / paged / non-service-document bodies) and the EDMX EntityContainer EntitySets (resolved by EntityType). Any indeterminate surface or a disagreement runs the resource as today, so a declared-but-404 resource fails for real. Provider-wide `metadata` + `service-document` scenarios are hoisted to run once per provider. **Adversarially reviewed (refute-by-default, 0 surviving blockers); +25 tests; 1000 pass + 2 expected-fail.**

## 2. CLI shared-option builders (`5073643`)

Centralizes the universal CLI flags (auth cluster, server URL, output dir) in `src/cli/shared-options.ts` so they can't drift across commands; subject flags (`--metadata`/`--payload`/`--input`) stay semantic by design. Non-breaking; the divergent `--url` / hand-rolled-auth sites convert in a follow-up.

## Reviewer notes
- Behavior change: under 2.1.0, declared-but-not-served Media is now NA instead of the 404 cascade.
- The report gains a `Service (provider-wide)` row (hoisted provider-wide scenarios).
- InternetTracking is in neither the tested (`WELL_KNOWN`) nor required set → runs as today (not carve-out-eligible). Flag if it should be.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
