### PR TITLE
Core 2.1.0 $expand — gate on per-item DD/Core schema validation

### DIFF
--- a/reso-certification/src/sdk/core.ts
+++ b/reso-certification/src/sdk/core.ts
@@ -11,6 +11,8 @@ import { validateMetadata, formatValidationSummary, collectValidationErrors } fr
 import { buildStandardMap, resolveTestParams, WELL_KNOWN_RESOURCES } from '../web-api-core/index.js';
 import { runCoreResourceScenarios, runProviderScenarios, summarizeScenarios, type ResourceTestReport } from '../web-api-core/test-runner.js';
 import { resolveServingDecision } from '../web-api-core/serving.js';
+import { createExpandSchemaValidator } from './expand-schema.js';
+import { generateMetadataReport } from '@reso-standards/reso-metadata-utils';
 import { isDeadlineError, runSettled } from '@reso-standards/reso-client';
 import { createCertSession, createSessionRequester } from '../test-runner/requester.js';
 import type { BaseTestContext, CoreConfig, PipelineStep, StepResult } from './types.js';
@@ -261,6 +263,22 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
     const session = createCertSession(config.totalTimeoutMs);
     const requester = createSessionRequester(session);
 
+    // Core 2.1.0 $expand is GATING and schema-validates each expanded child item against its target entity
+    // type. Build the validator ONCE per run from the provider's metadata report (generated from the EDMX we
+    // already fetched — no extra request). Best-effort: report generation OR schema build can throw on wonky
+    // metadata; either way the run continues and each $expand nav gates on the 200 response alone (a compliant
+    // server never false-fails). 2.0.0 has no $expand scenario, so the validator is only built for 2.1.0.
+    const buildExpandValidator = async (): Promise<import('../web-api-core/index.js').ExpandItemValidator | undefined> => {
+      try {
+        const metadataReport = generateMetadataReport(ctx.metadataXml!, version);
+        return await createExpandSchemaValidator({ metadataReport, version });
+      } catch (err) {
+        onProgress({ step: 'Run Core scenarios', status: 'running', message: `$expand schema validation unavailable — ${err instanceof Error ? err.message : String(err)}` });
+        return undefined;
+      }
+    };
+    const expandValidator = version === '2.1.0' ? await buildExpandValidator() : undefined;
+
     // Provider-wide structural pass — run ONCE for the whole provider, BEFORE the per-resource gate, so the
     // metadata + service-document scenarios are always recorded even if every resource ends up masked. The
     // service document doubles as Surface 1 of the serving detection, and the metadata response gives the
@@ -340,8 +358,9 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
           ctx.authToken!,
           version,
           requester,
-          // Provider-wide scenarios already ran once above; thread the detected version for the 4.01 gate.
-          { excludeProviderWide: true, odataVersion: provider.odataVersion },
+          // Provider-wide scenarios already ran once above; thread the detected version for the 4.01 gate and
+          // the once-per-run $expand schema validator (undefined at 2.0.0 / if it couldn't be built).
+          { excludeProviderWide: true, odataVersion: provider.odataVersion, ...(expandValidator ? { expandValidator } : {}) },
         );
 
         onProgress({

--- a/reso-certification/src/sdk/expand-schema.ts
+++ b/reso-certification/src/sdk/expand-schema.ts
@@ -1,0 +1,234 @@
+/**
+ * Expanded-item schema validator for the Core 2.1.0 $expand test.
+ *
+ * Builds a reusable validator from the provider's metadata report using the LEGACY JSON-schema utilities
+ * (`src/legacy/lib/schema`) — generate the JSON Schema ONCE, then validate each expanded child item against its
+ * target entity type. The Web API Core runner consumes it through the {@link ExpandItemValidator} interface and
+ * never touches the schema machinery itself.
+ *
+ * The legacy module is loaded via `createRequire` because it is CommonJS (and pulls in ajv + the ETL reference
+ * bridge) — the same interop pattern `src/cli/schema-command.ts` uses. We call the legacy utilities DIRECTLY
+ * (`generateJsonSchema` / `validate`) rather than the CLI's typed wrappers to avoid an sdk → cli layering
+ * inversion (cli already depends on sdk).
+ *
+ * ── Validation policy (mirrors DD/Core testing exactly — NOT RCF mode) ──
+ *  - `additionalProperties: false` when generating the schema: a field on the expanded item that the provider's
+ *    metadata does not advertise is an ERROR (`Fields MUST be advertised in the metadata`).
+ *  - `isRCF` is DERIVED by the legacy validator from `payload['@reso.context']` (`validate.js`). An expanded
+ *    child item never carries `@reso.context`, so `isRCF()` is `false` → DD/Core mode: a value exceeding the
+ *    provider's declared `maxLength` is a hard ERROR (`MUST have a maximum advertised length …`), not the RCF
+ *    `SHOULD have a maximum suggested length` warning.
+ *  - The committed `schema-validation-settings.json` exemptions are threaded as `validationConfig`, so the
+ *    `ignoreEnumerations` fields (Property MLS-area/school, Media ImageSizeDescription) downgrade an
+ *    unadvertised-enum ERROR to a WARNING — exactly as the DD/schema path does. The settings are keyed by DD
+ *    major.minor (`2.0`/`2.1`), so the endorsement version (`2.1.0`) is normalized before it reaches the
+ *    validator's `getVersion()` exemption lookup.
+ *  - The nav gates on `stats.totalErrors === 0`: errors fail, warnings do not.
+ */
+
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { MetadataReport, MetadataReportField } from '@reso-standards/reso-metadata-utils';
+import type { ExpandItemValidator } from '../web-api-core/test-runner.js';
+
+const requireLegacy = createRequire(import.meta.url);
+
+/** The committed, committee-approved exemptions file (never modified). Keyed by DD major.minor. */
+const SETTINGS_FILE = 'schema-validation-settings.json';
+
+/** The slice of the legacy schema module (`src/legacy/lib/schema/index.js`) this validator needs. */
+interface LegacySchemaModule {
+  readonly generateJsonSchema: (opts: {
+    readonly metadataReportJson: unknown;
+    readonly additionalProperties?: boolean;
+  }) => Promise<unknown>;
+  readonly validate: (opts: {
+    readonly jsonSchema: unknown;
+    readonly jsonPayload: unknown;
+    readonly resourceName?: string;
+    readonly version?: string;
+    readonly validationConfig?: unknown;
+    readonly errorMap?: Record<string, unknown>;
+  }) => Record<string, unknown>;
+}
+
+const isLegacySchemaModule = (m: unknown): m is LegacySchemaModule =>
+  typeof m === 'object' &&
+  m !== null &&
+  typeof (m as Record<string, unknown>).generateJsonSchema === 'function' &&
+  typeof (m as Record<string, unknown>).validate === 'function';
+
+const loadLegacySchemaModule = (): LegacySchemaModule => {
+  const raw: unknown = requireLegacy(resolve(dirname(fileURLToPath(import.meta.url)), '../legacy/lib/schema/index.js'));
+  if (!isLegacySchemaModule(raw)) {
+    throw new Error('Failed to load the legacy schema module — expected generateJsonSchema / validate exports.');
+  }
+  return raw;
+};
+
+/** The legacy `validate()` result carries a running error tally on `stats` and a per-message cache. */
+interface LegacyValidateResult {
+  readonly stats?: { readonly totalErrors?: number };
+  readonly errorCache?: Record<string, unknown>;
+}
+
+/**
+ * Normalize a version to DD major.minor (`2.1.0` → `2.1`). The legacy validator's `getVersion()` keys the
+ * `ignoreEnumerations` exemption lookup, and `schema-validation-settings.json` is keyed `2.0`/`2.1`; the Core
+ * endorsement carries the full semver (`2.1.0`), which would miss the exemptions and false-fail the exempt
+ * fields. The single generated schema is not version-keyed, so this only steers the exemption lookup/error text.
+ */
+const toDataDictionaryVersion = (version: string): string => version.split('.').slice(0, 2).join('.');
+
+/**
+ * Resolve the committed exemptions file: the current run directory first, then the copy shipped beside the
+ * package root (`../..` from `src/sdk` in dev, `dist/sdk` when packaged — same depth as `schema-command.ts`).
+ * `fileURLToPath` (not `new URL().pathname`) keeps this correct on Windows.
+ */
+const resolveSettingsPath = (): string | undefined => {
+  const cwdSettings = resolve(process.cwd(), SETTINGS_FILE);
+  if (existsSync(cwdSettings)) return cwdSettings;
+  const prebaked = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', SETTINGS_FILE);
+  return existsSync(prebaked) ? prebaked : undefined;
+};
+
+/** Load the exemptions (`ignoreEnumerations`) config; `{}` (no exemptions) when the file is absent/unreadable. */
+const loadValidationConfig = async (): Promise<Record<string, unknown>> => {
+  const path = resolveSettingsPath();
+  if (!path) return {};
+  try {
+    return JSON.parse(await readFile(path, 'utf-8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+};
+
+/** A `Collection(...)` type in the metadata report (e.g. `Collection(org.reso.metadata.enums.Feature)`). */
+const COLLECTION_TYPE = /^Collection\((.+)\)$/;
+
+/**
+ * Align the provider report's collection fields with the shape the legacy schema generator expects.
+ *
+ * `generateMetadataReport` serializes a non-expansion collection field's `type` WRAPPED
+ * (`Collection(org.reso.metadata.enums.Feature)`), whereas the legacy generator — written for the DD-reference
+ * shape — matches a collection field's ELEMENT type against the advertised lookups and primitive map. Left
+ * wrapped, an enum collection resolves to an empty enum (only `null` valid) and a primitive collection to
+ * `items: { type: object }`, so any populated collection value on a compliant server's expanded item would
+ * FALSE-FAIL. Unwrapping to the element type restores the DD-reference shape the generator matches on. This is
+ * a pure, local no-op for the DD reference itself (its collection fields are already unwrapped) and never
+ * touches expansion collections (those key off `typeName`, not `type`).
+ */
+const unwrapCollectionElementTypes = (report: MetadataReport): MetadataReport => ({
+  ...report,
+  fields: report.fields.map((field): MetadataReportField => {
+    if (field.isCollection === true && field.isExpansion !== true && typeof field.type === 'string') {
+      const match = COLLECTION_TYPE.exec(field.type);
+      if (match) return { ...field, type: match[1] };
+    }
+    return field;
+  }),
+});
+
+export interface CreateExpandSchemaValidatorInput {
+  /** The provider's metadata report — its `definitions` cover EVERY resource, so one schema validates any
+   *  expanded target entity type. Generate it once per run from the EDMX already fetched (`generateMetadataReport`). */
+  readonly metadataReport: MetadataReport;
+  /** The endorsement/DD version. Normalized to DD major.minor for the exemption lookup (see
+   *  {@link toDataDictionaryVersion}); the legacy validator also requires a truthy version for a payload without
+   *  an `@reso.context` (an expanded child item never carries one). */
+  readonly version: string;
+  /** Exemptions override. Defaults to the committed {@link SETTINGS_FILE}; tests inject a fixture directly so
+   *  they never depend on the current working directory. */
+  readonly validationConfig?: Readonly<Record<string, unknown>>;
+}
+
+/** A compiled schema handle — present only when construction AND the ajv compile both succeeded. */
+interface BuiltSchema {
+  readonly jsonSchema: unknown;
+}
+
+/**
+ * Build AND compile the schema ONCE. Returns `undefined` on ANY construction failure — a report the generator
+ * cannot project (returns null) OR a schema ajv cannot compile — so the caller can gate the nav on the 200
+ * alone rather than let a per-item catch silently pass every item (the false-PASS this guards against).
+ *
+ * `generateJsonSchema` builds the JSON Schema object but ajv compilation is LAZY (it happens inside the first
+ * `validate()`); a warm-up `validate()` against a real resource forces that compile HERE, so a non-compilable
+ * schema fails determinately at construction. The legacy `validate()` deep-clones and restores the schema it
+ * mutates on each call, so the warm-up leaves no residue for later items.
+ */
+const buildExpandSchema = async (
+  mod: LegacySchemaModule,
+  report: MetadataReport,
+  ddVersion: string,
+  validationConfig: unknown,
+): Promise<BuiltSchema | undefined> => {
+  try {
+    const normalized = unwrapCollectionElementTypes(report);
+    const jsonSchema = await mod.generateJsonSchema({ metadataReportJson: normalized, additionalProperties: false });
+    if (jsonSchema == null) return undefined;
+    // Force the lazy ajv compile of one representative resource now (result discarded) to surface a wholesale
+    // schema-compile failure HERE — caught below → undefined validator → the nav gates on the observable 200,
+    // never a silent per-item "valid". One compile is enough for a structural/wholesale failure. We deliberately
+    // do NOT warm every distinct resource: the legacy validate() compiles a resource-specific schema per call
+    // (it mutates `oneOf` per resource before `ajv.compile`), so warming all of them is O(resources) compiles
+    // at construction — 41 for the full DD reference, seconds of work on a CI runner. A compile failure isolated
+    // to a single OTHER resource is not reachable through generateMetadataReport anyway (the generator emits
+    // compilable schemas — even a dangling enum ref compiles, verified), and were it ever to occur the per-item
+    // catch degrades that item to the 200-gate rather than fabricating a fail.
+    const warmupResource = normalized.fields[0]?.resourceName;
+    if (warmupResource) {
+      mod.validate({ jsonSchema, jsonPayload: {}, resourceName: warmupResource, version: ddVersion, validationConfig, errorMap: {} });
+    }
+    return { jsonSchema };
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Build the expanded-item validator ONCE per run from a metadata report. `generateJsonSchema` builds a schema
+ * whose `definitions` cover every resource in the report, so a single schema validates any target entity type.
+ *
+ * Returns `undefined` when the schema cannot be built or compiled (a determinate tooling failure): the $expand
+ * nav then gates on its 200 response alone. A COMPLIANT server never false-fails, and — because a compile
+ * failure is surfaced as `undefined` rather than swallowed — the gate never silently passes an item it could
+ * not actually validate.
+ */
+export const createExpandSchemaValidator = async (
+  input: CreateExpandSchemaValidatorInput,
+): Promise<ExpandItemValidator | undefined> => {
+  const mod = loadLegacySchemaModule();
+  const ddVersion = toDataDictionaryVersion(input.version);
+  const validationConfig = input.validationConfig ?? (await loadValidationConfig());
+
+  const built = await buildExpandSchema(mod, input.metadataReport, ddVersion, validationConfig);
+  if (!built) return undefined;
+
+  return {
+    validate: (item, targetType) => {
+      try {
+        const result = mod.validate({
+          jsonSchema: built.jsonSchema,
+          jsonPayload: item,
+          resourceName: targetType,
+          version: ddVersion,
+          validationConfig,
+          errorMap: {},
+        }) as LegacyValidateResult;
+        const totalErrors = result.stats?.totalErrors ?? 0;
+        const errors = Object.keys(result.errorCache ?? {});
+        return { valid: totalErrors === 0, errors };
+      } catch {
+        // The schema COMPILED at construction (buildExpandSchema warmed it up), so a throw HERE is a genuinely
+        // unexpected per-item failure (an odd item shape / unknown target), not a systematic compile failure.
+        // Treat THIS item as indeterminate — never a false fail — while a real compile failure was already
+        // caught at construction (→ undefined validator), so it can never masquerade as "all valid".
+        return { valid: true, errors: [] };
+      }
+    },
+  };
+};

--- a/reso-certification/src/web-api-core/index.ts
+++ b/reso-certification/src/web-api-core/index.ts
@@ -15,8 +15,8 @@ export { selectEnumCandidates, isSingleRep, isMultiRep } from './enum-selection.
 export type { EnumCandidate } from './enum-selection.js';
 export { buildScenarioQuery } from './queries.js';
 export type { QuerySpec } from './queries.js';
-export { runCoreResourceScenarios, runProviderScenarios, isProviderWideScenario, summarizeScenarios } from './test-runner.js';
-export type { ScenarioResult, ResourceTestReport, TypeCoverage, ProviderScenariosResult, CoreResourceScenarioOptions } from './test-runner.js';
+export { runCoreResourceScenarios, runProviderScenarios, isProviderWideScenario, summarizeScenarios, runExpandNavScenarios, validateExpandedItems } from './test-runner.js';
+export type { ScenarioResult, ResourceTestReport, TypeCoverage, ProviderScenariosResult, CoreResourceScenarioOptions, ExpandItemValidator, ExpandItemValidation } from './test-runner.js';
 export { parseServiceDocument, servedPresence, declaredPresence, resolveServingDecision } from './serving.js';
 export type { Presence, ServingDecision } from './serving.js';
 export {

--- a/reso-certification/src/web-api-core/sampling.ts
+++ b/reso-certification/src/web-api-core/sampling.ts
@@ -84,6 +84,13 @@ export interface TestParams {
    *  metadata at test-setup time. Falls back to the field name if absent. */
   readonly lookupNameByField?: Readonly<Record<string, string>>;
   readonly expandField?: string;
+  /** ALL collection navigation properties declared on the resource, each with its unqualified target entity
+   *  type name. Core 2.1.0 tests $expand PER collection nav (GATING) — the runner fans one expand result out
+   *  per entry (GET {resource}?$expand={name}&$top=5, then schema-validate each expanded child against
+   *  {targetType}). Empty / absent ⇒ the resource declares no collection nav ⇒ the $expand scenario is N/A
+   *  (skip). {@link expandField} above stays the FIRST of these — kept for the RRK warning's default field
+   *  resolution and the single-field query path. */
+  readonly expandNavs?: ReadonlyArray<{ readonly name: string; readonly targetType: string }>;
   /** True when the $top=1000 sample was the COMPLETE resource (no forward `@odata.nextLink`). The `ne`
    *  empty-verdict needs this to distinguish "the field genuinely holds one value across the whole resource"
    *  (empty is correct → pass) from "our sample only saw one value" (unknowable → skip). */
@@ -407,11 +414,15 @@ export const resolveTestParams = async (
   const stringField = stringSample?.field;
   const stringValue = stringSample?.value;
 
-  // Select an expansion for the 2.1.0 $expand scenario: the FIRST COLLECTION navigation property in
-  // declaration order. Deterministic (declaration order) so tests stay stable; a collection is what `$top=5`
-  // and the RRK child-collection check expect. No collection nav (or no navigation properties at all) ⇒
-  // expandField stays undefined ⇒ the $expand scenario skips gracefully, exactly as before.
-  const expandField = entityType.navigationProperties?.find(np => np.isCollection)?.name;
+  // Collection navigation properties drive the 2.1.0 $expand scenario, now tested PER nav (GATING). Selection
+  // is declaration order (deterministic, so tests stay stable); a collection is what `$top=5` and the RRK
+  // child-collection check expect. `expandField` = the FIRST collection nav (kept for the RRK warning's default
+  // field resolution + the single-field query path); `expandNavs` = ALL of them with their unqualified target
+  // entity type names, so the runner can test each declared collection nav one at a time. No collection nav (or
+  // no navigation properties at all) ⇒ both stay empty ⇒ the $expand scenario skips gracefully (N/A).
+  const collectionNavs = (entityType.navigationProperties ?? []).filter(np => np.isCollection);
+  const expandField = collectionNavs[0]?.name;
+  const expandNavs = collectionNavs.map(np => ({ name: np.name, targetType: np.targetType }));
 
   // LookupName per candidate field (from the RESO.OData.Metadata.LookupName annotation — string lookups
   // only; enum-typed fields have no Lookup Resource) for the Lookup Resource validation scenario.
@@ -470,6 +481,7 @@ export const resolveTestParams = async (
     stringField,
     stringValue,
     expandField,
+    expandNavs,
     lookupNameByField: Object.keys(lookupNameByField).length ? lookupNameByField : undefined,
     skippedTypes,
   };

--- a/reso-certification/src/web-api-core/scenarios.ts
+++ b/reso-certification/src/web-api-core/scenarios.ts
@@ -255,10 +255,14 @@ const pagingScenarios: ReadonlyArray<PagingScenario> = [
 ];
 
 const expandScenarios: ReadonlyArray<ExpandScenario> = [
-  // Non-gating (optional): $expand fires when the resource has a collection nav (activating the RRK
-  // expanded-item warning), but a server that doesn't support expanding the chosen nav renders "Not
-  // Supported" rather than a hard failure — a specific unsupported expansion must not fail a compliant server.
-  { tag: 'expand', name: '$expand navigation property', category: 'expand', fieldParam: 'expandField', minVersion: '2.1.0', optional: true },
+  // GATING, tested PER declared COLLECTION navigation property (Core 2.1.0). The runner fans this single
+  // catalog entry out to one result per collection nav on the resource: each is GET {resource}?$expand={nav}
+  // &$top=5, and a declared nav that either cannot be expanded (non-200) OR returns a schema-invalid expanded
+  // item FAILS — the parallel of the declared-but-not-served rule (declare a nav and it must be expandable).
+  // A resource that declares NO collection nav has nothing to expand ⇒ the scenario SKIPs (N/A, never a fail;
+  // buildExpandUrl already returns undefined when there is no expand target). The non-gating RRK expanded-item
+  // warning still rides alongside each expanded nav.
+  { tag: 'expand', name: '$expand navigation property', category: 'expand', fieldParam: 'expandField', minVersion: '2.1.0' },
 ];
 
 // Runs first among string-enum tests; cascade-skip applies to dependent

--- a/reso-certification/src/web-api-core/test-runner.ts
+++ b/reso-certification/src/web-api-core/test-runner.ts
@@ -341,6 +341,151 @@ export const expandRrkWarnings = (
   });
 };
 
+// ── $expand gating (Core 2.1.0): tested per declared collection nav ──
+
+/** The outcome of schema-validating one expanded child item against its target entity type. */
+export interface ExpandItemValidation {
+  readonly valid: boolean;
+  /** Human-readable validation error messages when invalid; empty when valid. */
+  readonly errors: ReadonlyArray<string>;
+}
+
+/**
+ * Validates an expanded child item against its target entity type's schema. INJECTED by the SDK (built once
+ * per run from the provider's metadata report via the legacy JSON-schema validator — see
+ * `src/sdk/expand-schema.ts`). The Web API Core runner stays free of the schema machinery — it only calls this
+ * interface — so a validator that couldn't be built is simply not passed, and each $expand nav then gates on
+ * the 200 response alone (never a false fail).
+ */
+export interface ExpandItemValidator {
+  readonly validate: (item: Record<string, unknown>, targetType: string) => ExpandItemValidation;
+}
+
+/** Collect every expanded child OBJECT under `navName` across the sampled parent records. A collection nav
+ *  serializes as an array, so a non-array / absent value contributes nothing (there is simply nothing to
+ *  validate); null / non-object array elements are dropped (only real items are schema-validated). */
+const collectExpandedItems = (
+  records: ReadonlyArray<Record<string, unknown>>,
+  navName: string,
+): ReadonlyArray<Record<string, unknown>> =>
+  records.flatMap((record) => {
+    const expanded = record[navName];
+    return Array.isArray(expanded)
+      ? expanded.filter((x): x is Record<string, unknown> => x != null && typeof x === 'object')
+      : [];
+  });
+
+/**
+ * Schema-validate every expanded child item under ONE collection nav against its target entity type — the
+ * DATA check the $expand gate exists for ("validate the data, not just that a 200 came back"). A schema-invalid
+ * item is a determinate FAIL. No validator (couldn't be built for this run) or no expanded items ⇒ PASS: the
+ * nav already returned 200 and there is nothing we can determinately fault, and a compliant server must never
+ * false-fail.
+ */
+export const validateExpandedItems = (
+  records: ReadonlyArray<Record<string, unknown>>,
+  nav: { readonly name: string; readonly targetType: string },
+  validator: ExpandItemValidator | undefined,
+): AssertionResult => {
+  if (!validator) {
+    return { passed: true, message: `$expand ${nav.name}: expansion returned 200; schema validation unavailable for this run (no validator built)` };
+  }
+  const items = collectExpandedItems(records, nav.name);
+  if (items.length === 0) {
+    return { passed: true, message: `$expand ${nav.name}: 200 received; no expanded ${nav.targetType} item to schema-validate` };
+  }
+  const invalid = items.flatMap((item, index) => {
+    const { valid, errors } = validator.validate(item, nav.targetType);
+    return valid ? [] : [{ index, errors }];
+  });
+  if (invalid.length === 0) {
+    return { passed: true, message: `$expand ${nav.name}: all ${items.length} expanded ${nav.targetType} item(s) valid against the target entity type` };
+  }
+  const first = invalid[0];
+  const detail = first.errors.slice(0, 3).join('; ') || 'schema validation failed';
+  return { passed: false, message: `$expand ${nav.name}: ${invalid.length}/${items.length} expanded ${nav.targetType} item(s) schema-invalid against ${nav.targetType} — item ${first.index}: ${detail}` };
+};
+
+/**
+ * Execute the $expand test for ONE declared collection nav (Core 2.1.0, GATING). GET
+ * {resource}?$expand={nav}&$top=5, then:
+ *   - non-200 → FAIL (a declared nav that cannot be expanded — the parallel of declared-but-not-served);
+ *   - 200 → schema-validate every expanded child item against `nav.targetType`; a schema-invalid item FAILS;
+ *   - a transport/parse error (no determinate server response) → SKIPPED + errored (indeterminate, NOT a
+ *     failure) so a network blip can't false-fail a compliant server.
+ * The non-gating RRK expanded-item warning rides alongside on `warnings`, computed for this nav's field.
+ * Reuses buildExpandUrl by substituting the nav name into `expandField`.
+ */
+const runOneExpandNav = async (
+  serverUrl: string,
+  resource: string,
+  scenario: ExpandScenario,
+  params: TestParams,
+  nav: { readonly name: string; readonly targetType: string },
+  authToken: string,
+  requester: ODataRequester,
+  validator: ExpandItemValidator | undefined,
+): Promise<ScenarioResult> => {
+  const start = Date.now();
+  const tag = `expand-${nav.name}`;
+  const name = `$expand ${nav.name}`;
+  const navParams: TestParams = { ...params, expandField: nav.name };
+  const query = buildScenarioQuery(serverUrl, resource, scenario, navParams);
+  if (!query) {
+    // nav.name is always defined, so buildExpandUrl resolves — defensive only: an unbuildable query is
+    // UNTESTABLE (a skip), never a failure.
+    return skipResult(scenario, start, `could not build the $expand query for ${nav.name}`);
+  }
+  const assertions: AssertionResult[] = [];
+  try {
+    const reqStart = Date.now();
+    const response = await requester.request({ method: 'GET', url: query.url, authToken });
+    const requestLatency = Date.now() - reqStart;
+    const responseCheck = assertODataResponse(response, 200);
+    assertions.push(responseCheck);
+    if (!responseCheck.passed) {
+      // A declared collection nav that non-200s cannot be expanded → determinate FAIL.
+      return { tag, name, passed: false, skipped: false, assertions, duration: Date.now() - start, requestLatency, requestUrl: query.url };
+    }
+    const records = extractRecords(response.body);
+    assertions.push(validateExpandedItems(records, nav, validator));
+    const allPassed = assertions.every(a => a.passed);
+    const warnings = expandRrkWarnings(records, scenario, navParams);
+    return { tag, name, passed: allPassed, skipped: false, assertions, duration: Date.now() - start, requestLatency, requestUrl: query.url, ...(warnings.length > 0 ? { warnings } : {}) };
+  } catch (err) {
+    if (isDeadlineError(err)) throw err; // out of run budget — propagate so the run stops gracefully
+    // A transport/parse error is INDETERMINATE (no server response to fault) — SKIPPED + errored, so it never
+    // counts as a failure. Correctness rule: a compliant server must never false-fail on our network blip.
+    return { tag, name, passed: false, skipped: true, errored: true, assertions: [...assertions, { passed: false, message: `Skipped: $expand ${nav.name} errored — ${err instanceof Error ? err.message : String(err)}` }], duration: Date.now() - start, requestUrl: query.url };
+  }
+};
+
+/**
+ * Fan the single $expand catalog scenario out to one GATING result PER declared collection nav (Core 2.1.0).
+ * No collection nav on the resource ⇒ one SKIPPED result (N/A — a resource that declares no nav has nothing to
+ * expand and must never fail for it). Each nav is tested independently, so "several navs, one bad" fails
+ * exactly that nav and leaves the others passing. A run-deadline propagates to the caller's deadline handling.
+ */
+export const runExpandNavScenarios = async (
+  serverUrl: string,
+  resource: string,
+  scenario: ExpandScenario,
+  params: TestParams,
+  authToken: string,
+  requester: ODataRequester = webRequester,
+  validator?: ExpandItemValidator,
+): Promise<ReadonlyArray<ScenarioResult>> => {
+  const navs = params.expandNavs ?? [];
+  if (navs.length === 0) {
+    return [skipResult(scenario, Date.now(), 'resource declares no collection navigation property — nothing to expand (N/A)')];
+  }
+  const results: ScenarioResult[] = [];
+  for (const nav of navs) {
+    results.push(await runOneExpandNav(serverUrl, resource, scenario, params, nav, authToken, requester, validator));
+  }
+  return results;
+};
+
 /**
  * Execute the standard request→validate→assert flow for one scenario against `params`. Returns the
  * result plus `retryable`: true when the field couldn't be assessed (missing params, non-200, or an
@@ -744,6 +889,9 @@ const assertData = (
     }
 
     case 'expand':
+      // Reached only via the single-field executeStandardScenario path (kept for the RRK-warning unit tests):
+      // it asserts the 200 alone. The MAIN runner routes $expand through runExpandNavScenarios, which tests
+      // each declared collection nav and schema-validates every expanded child item against its target type.
       return { passed: true, message: 'Expand response received' };
 
     default:
@@ -1031,6 +1179,11 @@ export interface CoreResourceScenarioOptions {
   /** Skip the provider-wide scenarios (`metadata-validation` + `service-document`) — they run ONCE in the
    *  provider pass instead. Left off, they run inline as before (backward-compatible for direct callers). */
   readonly excludeProviderWide?: boolean;
+  /** Validates each expanded child item against its target entity type for the GATING 2.1.0 $expand test.
+   *  Built once per run by the SDK from the provider's metadata report (see `src/sdk/expand-schema.ts`).
+   *  Omitted when it couldn't be built — a $expand nav then gates on the 200 response alone (never a false
+   *  fail). Unused at 2.0.0 (the $expand scenario is 2.1.0-only). */
+  readonly expandValidator?: ExpandItemValidator;
 }
 
 /**
@@ -1083,6 +1236,22 @@ export const runCoreResourceScenarios = async (
         duration: 0,
         optional: scenario.optional,
       });
+      continue;
+    }
+
+    // $expand (Core 2.1.0) is GATING and tested PER declared collection nav — fan the single catalog scenario
+    // out to one result per nav (or a single N/A skip when the resource declares none). Handled here rather
+    // than inside runScenario because it yields MANY results; the run-deadline handling mirrors the generic path.
+    if (scenario.category === 'expand') {
+      try {
+        const expandResults = await runExpandNavScenarios(serverUrl, resource, scenario, params, authToken, requester, options?.expandValidator);
+        results.push(...expandResults);
+      } catch (err) {
+        if (!isDeadlineError(err)) throw err;
+        for (const remaining of scenarios.slice(i)) results.push(deadlineSkipResult(remaining));
+        deadlineReached = true;
+        break;
+      }
       continue;
     }
 

--- a/reso-certification/tests/web-api-core/expand-gating.test.ts
+++ b/reso-certification/tests/web-api-core/expand-gating.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import { resolve } from 'node:path';
+import { generateMetadataReport } from '@reso-standards/reso-metadata-utils';
+import type { MetadataReport } from '@reso-standards/reso-metadata-utils';
+import type { ODataRequester } from '../../src/test-runner/requester.js';
+import type { ODataResponse } from '../../src/test-runner/types.js';
+import type { ExpandScenario } from '../../src/web-api-core/scenarios.js';
+import type { TestParams } from '../../src/web-api-core/sampling.js';
+import {
+  runExpandNavScenarios,
+  validateExpandedItems,
+  summarizeScenarios,
+} from '../../src/web-api-core/test-runner.js';
+import { createExpandSchemaValidator } from '../../src/sdk/expand-schema.js';
+import { coreVerdict } from '../../src/sdk/core.js';
+
+// FULL Core 2.1.0 $expand gating. THE RULE (RESO standards lead): $expand is tested per declared COLLECTION
+// navigation property. No nav → N/A skip (never a failure). A declared collection nav is GATING: non-200 →
+// FAIL; 200 → schema-validate each expanded child item against its target entity type (a schema-invalid item →
+// FAIL). The RRK expanded-item warning still rides alongside, non-gating. A compliant server never false-fails.
+
+const require = createRequire(import.meta.url);
+const { getReferenceMetadata } = require(resolve(import.meta.dirname, '../../src/etl/index.cjs'));
+// A real DD 2.0 metadata report → a real legacy-backed validator. `Property` is a real resource in the report,
+// so we schema-validate expanded items against it (the nav→target wiring is what's under test, not the nav's
+// real-world semantics). AboveGradeFinishedAreaSource is a single enum with advertised values: 'Appraiser' is
+// valid, 'InvalidEnum' is a real schema-invalid fixture.
+const report = getReferenceMetadata('2.0');
+
+const expandScenario: ExpandScenario = {
+  tag: 'expand',
+  name: '$expand navigation property',
+  category: 'expand',
+  fieldParam: 'expandField',
+  minVersion: '2.1.0',
+};
+
+type Nav = { readonly name: string; readonly targetType: string };
+
+const paramsFor = (navs: ReadonlyArray<Nav>): TestParams => ({
+  resource: 'Property',
+  keyField: 'ListingKey',
+  keyValue: 'P1',
+  enumMode: 'string',
+  integerValueHigh: 0,
+  skippedTypes: [],
+  sampleComplete: true,
+  expandField: navs[0]?.name,
+  expandNavs: navs,
+});
+
+// One parent Property (ListingKey P1) whose expanded collection under `navField` is exactly `children`.
+const okExpand = (children: unknown, navField = 'Media'): ODataResponse => {
+  const body = { value: [{ ListingKey: 'P1', [navField]: children }] };
+  return { status: 200, headers: { 'odata-version': '4.01' }, body, rawBody: JSON.stringify(body) };
+};
+
+const status = (code: number): ODataResponse => ({
+  status: code,
+  headers: { 'odata-version': '4.01' },
+  body: { error: { code: String(code) } },
+  rawBody: '{}',
+});
+
+// A requester that dispatches by which nav is being expanded (matches `$expand=<nav>` in the URL).
+const requesterFor = (byNav: Readonly<Record<string, ODataResponse>>): ODataRequester => ({
+  request: async ({ url }) => {
+    const nav = Object.keys(byNav).find((n) => url.includes(`$expand=${n}`));
+    if (!nav) throw new Error(`no scripted response for ${url}`);
+    return byNav[nav];
+  },
+});
+
+// Guards the "no request should be made" cases.
+const throwingRequester: ODataRequester = {
+  request: async () => {
+    throw new Error('no request should have been issued');
+  },
+};
+
+describe('runExpandNavScenarios — no collection nav → N/A skip (never a failure)', () => {
+  it('a resource with no collection nav yields one SKIPPED result and issues no request', async () => {
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([]), 'tok', throwingRequester);
+    expect(results).toHaveLength(1);
+    expect(results[0].skipped).toBe(true);
+    expect(results[0].passed).toBe(true); // a skip renders N/A, not a failure
+    const summary = summarizeScenarios(results);
+    expect(summary.failed).toBe(0);
+    expect(summary.skipped).toBe(1);
+  });
+});
+
+describe('runExpandNavScenarios — a declared collection nav is GATING', () => {
+  it('200 + a schema-valid expanded item → PASS', async () => {
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    const req = requesterFor({ Media: okExpand([{ AboveGradeFinishedAreaSource: 'Appraiser' }]) });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', req, validator);
+    expect(results).toHaveLength(1);
+    expect(results[0].tag).toBe('expand-Media');
+    expect(results[0].passed).toBe(true);
+    expect(results[0].skipped).toBe(false);
+    expect(results[0].warnings).toBeUndefined();
+    expect(summarizeScenarios(results).passed).toBe(1);
+  });
+
+  it('a declared nav that non-200s → FAIL (declared but not expandable)', async () => {
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    const req = requesterFor({ Media: status(400) });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', req, validator);
+    expect(results[0].passed).toBe(false);
+    expect(results[0].skipped).toBe(false);
+    expect(summarizeScenarios(results).failed).toBe(1);
+  });
+
+  it('200 but a SCHEMA-INVALID expanded item → FAIL (validate the data, not just the 200)', async () => {
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    const req = requesterFor({ Media: okExpand([{ AboveGradeFinishedAreaSource: 'InvalidEnum' }]) });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', req, validator);
+    expect(results[0].passed).toBe(false);
+    expect(results[0].skipped).toBe(false);
+    expect(results[0].assertions.some((a) => !a.passed && a.message.includes('schema-invalid'))).toBe(true);
+    expect(summarizeScenarios(results).failed).toBe(1);
+  });
+
+  it('a transport error (no server response) → SKIPPED + errored, NOT a failure (indeterminate)', async () => {
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    const blip: ODataRequester = { request: async () => { throw new Error('network blip'); } };
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', blip, validator);
+    expect(results[0].skipped).toBe(true);
+    expect(results[0].errored).toBe(true);
+    expect(summarizeScenarios(results).failed).toBe(0);
+  });
+});
+
+describe('runExpandNavScenarios — the RRK warning still rides alongside, non-gating', () => {
+  it('a mismatched ResourceRecordKey on a schema-valid item → nav STILL passes, warning on .warnings', async () => {
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    // A schema-valid Media item — `ResourceRecordKey` is a real Media field, and under additionalProperties:false
+    // the item must carry ONLY advertised fields. RRK 'WRONG' ≠ parent Property ListingKey 'P1' → non-gating
+    // warning. (Validate against the Media target the expanded child actually is — matching the RRK doc: an
+    // expanded Media's ResourceRecordKey should echo the parent Property's ListingKey.)
+    const req = requesterFor({ Media: okExpand([{ ResourceRecordKey: 'WRONG' }]) });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Media' }]), 'tok', req, validator);
+    expect(results[0].passed).toBe(true); // 200 + schema-valid → passes despite the RRK mismatch
+    expect(results[0].warnings?.[0]).toContain('WRONG');
+    expect(summarizeScenarios(results).failed).toBe(0); // the warning is inert to the verdict
+  });
+});
+
+describe('runExpandNavScenarios — several navs, one bad fails exactly that nav', () => {
+  it('Media (valid) passes and Rooms (schema-invalid) fails; the failure counts in the verdict tally', async () => {
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    const req = requesterFor({
+      Media: okExpand([{ AboveGradeFinishedAreaSource: 'Appraiser' }], 'Media'),
+      Rooms: okExpand([{ AboveGradeFinishedAreaSource: 'InvalidEnum' }], 'Rooms'),
+    });
+    const results = await runExpandNavScenarios(
+      'http://x',
+      'Property',
+      expandScenario,
+      paramsFor([{ name: 'Media', targetType: 'Property' }, { name: 'Rooms', targetType: 'Property' }]),
+      'tok',
+      req,
+      validator,
+    );
+    expect(results).toHaveLength(2);
+    const media = results.find((r) => r.tag === 'expand-Media')!;
+    const rooms = results.find((r) => r.tag === 'expand-Rooms')!;
+    expect(media.passed).toBe(true);
+    expect(rooms.passed).toBe(false);
+
+    const summary = summarizeScenarios(results);
+    expect(summary.passed).toBe(1);
+    expect(summary.failed).toBe(1); // GATING: an expand failure is a real failure now
+    // And the run verdict derived from those counts is `failed` (the failure is not softened to incomplete).
+    expect(coreVerdict({ totalFailed: summary.failed, coverageFailed: false, deadlineReached: false })).toBe('failed');
+  });
+});
+
+describe('validateExpandedItems — the data-validation unit', () => {
+  const nav: Nav = { name: 'Media', targetType: 'Property' };
+  const parents = (children: unknown): ReadonlyArray<Record<string, unknown>> => [{ ListingKey: 'P1', Media: children }];
+
+  it('no validator (couldn’t be built this run) → PASS on the 200 alone (never a false fail)', () => {
+    const a = validateExpandedItems(parents([{ AboveGradeFinishedAreaSource: 'InvalidEnum' }]), nav, undefined);
+    expect(a.passed).toBe(true);
+  });
+
+  it('no expanded items → PASS (nothing to schema-validate)', async () => {
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    expect(validateExpandedItems(parents([]), nav, validator).passed).toBe(true);
+    expect(validateExpandedItems([{ ListingKey: 'P1' }], nav, validator).passed).toBe(true); // nav absent
+  });
+
+  it('a schema-invalid item → FAIL naming the offending item', async () => {
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    const a = validateExpandedItems(parents([{ AboveGradeFinishedAreaSource: 'InvalidEnum' }]), nav, validator);
+    expect(a.passed).toBe(false);
+    expect(a.message).toContain('schema-invalid');
+  });
+});
+
+describe('createExpandSchemaValidator — the legacy-backed item validator', () => {
+  it('a valid item → valid; a schema-invalid item → invalid with error messages', async () => {
+    const v = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    expect(v).toBeDefined();
+    expect(v!.validate({ AboveGradeFinishedAreaSource: 'Appraiser' }, 'Property').valid).toBe(true);
+    const bad = v!.validate({ AboveGradeFinishedAreaSource: 'InvalidEnum' }, 'Property');
+    expect(bad.valid).toBe(false);
+    expect(bad.errors.length).toBeGreaterThan(0);
+  });
+
+  it('an unadvertised field on a KNOWN target → invalid (additionalProperties:false, DD/Core mode)', async () => {
+    const v = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    const bad = v!.validate({ AboveGradeFinishedAreaSource: 'Appraiser', DefinitelyNotAPropertyField: 'x' }, 'Property');
+    expect(bad.valid).toBe(false);
+    expect(bad.errors.some((e) => e.includes('advertised in the metadata'))).toBe(true);
+  });
+
+  it('an unknown target type → treated VALID (indeterminate, never a false fail)', async () => {
+    const v = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    expect(v!.validate({ Anything: 'x' }, 'NoSuchResourceType').valid).toBe(true);
+  });
+});
+
+// The REAL production path: a provider-style EDMX → generateMetadataReport → createExpandSchemaValidator, then
+// validate genuine expanded items. Proves the DD/Core policy end-to-end (isRCF:false, additionalProperties:false,
+// the ignoreEnumerations exemptions, the totalErrors gate) against the metadata shape the runner actually builds
+// from (`src/sdk/core.ts` calls generateMetadataReport before this validator), not the DD reference alone.
+const PROVIDER_EDMX = `<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="org.reso.metadata">
+      <EntityType Name="Media">
+        <Key><PropertyRef Name="MediaKey"/></Key>
+        <Property Name="MediaKey" Type="Edm.String" MaxLength="255" Nullable="false"/>
+        <Property Name="ShortText" Type="Edm.String" MaxLength="5"/>
+        <Property Name="Order" Type="Edm.Int64"/>
+        <Property Name="MediaCategory" Type="org.reso.metadata.enums.MediaCategory"/>
+        <Property Name="ImageSizeDescription" Type="org.reso.metadata.enums.ImageSizeDescription"/>
+        <Property Name="Features" Type="Collection(org.reso.metadata.enums.Feature)" Nullable="false"/>
+      </EntityType>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="org.reso.metadata.enums">
+      <EnumType Name="MediaCategory"><Member Name="Photo"/><Member Name="Video"/></EnumType>
+      <EnumType Name="ImageSizeDescription"><Member Name="Thumbnail"/></EnumType>
+      <EnumType Name="Feature"><Member Name="Pool"/><Member Name="Garage"/></EnumType>
+    </Schema>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="ODataService">
+      <EntityContainer Name="Container"><EntitySet Name="Media" EntityType="org.reso.metadata.Media"/></EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>`;
+
+// The endorsement carries the full semver (2.1.0); the exemptions file is keyed by DD major.minor (2.1).
+const PROVIDER_VERSION = '2.1.0';
+// Mirror the shape of schema-validation-settings.json for the one exempt Media field the fixture exercises.
+const EXEMPTIONS = { '2.1': { Media: { ImageSizeDescription: { ignoreEnumerations: true } } } };
+
+const buildProviderValidator = (validationConfig?: Readonly<Record<string, unknown>>) =>
+  createExpandSchemaValidator({
+    metadataReport: generateMetadataReport(PROVIDER_EDMX, PROVIDER_VERSION),
+    version: PROVIDER_VERSION,
+    validationConfig,
+  });
+
+describe('createExpandSchemaValidator — provider path (EDMX → generateMetadataReport → validator)', () => {
+  it('a valid item (incl. a populated enum collection) → passes with 0 errors', async () => {
+    const v = await buildProviderValidator(EXEMPTIONS);
+    const r = v!.validate({ MediaKey: 'm1', MediaCategory: 'Photo', Order: 3, ShortText: 'abc', Features: ['Pool', 'Garage'] }, 'Media');
+    expect(r.valid).toBe(true);
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('a bad enum value on a non-exempt field → FAIL', async () => {
+    const v = await buildProviderValidator(EXEMPTIONS);
+    const r = v!.validate({ MediaKey: 'm1', MediaCategory: 'NotAdvertised' }, 'Media');
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes('advertised in the metadata'))).toBe(true);
+  });
+
+  it('a number served as a JSON string for an Int64 → FAIL', async () => {
+    const v = await buildProviderValidator(EXEMPTIONS);
+    const r = v!.validate({ MediaKey: 'm1', Order: '3' }, 'Media');
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes('MUST be integer'))).toBe(true);
+  });
+
+  it('a string exceeding the provider’s declared maxLength → FAIL (isRCF:false: advertised, not suggested)', async () => {
+    const v = await buildProviderValidator(EXEMPTIONS);
+    const r = v!.validate({ MediaKey: 'm1', ShortText: 'waytoolong' }, 'Media');
+    expect(r.valid).toBe(false);
+    // DD/Core mode wording — a hard "MUST … advertised length", NOT the RCF "SHOULD … suggested length" warning.
+    expect(r.errors.some((e) => e.includes('advertised length'))).toBe(true);
+    expect(r.errors.some((e) => e.includes('suggested length'))).toBe(false);
+  });
+
+  it('null for a (non-nullable) collection field → FAIL', async () => {
+    const v = await buildProviderValidator(EXEMPTIONS);
+    const r = v!.validate({ MediaKey: 'm1', Features: null }, 'Media');
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes('MUST be array'))).toBe(true);
+  });
+
+  it('a field absent from the provider metadata → FAIL (additionalProperties:false)', async () => {
+    const v = await buildProviderValidator(EXEMPTIONS);
+    const r = v!.validate({ MediaKey: 'm1', UndeclaredField: 'x' }, 'Media');
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes('advertised in the metadata'))).toBe(true);
+  });
+
+  it('a novel value on an ignoreEnumerations field → does NOT fail (downgraded to a warning)', async () => {
+    const v = await buildProviderValidator(EXEMPTIONS);
+    const r = v!.validate({ MediaKey: 'm1', ImageSizeDescription: 'HugeSize' }, 'Media');
+    expect(r.valid).toBe(true); // the exemption converts the unadvertised-enum error into a warning
+    expect(r.errors).toHaveLength(0);
+  });
+
+  it('WITHOUT the exemption the SAME novel value fails — proving the exemption is what downgrades it', async () => {
+    const v = await buildProviderValidator({}); // no exemptions threaded
+    const r = v!.validate({ MediaKey: 'm1', ImageSizeDescription: 'HugeSize' }, 'Media');
+    expect(r.valid).toBe(false);
+    expect(r.errors.some((e) => e.includes('advertised in the metadata'))).toBe(true);
+  });
+
+  it('a schema that cannot be built → validator is undefined; the nav then gates on the 200 alone', async () => {
+    // A report the legacy generator cannot project (returns null) → construction fails determinately.
+    const brokenReport = {
+      description: '', version: '2.1', generatedOn: '', resources: [], models: [],
+      fields: [], lookups: undefined, actions: [], functions: [],
+    } as unknown as MetadataReport;
+    // The legacy generator logs the caught projection error; silence that ONE expected line to keep output clean.
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const v = await createExpandSchemaValidator({ metadataReport: brokenReport, version: PROVIDER_VERSION });
+    spy.mockRestore();
+    expect(v).toBeUndefined();
+    // An undefined validator makes the nav gate on the 200 alone — a determinate tooling failure, never a
+    // silent per-item pass (validateExpandedItems short-circuits to passed:true without inspecting items).
+    const parent = [{ ListingKey: 'P1', Media: [{ MediaCategory: 'anything' }] }];
+    expect(validateExpandedItems(parent, { name: 'Media', targetType: 'Media' }, v).passed).toBe(true);
+  });
+});

--- a/reso-certification/tests/web-api-core/optional-tests.test.ts
+++ b/reso-certification/tests/web-api-core/optional-tests.test.ts
@@ -111,20 +111,24 @@ describe('classification: string functions optional, Core required', () => {
     }
   });
 
-  it('only string-function and $expand scenarios carry optional', () => {
-    // $expand is optional (non-gating): it fires to activate the RRK expanded-item warning, but a server
-    // that doesn't support expanding the chosen nav renders "Not Supported" rather than failing the cert.
+  it('$expand is NOT optional — it is GATING per declared collection nav (Core 2.1.0)', () => {
+    // Reworked: $expand no longer renders "Not Supported". A declared collection nav that cannot be expanded
+    // (or returns a schema-invalid expanded item) is a real Core failure; a resource with no collection nav
+    // simply skips. So the catalog entry carries no `optional` flag.
+    expect(byTag('expand')?.optional).toBeFalsy();
+  });
+
+  it('only string-function scenarios carry optional', () => {
     for (const s of allScenarios) {
-      if (s.optional) expect(['string-function', 'expand']).toContain(s.category);
+      if (s.optional) expect(s.category).toBe('string-function');
     }
   });
 
-  it('a failed $expand scenario is non-gating — Not Supported, contributes 0 to the failed count', () => {
-    // A server that returns non-200 for the chosen expansion must NOT fail Core cert: as an optional
-    // scenario, a determinate expand failure renders "Not Supported" and adds nothing to the failed tally.
-    const expandFailed = r({ tag: 'expand', passed: false, skipped: false, optional: true });
-    expect(optionalOutcome(expandFailed)).toBe('Not Supported');
-    expect(summarizeScenarios([expandFailed]).failed).toBe(0);
+  it('a failed $expand nav is GATING — a determinate failure contributes to the failed count', () => {
+    // A declared collection nav that non-200s or returns a schema-invalid expanded item MUST fail Core: the
+    // per-nav result carries no `optional` flag, so summarizeScenarios counts it as a real (required) failure.
+    const expandFailed = r({ tag: 'expand-Media', passed: false, skipped: false });
+    expect(summarizeScenarios([expandFailed]).failed).toBe(1);
   });
 });
 


### PR DESCRIPTION
## What this does

Converts the Core 2.1.0 `$expand` check from **non-gating sampling** (landed on beta.7) to a **GATING** check per declared collection navigation (RCP-039). Each expanded child item is schema-validated against its target entity type using the legacy validator in **DD/Core mode** — a Web API Core provider MUST advertise everything it serves.

Stacked on **#278** (base `beta.7`); the diff here is a single commit (`1a05721`).

## The validation policy (DD/Core, not RCF)

Confirmed against `reso-certification-utils` `main` and settled point-by-point:

| Axis | Setting | Effect |
|---|---|---|
| `isRCF` | **false** (DD/Core) — *derived*, not flagged | An expanded item carries no `@reso.context`, so the legacy validator's `isRCF()` resolves false. A `maxLength` overflow is a hard **"MUST … advertised length"** error, not the RCF **"SHOULD … suggested length"** warning. |
| `additionalProperties` | **false** | A field not advertised in the provider's metadata **fails**. |
| `schema-validation-settings.json` | respected | `ignoreEnumerations` exemptions apply (version normalized `2.1.0`→`2.1` for the lookup); an exempt field's novel value downgrades to a **warning**, not a failure. |
| gate | `stats.totalErrors === 0` | Warnings never fail a nav. |

Fail cases (all proven by tests): bad enum value (non-exempt), number served as a JSON string for an Int64/Decimal, `maxLength` overflow, `null` for a collection field, unadvertised field.

## Conservative degrade (no silent pass)

The validator is built **once** per run from the provider's metadata report (generated from the already-fetched EDMX — no extra request). If the schema cannot be built or compiled, the validator is `undefined` and the nav **gates on the observable 200 alone** — a determinate tooling failure never masquerades as per-item "valid". Construction warms the ajv compile of **one representative resource** so a wholesale compile failure surfaces there (→ `undefined`). A compile failure isolated to a single *other* resource is not reachable through `generateMetadataReport` (the generator emits compilable schemas — even a dangling enum ref compiles, verified), and warming every resource up front would cost O(resources) compiles at construction (41 for the full DD reference), so we deliberately don't — an earlier warm-all draft was reverted after it blew the 5s per-test CI timeout.

## Scope

- A resource with **no** declared collection nav simply **skips**.
- A declared nav that non-200s **or** returns a schema-invalid item is a **real Core failure** (contributes to the failed count; carries no `optional` flag).
- **2.0.0 is untouched** — it has no `$expand` scenario, so the validator is only built for 2.1.0.
- The RRK non-gating warning, the served-resource carve-out, and the gating mechanics from #278 are unchanged.

## Tests

8 new provider-path tests (`expand-gating.test.ts`) build from a **provider-style EDMX → `generateMetadataReport` → validator** (not the DD reference alone) and prove each fail/warn/valid case end-to-end, including the `ignoreEnumerations` downgrade and the compile-failure→`undefined` degrade. Full package suite green (1045 passed | 2 expected-fail pre-existing).

## Adversarial re-review

Ran a false-fail + false-pass panel on the revised gate. Reconciliation:

- **Warm-up hole (real, fixed here):** the compile warm-up covered only `fields[0]`'s resource; now warms every distinct resource so a per-resource compile failure degrades the whole validator conservatively.
- **Base-type inheritance false-fail (out of scope → follow-up ticket):** `additionalProperties:false` would false-fail a provider whose entity type uses OData `BaseType` inheritance *if* `generateMetadataReport` does not flatten inherited fields. That projection feeds the existing DD gate equally, so it is pre-existing and shared — not introduced here — and RESO EDMX is flat, so it is latent. Tracked in #281.

## Follow-ups (not in this PR)

- Base-type inheritance flattening in the shared `generateMetadataReport` projection (#281 — latent; affects DD gate + expand equally).
