### PR TITLE
cert 0.10.5 — bundle-static legacy/DD loads (#102) + land Lookup Resource work on mainline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ The browser UI, Electron desktop shell, CORS proxy and test-data generator moved
 ## Common Commands
 
 ```bash
-npm test                    # Run all tests (1,944 across 8 packages)
+npm test                    # Run all tests (1,963 across 8 packages)
 npm run test:server         # Run server tests only
 npm run test:validation     # Run validation tests only
 npm run lint                # Biome lint check

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RESO Tools
 
-![Tests](https://img.shields.io/badge/tests-1944%20passed-brightgreen)
+![Tests](https://img.shields.io/badge/tests-1963%20passed-brightgreen)
 ![Compliance](https://img.shields.io/badge/RESO%20compliance-4%2F4%20suites-blue)
 [![Download](https://img.shields.io/github/v/release/RESOStandards/reso-tools?label=download&color=blue)](https://github.com/RESOStandards/reso-tools/releases/latest)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,20 @@
 
 ---
 
+## reso-certification 0.10.4 – 2026-09-02
+
+A published-package patch to `reso-certification` – no monorepo release. Consumers on `^0.10.0` pick it up automatically; no other package changed (`reso-client` stays 0.2.2, `reso-common` 0.2.1).
+
+### `reso-certification` 0.10.4 – Web API Core 2.1.0 Lookup Resource certification
+
+- **Exhaustive `/Lookup` fetch by `LookupName`.** The served Lookup Resource is paged all the way through for each queried `LookupName` (`@odata.nextLink` followed with no page cap), so value presence reflects the provider's entire catalogue rather than the first page – there is no server-side value filter on `/Lookup` yet. A per-run cache keyed by `LookupName` dedupes the fetch across fields that share an enumeration.
+- **Value presence across all three wire forms.** A served value is matched against the union of `LookupValue`, `StandardLookupValue`, and `LegacyODataValue`, so a provider serving any legal form of a catalogued value is not false-failed.
+- **Gating StandardLookupValue validity.** Each declared `StandardLookupValue` is validated against the Data Dictionary standard set for the field's DD type – never the provider's arbitrary `LookupName` – with an any-DD-enum fallback for open enumerations that carry no standard set. A non-standard declared value fails Core.
+- **Both gates honor `ignoreEnumerations`.** The committee-approved `schema-validation-settings.json` exemption (keyed by DD major.minor version) is threaded into both the presence and validity checks, so an exempt open or local field is never false-failed.
+- **Tests:** new coverage for exhaustive paging, the tri-form presence union, the field-type DD-standard join, and the ignore-list exemption. Full monorepo suite now 1,963 passing across 8 packages.
+
+---
+
 ## reso-certification 0.10.3 – 2026-09-01
 
 A published-package patch to `reso-certification` – no monorepo release. Consumers on `^0.10.0` pick it up automatically; no other package changed (`reso-client` stays 0.2.2, `reso-common` 0.2.1).

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,18 @@
 
 ---
 
+## reso-certification 0.10.5 – 2026-09-02
+
+A published-package patch to `reso-certification` – no monorepo release. Consumers on `^0.10.0` pick it up automatically; behavior-preserving for the CLI and cert-backend (no test-count change), and no other package changed.
+
+### `reso-certification` 0.10.5 – bundle-static legacy-schema + DD-reference loads (reso-tools-private #102)
+
+- **Desktop cert-worker fix.** The legacy JSON-schema module and the DD reference JSON were loaded via a computed `createRequire` path and a template-literal `require()`, which esbuild could not statically follow — so in the packaged desktop app they did not load, and Web API Core 2.1.0 `$expand` per-item schema validation silently degraded to "unavailable" (the nav gated on the HTTP 200 alone). Both loads are now bundle-static: a lazy dynamic `import()` with a literal specifier for the legacy module, and a per-version `switch` for the DD reference JSON, so esbuild inlines them into the cert-worker bundle.
+- **Behavior-preserving** for the CLI and cert-backend (they run from `dist`, where the old paths resolved); full cert suite green (1,064 passed / 2 expected-fail). The desktop bundle now inlines the legacy schema and all three DD JSONs, verified by a new runtime load smoke in the bundler (reso-tools-private).
+- Unsupported-version metadata lookups now **fail loud** (log) instead of silently returning empty.
+
+---
+
 ## reso-certification 0.10.4 – 2026-09-02
 
 A published-package patch to `reso-certification` – no monorepo release. Consumers on `^0.10.0` pick it up automatically; no other package changed (`reso-client` stays 0.2.2, `reso-common` 0.2.1).

--- a/package-lock.json
+++ b/package-lock.json
@@ -5626,7 +5626,7 @@
     },
     "reso-certification": {
       "name": "@reso-standards/reso-certification",
-      "version": "0.10.4",
+      "version": "0.10.5",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@reso-standards/reso-client": "^0.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5626,7 +5626,7 @@
     },
     "reso-certification": {
       "name": "@reso-standards/reso-certification",
-      "version": "0.10.3",
+      "version": "0.10.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@reso-standards/reso-client": "^0.2.0",

--- a/reso-certification/README.md
+++ b/reso-certification/README.md
@@ -198,7 +198,7 @@ docker compose --profile compliance-core up --build \
 ```bash
 npm install
 npm run build
-npm test        # ~1045 tests
+npm test        # ~1064 tests
 npm run dev     # Watch mode
 ```
 

--- a/reso-certification/package.json
+++ b/reso-certification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reso-standards/reso-certification",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",

--- a/reso-certification/package.json
+++ b/reso-certification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reso-standards/reso-certification",
-  "version": "0.10.4",
+  "version": "0.10.5",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",

--- a/reso-certification/src/etl/common.cjs
+++ b/reso-certification/src/etl/common.cjs
@@ -68,7 +68,21 @@ const getSimpleDataType = (type, isCollection) => {
  * @param {String} version the version of the metadata to fetch, for example "1.7" (current default)
  * @returns the latest copy of the metadata file at the URL in the description
  */
-const getMetadata = (version = CURRENT_DD_VERSION) => require(`@reso-standards/reso-common/reference-metadata/dd-${version}.json`) || {};
+const getMetadata = (version = CURRENT_DD_VERSION) => {
+  // STATIC specifiers (one literal require per version) so the esbuild cert-worker bundle inlines each
+  // reference JSON — a template-literal require escapes static analysis and fails in the packaged app
+  // (reso-tools-private #102). Add a case when a new DD version lands.
+  switch (version) {
+    case '1.7': return require('@reso-standards/reso-common/reference-metadata/dd-1.7.json') || {};
+    case '2.0': return require('@reso-standards/reso-common/reference-metadata/dd-2.0.json') || {};
+    case '2.1': return require('@reso-standards/reso-common/reference-metadata/dd-2.1.json') || {};
+    default:
+      // Fail LOUD (match getReferenceMetadata): an unsupported/unmapped version returning empty would read
+      // downstream as "no reference data" and silently misclassify every provider value as non-standard.
+      console.error(`Cannot load metadata for version '${version}'! Unsupported version — no reference data.`);
+      return {};
+  }
+};
 
 /**
  *

--- a/reso-certification/src/etl/index.cjs
+++ b/reso-certification/src/etl/index.cjs
@@ -3,8 +3,18 @@ const { processLookupResourceMetadata, processLookupResourceMetadataFiles } = re
 const getReferenceMetadata = (version = '2.1') => {
   try {
     // DD reference metadata is owned by reso-common (single source; refreshed via
-    // `npm run update:dd-reference`). Consumed here via its subpath export.
-    return require(`@reso-standards/reso-common/reference-metadata/dd-${version}.json`);
+    // `npm run update:dd-reference`). Consumed via its subpath export with STATIC specifiers
+    // (one literal require per supported version) so the esbuild cert-worker bundle inlines each
+    // JSON — a template-literal require escapes static analysis and fails in the packaged app
+    // (reso-tools-private #102). Add a case when a new DD version lands.
+    switch (version) {
+      case '1.7': return require('@reso-standards/reso-common/reference-metadata/dd-1.7.json');
+      case '2.0': return require('@reso-standards/reso-common/reference-metadata/dd-2.0.json');
+      case '2.1': return require('@reso-standards/reso-common/reference-metadata/dd-2.1.json');
+      default:
+        console.error(`Cannot load reference metadata for version '${version}'! Unsupported version.`);
+        return null;
+    }
   } catch (err) {
     console.error(`Cannot load reference metadata for version '${version}'!. ${err ? `Error: ${err}` : ''}`);
     return null;

--- a/reso-certification/src/sdk/core.ts
+++ b/reso-certification/src/sdk/core.ts
@@ -8,10 +8,10 @@
 import { resolveAuthToken } from '../test-runner/auth.js';
 import { fetchMetadata, loadMetadataFromFile, parseMetadataXml, getEntityType, persistMetadataXml } from '../test-runner/metadata.js';
 import { validateMetadata, formatValidationSummary, collectValidationErrors } from './metadata-validation.js';
-import { buildStandardMap, resolveTestParams, WELL_KNOWN_RESOURCES } from '../web-api-core/index.js';
+import { buildStandardMap, createLookupCache, resolveTestParams, WELL_KNOWN_RESOURCES } from '../web-api-core/index.js';
 import { runCoreResourceScenarios, runProviderScenarios, summarizeScenarios, type ResourceTestReport } from '../web-api-core/test-runner.js';
 import { resolveServingDecision } from '../web-api-core/serving.js';
-import { createExpandSchemaValidator } from './expand-schema.js';
+import { createExpandSchemaValidator, isEnumerationIgnored, loadValidationConfig } from './expand-schema.js';
 import { generateMetadataReport } from '@reso-standards/reso-metadata-utils';
 import { isDeadlineError, runSettled } from '@reso-standards/reso-client';
 import { createCertSession, createSessionRequester } from '../test-runner/requester.js';
@@ -255,6 +255,19 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
     const version = ctx.version;
     // Standard map (DD reference) built once per run — field/value membership for standard-first selection.
     const standardMap = buildStandardMap(version);
+
+    // Lookup Resource validation dependencies, built ONCE per run and shared across resources:
+    //   - a cache keyed by LookupName so a LookupName referenced by several fields is fetched/paged once;
+    //   - the committee-approved ignore-enumerations predicate (schema-validation-settings.json).
+    // The cache resolves a (resource, field) to its provider LookupName off a per-resource registry populated
+    // from each resource's sampled `lookupNameByField` as params resolve below — never a module-level global.
+    const lookupNamesByResource = new Map<string, Readonly<Record<string, string>>>();
+    const lookupCache = createLookupCache({
+      lookupNameFor: (resource, field) => lookupNamesByResource.get(resource)?.[field],
+    });
+    const validationConfig = await loadValidationConfig();
+    const isEnumIgnored = (resource: string, field: string): boolean =>
+      isEnumerationIgnored(validationConfig, version, resource, field);
     // One resilience session shared across the whole run (see createCertSession for the full
     // rationale): cert retries only 429/503 (twice), records every other response and moves on,
     // with no breaker or pacing and a 15-min per-request timeout. A total run budget bounds the
@@ -337,6 +350,10 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
         });
         if (params === null) return deadlineResourceReport(resource);
 
+        // Register this resource's field → provider LookupName map so the shared cache can resolve
+        // (resource, field) → LookupName for the Lookup Resource presence + SLV-validity checks.
+        lookupNamesByResource.set(resource, params.lookupNameByField ?? {});
+
         if (params.skippedTypes.length > 0) {
           onProgress({
             step: 'Run Core scenarios',
@@ -358,9 +375,10 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
           ctx.authToken!,
           version,
           requester,
-          // Provider-wide scenarios already ran once above; thread the detected version for the 4.01 gate and
-          // the once-per-run $expand schema validator (undefined at 2.0.0 / if it couldn't be built).
-          { excludeProviderWide: true, odataVersion: provider.odataVersion, ...(expandValidator ? { expandValidator } : {}) },
+          // Provider-wide scenarios already ran once above; thread the detected version for the 4.01 gate, the
+          // once-per-run $expand schema validator (undefined at 2.0.0 / if it couldn't be built), and the
+          // shared Lookup Resource cache + standard map + ignore predicate.
+          { excludeProviderWide: true, odataVersion: provider.odataVersion, ...(expandValidator ? { expandValidator } : {}), lookupCache, standardMap, isEnumerationIgnored: isEnumIgnored },
         );
 
         onProgress({

--- a/reso-certification/src/sdk/expand-schema.ts
+++ b/reso-certification/src/sdk/expand-schema.ts
@@ -6,10 +6,12 @@
  * target entity type. The Web API Core runner consumes it through the {@link ExpandItemValidator} interface and
  * never touches the schema machinery itself.
  *
- * The legacy module is loaded via `createRequire` because it is CommonJS (and pulls in ajv + the ETL reference
- * bridge) — the same interop pattern `src/cli/schema-command.ts` uses. We call the legacy utilities DIRECTLY
- * (`generateJsonSchema` / `validate`) rather than the CLI's typed wrappers to avoid an sdk → cli layering
- * inversion (cli already depends on sdk).
+ * The legacy module is loaded lazily via a dynamic `import()` with a LITERAL specifier so the esbuild
+ * cert-worker bundle inlines it — a computed `createRequire` path escapes static analysis and fails to load
+ * in the packaged app (reso-tools-private #102); the lazy `import()` also defers the ajv + ETL-reference cost
+ * until the $expand path actually runs. We call the legacy utilities DIRECTLY (`generateJsonSchema` /
+ * `validate`) rather than the CLI's typed wrappers to avoid an sdk → cli layering inversion (cli already
+ * depends on sdk).
  *
  * ── Validation policy (mirrors DD/Core testing exactly — NOT RCF mode) ──
  *  - `additionalProperties: false` when generating the schema: a field on the expanded item that the provider's
@@ -28,13 +30,10 @@
 
 import { existsSync } from 'node:fs';
 import { readFile } from 'node:fs/promises';
-import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { MetadataReport, MetadataReportField } from '@reso-standards/reso-metadata-utils';
 import type { ExpandItemValidator } from '../web-api-core/test-runner.js';
-
-const requireLegacy = createRequire(import.meta.url);
 
 /** The committed, committee-approved exemptions file (never modified). Keyed by DD major.minor. */
 const SETTINGS_FILE = 'schema-validation-settings.json';
@@ -61,8 +60,17 @@ const isLegacySchemaModule = (m: unknown): m is LegacySchemaModule =>
   typeof (m as Record<string, unknown>).generateJsonSchema === 'function' &&
   typeof (m as Record<string, unknown>).validate === 'function';
 
-const loadLegacySchemaModule = (): LegacySchemaModule => {
-  const raw: unknown = requireLegacy(resolve(dirname(fileURLToPath(import.meta.url)), '../legacy/lib/schema/index.js'));
+const loadLegacySchemaModule = async (): Promise<LegacySchemaModule> => {
+  // Static specifier so esbuild bundles the legacy module (+ its graph) into the cert-worker bundle;
+  // a computed createRequire path escapes static analysis and fails in the packaged app (reso-tools-private #102).
+  // Dynamic import() keeps the load lazy — the legacy module pulls in ajv + the DD reference, loaded only
+  // when the $expand schema path actually runs, not at SDK import.
+  // The specifier MUST stay a literal in the call so esbuild statically follows + inlines the module
+  // (a variable specifier would escape the bundle — the very bug this fixes). `as string` only widens
+  // the literal's type so tsc treats it as a runtime dynamic import of the untyped legacy CJS module
+  // (no implicit-any TS7016); the assertion is erased in the emitted JS. Shape runtime-guarded below.
+  const mod: unknown = await import('../legacy/lib/schema/index.js' as string);
+  const raw = (mod as { readonly default?: unknown }).default ?? mod;
   if (!isLegacySchemaModule(raw)) {
     throw new Error('Failed to load the legacy schema module — expected generateJsonSchema / validate exports.');
   }
@@ -223,7 +231,7 @@ const buildExpandSchema = async (
 export const createExpandSchemaValidator = async (
   input: CreateExpandSchemaValidatorInput,
 ): Promise<ExpandItemValidator | undefined> => {
-  const mod = loadLegacySchemaModule();
+  const mod = await loadLegacySchemaModule();
   const ddVersion = toDataDictionaryVersion(input.version);
   const validationConfig = input.validationConfig ?? (await loadValidationConfig());
 

--- a/reso-certification/src/sdk/expand-schema.ts
+++ b/reso-certification/src/sdk/expand-schema.ts
@@ -96,7 +96,7 @@ const resolveSettingsPath = (): string | undefined => {
 };
 
 /** Load the exemptions (`ignoreEnumerations`) config; `{}` (no exemptions) when the file is absent/unreadable. */
-const loadValidationConfig = async (): Promise<Record<string, unknown>> => {
+export const loadValidationConfig = async (): Promise<Record<string, unknown>> => {
   const path = resolveSettingsPath();
   if (!path) return {};
   try {
@@ -104,6 +104,28 @@ const loadValidationConfig = async (): Promise<Record<string, unknown>> => {
   } catch {
     return {};
   }
+};
+
+/** Narrow `unknown` to a plain object for safe nested lookups (no `any`). */
+const asRecord = (v: unknown): Record<string, unknown> | undefined =>
+  typeof v === 'object' && v !== null ? (v as Record<string, unknown>) : undefined;
+
+/**
+ * True when a resource+field is on the committee-approved ignore-enumerations list (a closed enum whose
+ * unadvertised/local values are permitted). The committed `schema-validation-settings.json` is keyed
+ * DD-major.minor → resource → field → `{ ignoreEnumerations: true }`, so the endorsement's full semver
+ * (`2.1.0`) is normalized to `2.1` before the lookup. `config` is the object {@link loadValidationConfig}
+ * returns — pass it once per run and bind the predicate.
+ */
+export const isEnumerationIgnored = (
+  config: Readonly<Record<string, unknown>>,
+  version: string,
+  resource: string,
+  field: string,
+): boolean => {
+  const ddVersion = toDataDictionaryVersion(version);
+  const fieldNode = asRecord(asRecord(asRecord(config[ddVersion])?.[resource])?.[field]);
+  return fieldNode?.ignoreEnumerations === true;
 };
 
 /** A `Collection(...)` type in the metadata report (e.g. `Collection(org.reso.metadata.enums.Feature)`). */

--- a/reso-certification/src/web-api-core/index.ts
+++ b/reso-certification/src/web-api-core/index.ts
@@ -11,12 +11,14 @@ export { resolveTestParams, detectEnumMode, WELL_KNOWN_RESOURCES, REQUIRED_RESOU
 export type { TestParams, EnumMode } from './sampling.js';
 export { buildStandardMap, buildStandardMapFrom } from './standard-map.js';
 export type { StandardMap } from './standard-map.js';
+export { createLookupCache } from './lookup-cache.js';
+export type { LookupCache } from './lookup-cache.js';
 export { selectEnumCandidates, isSingleRep, isMultiRep } from './enum-selection.js';
 export type { EnumCandidate } from './enum-selection.js';
 export { buildScenarioQuery } from './queries.js';
 export type { QuerySpec } from './queries.js';
-export { runCoreResourceScenarios, runProviderScenarios, isProviderWideScenario, summarizeScenarios, runExpandNavScenarios, validateExpandedItems } from './test-runner.js';
-export type { ScenarioResult, ResourceTestReport, TypeCoverage, ProviderScenariosResult, CoreResourceScenarioOptions, ExpandItemValidator, ExpandItemValidation } from './test-runner.js';
+export { runCoreResourceScenarios, runProviderScenarios, isProviderWideScenario, summarizeScenarios, runExpandNavScenarios, validateExpandedItems, lookupResourcePresence, lookupResourceSlvValidity } from './test-runner.js';
+export type { ScenarioResult, ResourceTestReport, TypeCoverage, ProviderScenariosResult, CoreResourceScenarioOptions, ExpandItemValidator, ExpandItemValidation, LookupResourceContext } from './test-runner.js';
 export { parseServiceDocument, servedPresence, declaredPresence, resolveServingDecision } from './serving.js';
 export type { Presence, ServingDecision } from './serving.js';
 export {

--- a/reso-certification/src/web-api-core/lookup-cache.ts
+++ b/reso-certification/src/web-api-core/lookup-cache.ts
@@ -1,0 +1,85 @@
+/**
+ * Per-run cache of provider Lookup Resource rows, keyed by the provider's LookupName.
+ *
+ * The Web API Core Lookup Resource scenario (RCP-032/039) fetches EVERY `/Lookup` row for a field's LookupName
+ * to prove the field's sampled values are published there. Many fields across many resources share ONE
+ * LookupName (the Lookup Resource is deliberately shared), so keying the cache by LookupName lets a second
+ * field that references an already-fetched LookupName reuse those rows instead of re-paging the whole enum —
+ * the cache-hit win. Scope is ONE run: the cache is created per run in `sampleAndTest` and threaded down, never
+ * a module-level global, so no run ever sees another run's stale rows.
+ *
+ * A row's value is polymorphic across THREE legal wire forms — the human `LookupValue`, the DD-standard
+ * display `StandardLookupValue`, and the machine `LegacyODataValue` — and a provider may serve a data value as
+ * any of them, so membership unions all three. `toStandard` maps any form back to the row's StandardLookupValue.
+ *
+ * Mirrors `standard-map.ts`: a plain object of closures over a captured `Map`, the local mutable state scoped
+ * to the builder and read-only through the returned interface — never leaked.
+ */
+
+/** A parsed /Lookup row. The three columns whose union forms a value's legal wire forms. */
+const LOOKUP_VALUE_FIELD = 'LookupValue';
+const STANDARD_LOOKUP_VALUE_FIELD = 'StandardLookupValue';
+const LEGACY_ODATA_VALUE_FIELD = 'LegacyODataValue';
+
+/** A per-run cache of /Lookup rows keyed internally by the provider's LookupName; queried by (resource, field). */
+export interface LookupCache {
+  /** Store the fetched rows for a LookupName. Idempotent — a LookupName already filled is left as-is, so a
+   *  shared LookupName is fetched at most once across the run (the cache-hit dedup). */
+  readonly put: (lookupName: string, rows: ReadonlyArray<Record<string, unknown>>) => void;
+  /** True when `value` appears on any cached row for the field's LookupName under ANY of the three legal wire
+   *  forms (LookupValue | StandardLookupValue | LegacyODataValue). */
+  readonly has: (resource: string, field: string, value: string) => boolean;
+  /** The StandardLookupValue of the cached row that carries `value` in any wire form, or undefined when no
+   *  cached row matches (or the row has no StandardLookupValue). */
+  readonly toStandard: (resource: string, field: string, value: string) => string | undefined;
+  /** The cached rows for the field's LookupName, or undefined when that LookupName was never filled (a cache
+   *  miss — the caller must fetch). Used by the SLV-validity pass and the fetch-skip on a cache hit. */
+  readonly rowsFor: (resource: string, field: string) => ReadonlyArray<Record<string, unknown>> | undefined;
+}
+
+/** A filled cache entry: the rows plus a membership set unioning all three value forms across them. */
+interface CachedLookup {
+  readonly rows: ReadonlyArray<Record<string, unknown>>;
+  readonly members: ReadonlySet<string>;
+}
+
+/** The three value forms present on a /Lookup row, as strings, null/undefined dropped. */
+const valueFormsOf = (row: Record<string, unknown>): ReadonlyArray<string> =>
+  [row[LOOKUP_VALUE_FIELD], row[STANDARD_LOOKUP_VALUE_FIELD], row[LEGACY_ODATA_VALUE_FIELD]]
+    .filter((v) => v != null)
+    .map((v) => String(v));
+
+/**
+ * Build a {@link LookupCache}. `deps.lookupNameFor` resolves a (resource, field) pair to the provider's
+ * LookupName (off the per-resource `TestParams.lookupNameByField`); when it can't, the field name is the
+ * fallback key — mirroring the Lookup Resource assertion's `?? field`, so the put key and the query key agree.
+ */
+export const createLookupCache = (deps: {
+  readonly lookupNameFor: (resource: string, field: string) => string | undefined;
+}): LookupCache => {
+  // Local mutable store, scoped to this run and read-only through the returned closures — never leaked. Keyed
+  // by LookupName so fields that share a LookupName dedupe to ONE entry (the cache-hit win).
+  const store = new Map<string, CachedLookup>();
+
+  const resolveName = (resource: string, field: string): string => deps.lookupNameFor(resource, field) ?? field;
+
+  const put = (lookupName: string, rows: ReadonlyArray<Record<string, unknown>>): void => {
+    if (store.has(lookupName)) return; // idempotent — a shared LookupName is filled exactly once
+    const members = new Set<string>(rows.flatMap(valueFormsOf));
+    store.set(lookupName, { rows, members });
+  };
+
+  const has = (resource: string, field: string, value: string): boolean =>
+    store.get(resolveName(resource, field))?.members.has(value) ?? false;
+
+  const toStandard = (resource: string, field: string, value: string): string | undefined => {
+    const row = store.get(resolveName(resource, field))?.rows.find((r) => valueFormsOf(r).includes(value));
+    const slv = row?.[STANDARD_LOOKUP_VALUE_FIELD];
+    return slv != null ? String(slv) : undefined;
+  };
+
+  const rowsFor = (resource: string, field: string): ReadonlyArray<Record<string, unknown>> | undefined =>
+    store.get(resolveName(resource, field))?.rows;
+
+  return { put, has, toStandard, rowsFor };
+};

--- a/reso-certification/src/web-api-core/standard-map.ts
+++ b/reso-certification/src/web-api-core/standard-map.ts
@@ -27,6 +27,12 @@ export interface StandardMap {
   readonly isStandardValue: (value: string) => boolean;
   /** The standard values for one lookup/enum name — a precise, per-field match when the lookup is known. */
   readonly standardValues: (lookupName: string) => ReadonlySet<string>;
+  /** The DD-standard values for a resource+field's OWN enum, resolved via the field's DD `type` (an
+   *  enumeration field's `type` IS its enum name, which keys {@link standardValues}). Returns undefined when
+   *  the field isn't a resolvable DD enumeration (unknown field, or a non-enum type) so the caller can fall
+   *  back to {@link isStandardValue}. This is the precise per-FIELD join — it never uses a provider's arbitrary
+   *  wire LookupName, only the field's DD type. */
+  readonly standardValuesForField: (resource: string, field: string) => ReadonlySet<string> | undefined;
 }
 
 const fieldKey = (resource: string, field: string): string => `${resource}/${field}`;
@@ -34,6 +40,9 @@ const fieldKey = (resource: string, field: string): string => `${resource}/${fie
 /** Build a {@link StandardMap} from an already-loaded DD reference. Pure — the unit-test seam. */
 export const buildStandardMapFrom = (ref: DdReference): StandardMap => {
   const fields = new Set(ref.fields.map((f) => fieldKey(f.resourceName, f.fieldName)));
+  // A field's DD `type` is its enum name for an enumeration field (e.g. `org.reso.metadata.enums.StandardStatus`),
+  // which is exactly how the lookups below are keyed — so this map is the field → enum-name join.
+  const fieldTypes = new Map<string, string>(ref.fields.map((f) => [fieldKey(f.resourceName, f.fieldName), f.type]));
   // A DD lookup value has two legal wire forms (the dual representation): the machine LegacyODataValue —
   // here `lookupValue` — and the human StandardName carried in the RESO.OData.Metadata.StandardName
   // annotation. A provider may serve EITHER, so both must count as standard; keying only on the machine
@@ -56,6 +65,10 @@ export const buildStandardMapFrom = (ref: DdReference): StandardMap => {
     isStandardField: (resource, field) => fields.has(fieldKey(resource, field)),
     isStandardValue: (value) => allValues.has(value),
     standardValues: (lookupName) => byLookup.get(lookupName) ?? new Set<string>(),
+    standardValuesForField: (resource, field) => {
+      const type = fieldTypes.get(fieldKey(resource, field));
+      return type ? byLookup.get(type) : undefined; // undefined for an unknown field or a non-enum type
+    },
   };
 };
 
@@ -66,6 +79,7 @@ const EMPTY_STANDARD_MAP: StandardMap = {
   isStandardField: () => false,
   isStandardValue: () => false,
   standardValues: () => new Set<string>(),
+  standardValuesForField: () => undefined,
 };
 
 const isValidRef = (ref: DdReference | null): ref is DdReference =>

--- a/reso-certification/src/web-api-core/test-runner.ts
+++ b/reso-certification/src/web-api-core/test-runner.ts
@@ -11,6 +11,8 @@ import { MetadataFetchError, decodeFlagsValue } from '@reso-standards/reso-metad
 import { type EnumRepresentation, isDeadlineError } from '@reso-standards/reso-client';
 import type { TestParams } from './sampling.js';
 import type { EnumCandidate } from './enum-selection.js';
+import { buildStandardMap, type StandardMap } from './standard-map.js';
+import { createLookupCache, type LookupCache } from './lookup-cache.js';
 import { buildScenarioQuery } from './queries.js';
 import { emptyVerdict, type EmptyContext, type EmptyVerdict } from './empty-verdict.js';
 import { scenariosForVersion, type ComparisonOp, type CoreScenario, type ExpandScenario } from './scenarios.js';
@@ -596,13 +598,101 @@ const runEnumFamilyScenario = async (
 };
 
 /**
+ * Per-run dependencies the Lookup Resource scenario needs, bundled so the plumbing threads ONE param:
+ *   - `cache` — the row cache keyed by LookupName, shared across resources so a LookupName referenced by
+ *     several fields is fetched (and paged) at most once (the cache-hit win);
+ *   - `standardMap` — the DD standard map, for the SLV-validity join (field → DD enum via the field's DD type);
+ *   - `isEnumerationIgnored` — the committee-approved ignore-enumerations predicate.
+ */
+export interface LookupResourceContext {
+  readonly cache: LookupCache;
+  readonly standardMap: StandardMap;
+  readonly isEnumerationIgnored: (resource: string, field: string) => boolean;
+}
+
+/**
+ * PRESENCE assertion for the Lookup Resource scenario. The query filters by LookupName, so the returned rows
+ * prove the declared LookupName resolves. Determinate FAIL when NO row came back, or a row carries the WRONG
+ * LookupName (the query didn't resolve as declared). Then every provider-sampled value must be published: it
+ * PASSES iff the field is on the committee-approved ignore-enumerations list (its unadvertised/local values are
+ * permitted) OR the value appears on a cached row under ANY of the three legal wire forms — LookupValue,
+ * StandardLookupValue, LegacyODataValue — via {@link LookupCache.has}, which unions all three. This closes the
+ * two false-fail holes in the old union: it never counted LegacyODataValue and never consulted the ignore list.
+ */
+export const lookupResourcePresence = (
+  rows: ReadonlyArray<Record<string, unknown>>,
+  effParams: TestParams,
+  field: string,
+  expectedLookupName: string,
+  cache: LookupCache,
+  isEnumerationIgnored: (resource: string, field: string) => boolean,
+): AssertionResult => {
+  const resource = effParams.resource;
+  if (rows.length === 0) {
+    return { passed: false, message: `Lookup Resource returned no rows for LookupName '${expectedLookupName}'` };
+  }
+  const wrongName = rows.find(r => r.LookupName != null && String(r.LookupName) !== expectedLookupName);
+  if (wrongName) {
+    return { passed: false, message: `Lookup Resource returned a row with LookupName=${JSON.stringify(wrongName.LookupName)}, expected '${expectedLookupName}'` };
+  }
+  if (isEnumerationIgnored(resource, field)) {
+    return { passed: true, message: `Lookup Resource '${expectedLookupName}': ${resource}.${field} is on the committee-approved ignore-enumerations list — value presence not enforced` };
+  }
+  const sampleValues = [effParams.singleLookupValue, effParams.singleLookupValue2, effParams.singleLookupValue3]
+    .filter((v): v is string => typeof v === 'string' && v.length > 0);
+  const missing = sampleValues.filter(v => !cache.has(resource, field, v));
+  if (missing.length > 0) {
+    return { passed: false, message: `Lookup Resource missing sample value(s): ${missing.map(v => `'${v}'`).join(', ')} for LookupName '${expectedLookupName}'` };
+  }
+  return { passed: true, message: `Lookup Resource validated: LookupName '${expectedLookupName}' with ${sampleValues.length} sample value(s) present` };
+};
+
+/**
+ * SLV-VALIDITY assertion (GATING, alongside presence). For each cached /Lookup row under this LookupName, UNLESS
+ * the field is ignore-listed, the row's declared `StandardLookupValue` MUST be a DD-standard value for the
+ * FIELD'S DD enum — joined via the field's DD type ({@link StandardMap.standardValuesForField}), NEVER the
+ * provider's arbitrary wire LookupName. A declared StandardLookupValue that is not DD-standard is a bad remap
+ * that breaks downstream consumers → a determinate FAIL. When the field can't be resolved to a precise DD enum,
+ * fall back to "is it standard in ANY DD enum" ({@link StandardMap.isStandardValue}) rather than crash.
+ */
+export const lookupResourceSlvValidity = (
+  rows: ReadonlyArray<Record<string, unknown>>,
+  resource: string,
+  field: string,
+  expectedLookupName: string,
+  standardMap: StandardMap,
+  isEnumerationIgnored: (resource: string, field: string) => boolean,
+): AssertionResult => {
+  if (isEnumerationIgnored(resource, field)) {
+    return { passed: true, message: `Lookup Resource '${expectedLookupName}': ${resource}.${field} is on the ignore-enumerations list — StandardLookupValue validity not enforced` };
+  }
+  // Prefer the precise per-field DD set (joined on the field's DD type); fall back to "any DD enum" only when
+  // the field can't be resolved to a DD enum, so an unresolvable field degrades to a laxer check, never a crash.
+  const perFieldSet = standardMap.standardValuesForField(resource, field);
+  const isDdStandard = (slv: string): boolean => (perFieldSet ? perFieldSet.has(slv) : standardMap.isStandardValue(slv));
+  const declared = rows.flatMap(r => {
+    const slv = r.StandardLookupValue;
+    return slv != null && String(slv).length > 0 ? [String(slv)] : [];
+  });
+  const invalid = [...new Set(declared.filter(slv => !isDdStandard(slv)))];
+  if (invalid.length > 0) {
+    return { passed: false, message: `Lookup Resource '${expectedLookupName}': ${invalid.length} declared StandardLookupValue(s) not DD-standard for ${resource}.${field} — e.g. ${invalid.slice(0, 5).map(v => `'${v}'`).join(', ')} (a non-standard remap breaks downstream consumers)` };
+  }
+  return { passed: true, message: `Lookup Resource '${expectedLookupName}': all ${declared.length} declared StandardLookupValue(s) are DD-standard for ${resource}.${field}` };
+};
+
+/**
  * Run the Lookup Resource validation scenario. The Lookup Resource (RCP-032/039) is the *string*-lookup
  * mechanism, so this validates against a `SINGLE_STRING` field; enum-typed providers have no Lookup
  * Resource and the scenario simply doesn't apply → skip. Unlike the generic flow, an empty Lookup Resource
- * is a FAILURE not a skip — the scenario exists to prove the declared LookupName is present, and its
- * `assertData` case turns 0 rows into a fail.
+ * is a FAILURE not a skip — the scenario exists to prove the declared LookupName is present.
+ *
+ * Every `/Lookup` row for the field's LookupName is fetched (paged all the way through, no cap) and cached by
+ * LookupName. A later field that references an ALREADY-cached LookupName reuses those rows and skips the fetch
+ * entirely — the 200 was verified when the cache was first filled — so the whole enum is paged at most once per
+ * run. The presence + SLV-validity assertions are computed off those rows (see the helpers above).
  */
-const runLookupResourceScenario = async (
+export const runLookupResourceScenario = async (
   serverUrl: string,
   resource: string,
   scenario: CoreScenario,
@@ -610,6 +700,7 @@ const runLookupResourceScenario = async (
   authToken: string,
   start: number,
   requester: ODataRequester = webRequester,
+  lookupCtx: LookupResourceContext,
 ): Promise<ScenarioResult> => {
   const stringField = (params.singleLookupCandidates ?? []).find(c => c.representation === 'SINGLE_STRING');
   if (!stringField) {
@@ -626,6 +717,27 @@ const runLookupResourceScenario = async (
   };
   const query = buildScenarioQuery(serverUrl, resource, scenario, effParams);
   if (!query) return skipResult(scenario, start, 'required test parameters not available for the Lookup Resource scenario');
+  const tag = scenario.tag;
+  const name = scenario.name;
+  const field = stringField.field;
+  const expectedLookupName = effParams.lookupNameByField?.[field] ?? field;
+
+  // The gating data assertions over the (fetched or cached) /Lookup rows — presence + SLV-validity, side by
+  // side. Both consult the ignore list; presence unions all three value forms via the cache, SLV-validity joins
+  // each row's StandardLookupValue against the field's own DD enum.
+  const validate = (rows: ReadonlyArray<Record<string, unknown>>): ReadonlyArray<AssertionResult> => [
+    lookupResourcePresence(rows, effParams, field, expectedLookupName, lookupCtx.cache, lookupCtx.isEnumerationIgnored),
+    lookupResourceSlvValidity(rows, resource, field, expectedLookupName, lookupCtx.standardMap, lookupCtx.isEnumerationIgnored),
+  ];
+
+  // CACHE HIT: another field already fetched (and 200-verified) every row for this LookupName. Reuse them and
+  // skip the fetch — validate against the cached rows so the result is still a valid, gating ScenarioResult.
+  const cachedRows = lookupCtx.cache.rowsFor(resource, field);
+  if (cachedRows) {
+    const assertions = validate(cachedRows);
+    return { tag, name, passed: assertions.every(a => a.passed), skipped: false, assertions, duration: Date.now() - start, requestUrl: query.url };
+  }
+
   const assertions: AssertionResult[] = [];
   try {
     const reqStart = Date.now();
@@ -634,15 +746,16 @@ const runLookupResourceScenario = async (
     const responseCheck = assertODataResponse(response, 200);
     assertions.push(responseCheck);
     if (!responseCheck.passed) {
-      return { tag: scenario.tag, name: scenario.name, passed: false, skipped: false, assertions, duration: Date.now() - start, requestLatency, requestUrl: query.url };
+      return { tag, name, passed: false, skipped: false, assertions, duration: Date.now() - start, requestLatency, requestUrl: query.url };
     }
-    // Collect ALL /Lookup rows for this LookupName across pages: a published value can sit beyond page 1
-    // under server-driven paging, and the local (rarely-populated) value we test here is especially likely
-    // to. Reading only page 1 would falsely report it missing and FALSE-FAIL a conformant provider.
+    // Fetch EVERY /Lookup row for this LookupName by paging all the way through, with NO page cap. A published
+    // value can sit arbitrarily deep under server-driven paging, and RESO has no value-filter on /Lookup yet
+    // (RCP-039 mandates only the LookupName filter), so a fixed cap would false-fail a conformant provider by
+    // reporting a present value as missing. The large pull is on-demand and rare (most LookupNames are small);
+    // the run deadline is the only global stop.
     const records: Record<string, unknown>[] = [...extractRecords(response.body)];
     let nextLink = extractNextLink(response.body);
-    let pages = 1;
-    while (nextLink && pages < 25) {
+    while (nextLink) {
       let pageResp: Awaited<ReturnType<typeof odataRequest>>;
       try {
         pageResp = await requester.request({ method: 'GET', url: rebaseNextLink(nextLink, query.url), authToken });
@@ -653,15 +766,16 @@ const runLookupResourceScenario = async (
       if (!assertODataResponse(pageResp, 200).passed) break;
       records.push(...extractRecords(pageResp.body));
       nextLink = extractNextLink(pageResp.body);
-      pages += 1;
     }
-    const dataAssertion = assertData(records, scenario, effParams); // handles 0 rows / wrong name / missing values → fail
-    if (dataAssertion) assertions.push(dataAssertion);
+    // Cache the fully-paged rows under this LookupName so later fields referencing it skip the fetch. Put BEFORE
+    // validating so the presence check's cache.has sees this LookupName's rows.
+    lookupCtx.cache.put(expectedLookupName, records);
+    assertions.push(...validate(records)); // 0 rows / wrong name / missing values → fail
     const allPassed = assertions.every(a => a.passed);
-    return { tag: scenario.tag, name: scenario.name, passed: allPassed, skipped: false, assertions, duration: Date.now() - start, requestLatency, requestUrl: query.url };
+    return { tag, name, passed: allPassed, skipped: false, assertions, duration: Date.now() - start, requestLatency, requestUrl: query.url };
   } catch (err) {
     if (isDeadlineError(err)) throw err; // out of run budget — propagate so the run stops gracefully
-    return { tag: scenario.tag, name: scenario.name, passed: false, skipped: false, errored: true, assertions: [{ passed: false, message: `Error: ${err instanceof Error ? err.message : String(err)}` }], duration: Date.now() - start, requestUrl: query.url };
+    return { tag, name, passed: false, skipped: false, errored: true, assertions: [{ passed: false, message: `Error: ${err instanceof Error ? err.message : String(err)}` }], duration: Date.now() - start, requestUrl: query.url };
   }
 };
 
@@ -673,12 +787,13 @@ const runScenario = async (
   params: TestParams,
   authToken: string,
   requester: ODataRequester = webRequester,
+  lookupCtx: LookupResourceContext,
 ): Promise<ScenarioResult> => {
   const start = Date.now();
 
   // Lookup Resource validation applies only to string (Lookup Resource) lookups.
   if (scenario.category === 'lookup-resource') {
-    return runLookupResourceScenario(serverUrl, resource, scenario, params, authToken, start, requester);
+    return runLookupResourceScenario(serverUrl, resource, scenario, params, authToken, start, requester, lookupCtx);
   }
 
   // Enum-family scenarios gate on the selected field's REAL representation and try candidate fields —
@@ -856,37 +971,9 @@ const assertData = (
         : { passed: false, message: `${failures.length} records failed: ${failures[0]}` };
     }
 
-    case 'lookup-resource': {
-      // The fetched payload is the Lookup Resource filtered by LookupName.
-      // Validate (1) at least one row came back, (2) every returned row's
-      // LookupName matches what we asked for, and (3) the provider's
-      // declared sample lookup values appear in the returned set.
-      const field = resolveField(scenario.fieldParam);
-      const expectedLookupName = params.lookupNameByField?.[field] ?? field;
-      const sampleValues = [
-        params.singleLookupValue,
-        params.singleLookupValue2,
-        params.singleLookupValue3,
-      ].filter((v): v is string => typeof v === 'string' && v.length > 0);
-
-      if (records.length === 0) {
-        return { passed: false, message: `Lookup Resource returned no rows for LookupName '${expectedLookupName}'` };
-      }
-      const wrongName = records.find(r => r.LookupName != null && String(r.LookupName) !== expectedLookupName);
-      if (wrongName) {
-        return { passed: false, message: `Lookup Resource returned a row with LookupName=${JSON.stringify(wrongName.LookupName)}, expected '${expectedLookupName}'` };
-      }
-      const returnedValues = new Set(records.flatMap(r => {
-        const a = r.StandardLookupValue != null ? [String(r.StandardLookupValue)] : [];
-        const b = r.LookupValue != null ? [String(r.LookupValue)] : [];
-        return [...a, ...b];
-      }));
-      const missing = sampleValues.filter(v => !returnedValues.has(v));
-      if (missing.length > 0) {
-        return { passed: false, message: `Lookup Resource missing sample value(s): ${missing.map(v => `'${v}'`).join(', ')} for LookupName '${expectedLookupName}'` };
-      }
-      return { passed: true, message: `Lookup Resource validated: LookupName '${expectedLookupName}' with ${sampleValues.length} sample value(s) present` };
-    }
+    // 'lookup-resource' is NOT handled here — runScenario routes it to runLookupResourceScenario, which fetches
+    // (and caches) every /Lookup row for the LookupName and validates via lookupResourcePresence +
+    // lookupResourceSlvValidity (all-three-forms membership + the ignore list + StandardLookupValue validity).
 
     case 'expand':
       // Reached only via the single-field executeStandardScenario path (kept for the RRK-warning unit tests):
@@ -1184,6 +1271,14 @@ export interface CoreResourceScenarioOptions {
    *  Omitted when it couldn't be built — a $expand nav then gates on the 200 response alone (never a false
    *  fail). Unused at 2.0.0 (the $expand scenario is 2.1.0-only). */
   readonly expandValidator?: ExpandItemValidator;
+  /** Per-run Lookup Resource cache, keyed by LookupName and SHARED across resources so a LookupName referenced
+   *  by several fields is fetched/paged once. Omitted by direct callers → a per-resource fallback is built. */
+  readonly lookupCache?: LookupCache;
+  /** The DD standard map for the Lookup Resource SLV-validity join. Omitted → built per resource as a fallback. */
+  readonly standardMap?: StandardMap;
+  /** Committee-approved ignore-enumerations predicate (from schema-validation-settings.json). Omitted → no
+   *  exemptions (every field's enumerations are enforced). */
+  readonly isEnumerationIgnored?: (resource: string, field: string) => boolean;
 }
 
 /**
@@ -1201,6 +1296,15 @@ export const runCoreResourceScenarios = async (
   const scenarios = scenariosForVersion(version)
     .filter(s => (options?.excludeProviderWide ? !isProviderWideScenario(s) : true));
   const results: ScenarioResult[] = [];
+
+  // Lookup Resource dependencies. The SDK threads a run-wide cache + standard map + ignore predicate; a direct
+  // caller (e.g. a focused test) gets a per-resource fallback so the scenario still works in isolation. The
+  // fallback cache resolves LookupNames off THIS resource's params (it only ever tests one resource).
+  const lookupCtx: LookupResourceContext = {
+    cache: options?.lookupCache ?? createLookupCache({ lookupNameFor: (res, fld) => (res === resource ? params.lookupNameByField?.[fld] : undefined) }),
+    standardMap: options?.standardMap ?? buildStandardMap(version),
+    isEnumerationIgnored: options?.isEnumerationIgnored ?? (() => false),
+  };
 
   // Track cross-scenario state for cascade-skip + OData-version gating. The version is pre-seeded from the
   // provider pass when the provider-wide scenarios are hoisted out (else the inline metadata scenario sets it).
@@ -1256,7 +1360,7 @@ export const runCoreResourceScenarios = async (
     }
 
     try {
-      const result = await runScenario(serverUrl, resource, scenario, params, authToken, requester);
+      const result = await runScenario(serverUrl, resource, scenario, params, authToken, requester, lookupCtx);
       results.push({ ...result, optional: scenario.optional });
 
       // Latch state for subsequent iterations.

--- a/reso-certification/tests/sdk/ignore-enumerations.test.ts
+++ b/reso-certification/tests/sdk/ignore-enumerations.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { isEnumerationIgnored, loadValidationConfig } from '../../src/sdk/expand-schema.js';
+
+// A minimal stand-in mirroring schema-validation-settings.json's shape: version → resource → field → flag.
+const config = {
+  '2.0': { Property: { MLSAreaMinor: { ignoreEnumerations: true } } },
+  '2.1': {
+    Property: { MLSAreaMinor: { ignoreEnumerations: true } },
+    Media: { ImageSizeDescription: { ignoreEnumerations: true } },
+  },
+};
+
+describe('isEnumerationIgnored', () => {
+  it('normalizes the 3-part endorsement version to DD major.minor before the lookup', () => {
+    expect(isEnumerationIgnored(config, '2.1.0', 'Property', 'MLSAreaMinor')).toBe(true);
+    expect(isEnumerationIgnored(config, '2.0.0', 'Property', 'MLSAreaMinor')).toBe(true);
+    expect(isEnumerationIgnored(config, '2.1.0', 'Media', 'ImageSizeDescription')).toBe(true);
+  });
+
+  it('is false for a field / resource / version not on the list', () => {
+    expect(isEnumerationIgnored(config, '2.1.0', 'Property', 'StandardStatus')).toBe(false); // field not listed
+    expect(isEnumerationIgnored(config, '2.1.0', 'Member', 'MLSAreaMinor')).toBe(false); // wrong resource
+    expect(isEnumerationIgnored(config, '2.0.0', 'Media', 'ImageSizeDescription')).toBe(false); // not in 2.0
+    expect(isEnumerationIgnored({}, '2.1.0', 'Property', 'MLSAreaMinor')).toBe(false); // empty config
+  });
+
+  it('reads the real committee-approved schema-validation-settings.json', async () => {
+    // cwd is the reso-certification package root under vitest, so resolveSettingsPath finds the committed file.
+    const real = await loadValidationConfig();
+    expect(isEnumerationIgnored(real, '2.1.0', 'Property', 'MLSAreaMinor')).toBe(true);
+    expect(isEnumerationIgnored(real, '2.0.0', 'Media', 'ImageSizeDescription')).toBe(true);
+    expect(isEnumerationIgnored(real, '2.1.0', 'Property', 'ListPrice')).toBe(false);
+  });
+});

--- a/reso-certification/tests/web-api-core-standard-map.test.ts
+++ b/reso-certification/tests/web-api-core-standard-map.test.ts
@@ -35,6 +35,15 @@ describe('buildStandardMapFrom — membership tests', () => {
     expect([...map.standardValues('org.reso.metadata.enums.StandardStatus')].sort()).toEqual(['Active', 'Pending']);
     expect(map.standardValues('org.reso.metadata.enums.DoesNotExist').size).toBe(0);
   });
+
+  it('standardValuesForField: joins a field to its DD enum via the field type', () => {
+    // The enum field resolves to its own enum's values (via its `type`, not a wire LookupName).
+    expect([...(map.standardValuesForField('Property', 'StandardStatus') ?? [])].sort()).toEqual(['Active', 'Pending']);
+    // A non-enum field's type (Edm.Decimal) is not a lookup name → undefined → caller falls back to isStandardValue.
+    expect(map.standardValuesForField('Property', 'ListPrice')).toBeUndefined();
+    // An unknown field → undefined.
+    expect(map.standardValuesForField('Property', 'ZZZLocalField')).toBeUndefined();
+  });
 });
 
 describe('buildStandardMap — loads the real dd-2.1 reference', () => {

--- a/reso-certification/tests/web-api-core/lookup-cache.test.ts
+++ b/reso-certification/tests/web-api-core/lookup-cache.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { createLookupCache } from '../../src/web-api-core/lookup-cache.js';
+
+// Two fields share the LookupName 'PropertyType'; 'StandardStatus' maps to its own; 'Unmapped' has no name.
+const lookupNameFor = (resource: string, field: string): string | undefined =>
+  ({
+    'Property/PropertyType': 'PropertyType',
+    'Property/PropertySubType': 'PropertyType', // shares the LookupName with PropertyType — the dedup case
+    'Property/StandardStatus': 'StandardStatus',
+  })[`${resource}/${field}`];
+
+// PropertyType rows. The last row's data value distinguishes ONLY on LegacyODataValue (the form the old
+// presence union missed): LookupValue/StandardLookupValue are 'Residential' but LegacyODataValue is 'LEGACY_ONLY'.
+const propertyTypeRows: ReadonlyArray<Record<string, unknown>> = [
+  { LookupName: 'PropertyType', LookupValue: 'ResidentialLease', StandardLookupValue: 'Residential Lease', LegacyODataValue: 'ResidentialLease' },
+  { LookupName: 'PropertyType', LookupValue: 'CommercialSale', StandardLookupValue: 'Commercial Sale', LegacyODataValue: 'CommercialSale' },
+  { LookupName: 'PropertyType', LookupValue: 'Residential', StandardLookupValue: 'Residential', LegacyODataValue: 'LEGACY_ONLY' },
+];
+
+describe('createLookupCache', () => {
+  it('has(): membership unions all three wire forms, including LegacyODataValue', () => {
+    const cache = createLookupCache({ lookupNameFor });
+    cache.put('PropertyType', propertyTypeRows);
+
+    expect(cache.has('Property', 'PropertyType', 'CommercialSale')).toBe(true); // LookupValue form
+    expect(cache.has('Property', 'PropertyType', 'Residential Lease')).toBe(true); // StandardLookupValue form
+    expect(cache.has('Property', 'PropertyType', 'LEGACY_ONLY')).toBe(true); // LegacyODataValue-only form
+    expect(cache.has('Property', 'PropertyType', 'NotPresent')).toBe(false); // genuine miss
+  });
+
+  it('toStandard(): any wire form resolves to that row\'s StandardLookupValue', () => {
+    const cache = createLookupCache({ lookupNameFor });
+    cache.put('PropertyType', propertyTypeRows);
+
+    expect(cache.toStandard('Property', 'PropertyType', 'CommercialSale')).toBe('Commercial Sale'); // via LookupValue
+    expect(cache.toStandard('Property', 'PropertyType', 'Commercial Sale')).toBe('Commercial Sale'); // via SLV itself
+    expect(cache.toStandard('Property', 'PropertyType', 'LEGACY_ONLY')).toBe('Residential'); // via LegacyODataValue
+    expect(cache.toStandard('Property', 'PropertyType', 'NotPresent')).toBeUndefined(); // no matching row
+  });
+
+  it('dedup: two fields sharing a LookupName resolve from ONE put (one entry)', () => {
+    const cache = createLookupCache({ lookupNameFor });
+    cache.put('PropertyType', propertyTypeRows); // filled once by PropertyType
+
+    // PropertySubType shares the LookupName — it resolves against the SAME rows without its own put.
+    expect(cache.has('Property', 'PropertySubType', 'CommercialSale')).toBe(true);
+    expect(cache.rowsFor('Property', 'PropertySubType')).toBe(cache.rowsFor('Property', 'PropertyType'));
+    expect(cache.rowsFor('Property', 'PropertySubType')).toHaveLength(3);
+
+    // put is idempotent: a second put for the same LookupName is a no-op (first fill wins).
+    cache.put('PropertyType', [{ LookupName: 'PropertyType', LookupValue: 'Replaced', StandardLookupValue: 'Replaced', LegacyODataValue: 'Replaced' }]);
+    expect(cache.rowsFor('Property', 'PropertyType')).toHaveLength(3);
+    expect(cache.has('Property', 'PropertyType', 'Replaced')).toBe(false);
+  });
+
+  it('miss: an unfilled LookupName returns false / undefined', () => {
+    const cache = createLookupCache({ lookupNameFor });
+    cache.put('PropertyType', propertyTypeRows);
+
+    // StandardStatus was never put.
+    expect(cache.has('Property', 'StandardStatus', 'Active')).toBe(false);
+    expect(cache.toStandard('Property', 'StandardStatus', 'Active')).toBeUndefined();
+    expect(cache.rowsFor('Property', 'StandardStatus')).toBeUndefined();
+  });
+
+  it('falls back to the field name as the key when no LookupName resolves', () => {
+    // lookupNameFor returns undefined for 'Unmapped' → the cache keys on the field name, so a put under the
+    // field name is found by has()/rowsFor() (mirrors the Lookup Resource assertion's `?? field`).
+    const cache = createLookupCache({ lookupNameFor });
+    cache.put('Unmapped', [{ LookupName: 'Unmapped', LookupValue: 'X', StandardLookupValue: 'X', LegacyODataValue: 'X' }]);
+    expect(cache.has('Property', 'Unmapped', 'X')).toBe(true);
+    expect(cache.rowsFor('Property', 'Unmapped')).toHaveLength(1);
+  });
+});

--- a/reso-certification/tests/web-api-core/lookup-resource-cache-hit.test.ts
+++ b/reso-certification/tests/web-api-core/lookup-resource-cache-hit.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import type { DdReference } from '../../src/metadata/dd-metadata-checks.js';
+import type { EnumCandidate } from '../../src/web-api-core/enum-selection.js';
+import { createLookupCache } from '../../src/web-api-core/lookup-cache.js';
+import type { CoreScenario } from '../../src/web-api-core/scenarios.js';
+import { buildStandardMapFrom } from '../../src/web-api-core/standard-map.js';
+import type { TestParams } from '../../src/web-api-core/sampling.js';
+import { type LookupResourceContext, runLookupResourceScenario } from '../../src/web-api-core/test-runner.js';
+import type { ODataRequester } from '../../src/test-runner/requester.js';
+
+const ref: DdReference = {
+  fields: [{ resourceName: 'Property', fieldName: 'PropertyType', type: 'org.reso.metadata.enums.PropertyType' }],
+  lookups: [
+    { lookupName: 'org.reso.metadata.enums.PropertyType', lookupValue: 'Residential', annotations: [{ term: 'RESO.OData.Metadata.StandardName', value: 'Residential' }] },
+  ],
+};
+
+const candidate: EnumCandidate = {
+  field: 'PropertyType',
+  representation: 'SINGLE_STRING',
+  isStandard: true,
+  values: ['Residential'],
+  lookupSampleValues: ['Residential'],
+  distinctValueCount: 1,
+  fillRate: 1,
+  lookupName: 'PropertyType',
+};
+
+const params: TestParams = {
+  resource: 'Property',
+  keyField: 'ListingKey',
+  keyValue: '1',
+  enumMode: 'string',
+  integerValueHigh: 0,
+  skippedTypes: [],
+  sampleComplete: true,
+  singleLookupField: 'PropertyType',
+  singleLookupCandidates: [candidate],
+  lookupNameByField: { PropertyType: 'PropertyType' },
+};
+
+const scenario: CoreScenario = {
+  tag: 'lookup-resource-validation',
+  name: 'Lookup Resource: LookupName and sample values present',
+  category: 'lookup-resource',
+  assertion: 'lookup-resource-validation',
+  fieldParam: 'singleLookupField',
+  valueParam: 'singleLookupValue',
+  minVersion: '2.1.0',
+};
+
+// A requester that FAILS the test if it is ever called — the whole point of a cache hit is that no request goes out.
+const throwingRequester: ODataRequester = {
+  request: async () => {
+    throw new Error('runLookupResourceScenario issued a request on a cache hit — the fetch was not skipped');
+  },
+};
+
+describe('runLookupResourceScenario — cache hit skips the fetch', () => {
+  it('reuses the pre-filled rows, issues no request, and still returns a valid gating result', async () => {
+    const cache = createLookupCache({ lookupNameFor: (_res, f) => (f === 'PropertyType' ? 'PropertyType' : undefined) });
+    // A prior resource already fetched (and 200-verified) this LookupName's rows.
+    cache.put('PropertyType', [{ LookupName: 'PropertyType', LookupValue: 'Residential', StandardLookupValue: 'Residential', LegacyODataValue: 'Residential' }]);
+
+    const lookupCtx: LookupResourceContext = {
+      cache,
+      standardMap: buildStandardMapFrom(ref),
+      isEnumerationIgnored: () => false,
+    };
+
+    const result = await runLookupResourceScenario('http://server', 'Property', scenario, params, 'tok', 0, throwingRequester, lookupCtx);
+
+    expect(result.skipped).toBe(false);
+    expect(result.passed).toBe(true); // presence (Residential present) + SLV-validity (Residential is DD-standard)
+    expect(result.assertions.length).toBe(2); // both gating assertions ran off the cached rows
+  });
+});

--- a/reso-certification/tests/web-api-core/lookup-resource-presence.test.ts
+++ b/reso-certification/tests/web-api-core/lookup-resource-presence.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { createLookupCache } from '../../src/web-api-core/lookup-cache.js';
+import type { TestParams } from '../../src/web-api-core/sampling.js';
+import { lookupResourcePresence } from '../../src/web-api-core/test-runner.js';
+
+// A cache wired to resolve the two test fields to their LookupNames, matching the SDK's per-resource registry.
+const makeCache = (rows: ReadonlyArray<Record<string, unknown>>, lookupName: string, field: string) => {
+  const cache = createLookupCache({ lookupNameFor: (_res, f) => (f === field ? lookupName : undefined) });
+  cache.put(lookupName, rows);
+  return cache;
+};
+
+const baseParams = (values: ReadonlyArray<string>): TestParams => ({
+  resource: 'Property',
+  keyField: 'ListingKey',
+  keyValue: '1',
+  enumMode: 'string',
+  integerValueHigh: 0,
+  skippedTypes: [],
+  sampleComplete: true,
+  singleLookupField: 'PropertyType',
+  singleLookupValue: values[0],
+  singleLookupValue2: values[1],
+  singleLookupValue3: values[2],
+  lookupNameByField: { PropertyType: 'PropertyType' },
+});
+
+// A row whose data value distinguishes ONLY on LegacyODataValue — the form the old presence union missed.
+const rows: ReadonlyArray<Record<string, unknown>> = [
+  { LookupName: 'PropertyType', LookupValue: 'CommercialSale', StandardLookupValue: 'Commercial Sale', LegacyODataValue: 'CommercialSale' },
+  { LookupName: 'PropertyType', LookupValue: 'Residential', StandardLookupValue: 'Residential', LegacyODataValue: 'LEGACY_ONLY' },
+];
+
+const never = (): boolean => false;
+const always = (): boolean => true;
+
+describe('lookupResourcePresence', () => {
+  it('passes a value present ONLY as LegacyODataValue (the closed false-fail hole)', () => {
+    const cache = makeCache(rows, 'PropertyType', 'PropertyType');
+    const res = lookupResourcePresence(rows, baseParams(['LEGACY_ONLY']), 'PropertyType', 'PropertyType', cache, never);
+    expect(res.passed).toBe(true);
+  });
+
+  it('a genuinely-missing value on a NON-exempt field fails', () => {
+    const cache = makeCache(rows, 'PropertyType', 'PropertyType');
+    const res = lookupResourcePresence(rows, baseParams(['NotPublished']), 'PropertyType', 'PropertyType', cache, never);
+    expect(res.passed).toBe(false);
+    expect(res.message).toContain('NotPublished');
+  });
+
+  it('an ignoreEnumerations field with an unadvertised value passes (exempt)', () => {
+    const cache = makeCache(rows, 'PropertyType', 'PropertyType');
+    // The value is NOT in the rows, but the field is exempt → pass.
+    const res = lookupResourcePresence(rows, baseParams(['SomeLocalValue']), 'PropertyType', 'PropertyType', cache, always);
+    expect(res.passed).toBe(true);
+    expect(res.message).toContain('ignore-enumerations');
+  });
+
+  it('0 rows and a wrong LookupName are still determinate fails (independent of the ignore list)', () => {
+    const emptyCache = createLookupCache({ lookupNameFor: () => 'PropertyType' });
+    const zero = lookupResourcePresence([], baseParams(['x']), 'PropertyType', 'PropertyType', emptyCache, always);
+    expect(zero.passed).toBe(false);
+    expect(zero.message).toContain('no rows');
+
+    const wrongRows = [{ LookupName: 'SomethingElse', LookupValue: 'x', StandardLookupValue: 'x', LegacyODataValue: 'x' }];
+    const wrongCache = makeCache(wrongRows, 'PropertyType', 'PropertyType');
+    const wrong = lookupResourcePresence(wrongRows, baseParams(['x']), 'PropertyType', 'PropertyType', wrongCache, always);
+    expect(wrong.passed).toBe(false);
+    expect(wrong.message).toContain('expected');
+  });
+});

--- a/reso-certification/tests/web-api-core/lookup-resource-slv-validity.test.ts
+++ b/reso-certification/tests/web-api-core/lookup-resource-slv-validity.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import type { DdReference } from '../../src/metadata/dd-metadata-checks.js';
+import { buildStandardMapFrom } from '../../src/web-api-core/standard-map.js';
+import { lookupResourceSlvValidity } from '../../src/web-api-core/test-runner.js';
+
+// Two DISTINCT DD enums — proving the SLV join is per-FIELD, not "standard in any enum". StandardStatus owns
+// {Active, Pending}; AccessibilityFeatures owns {AccessibleApproachWithRamp}. A StandardStatus row declaring an
+// AccessibilityFeatures value must still fail.
+const ref: DdReference = {
+  fields: [
+    { resourceName: 'Property', fieldName: 'StandardStatus', type: 'org.reso.metadata.enums.StandardStatus' },
+  ],
+  lookups: [
+    { lookupName: 'org.reso.metadata.enums.StandardStatus', lookupValue: 'Active', annotations: [{ term: 'RESO.OData.Metadata.StandardName', value: 'Active' }] },
+    { lookupName: 'org.reso.metadata.enums.StandardStatus', lookupValue: 'Pending', annotations: [{ term: 'RESO.OData.Metadata.StandardName', value: 'Pending' }] },
+    { lookupName: 'org.reso.metadata.enums.AccessibilityFeatures', lookupValue: 'AccessibleApproachWithRamp' },
+  ],
+};
+const standardMap = buildStandardMapFrom(ref);
+const never = (): boolean => false;
+const always = (): boolean => true;
+
+const row = (slv: string): Record<string, unknown> => ({ LookupName: 'StandardStatus', StandardLookupValue: slv });
+
+describe('lookupResourceSlvValidity', () => {
+  it('passes when every declared StandardLookupValue is DD-standard for the field enum', () => {
+    const res = lookupResourceSlvValidity([row('Active'), row('Pending')], 'Property', 'StandardStatus', 'StandardStatus', standardMap, never);
+    expect(res.passed).toBe(true);
+  });
+
+  it('fails (gating) on a bogus StandardLookupValue — a bad remap', () => {
+    const res = lookupResourceSlvValidity([row('Active'), row('CompletelyMadeUp')], 'Property', 'StandardStatus', 'StandardStatus', standardMap, never);
+    expect(res.passed).toBe(false);
+    expect(res.message).toContain('CompletelyMadeUp');
+  });
+
+  it('joins on the FIELD\'s enum — a value standard in ANOTHER enum still fails', () => {
+    // AccessibleApproachWithRamp is a real DD value, but not for StandardStatus → fail under the precise per-field set.
+    const res = lookupResourceSlvValidity([row('AccessibleApproachWithRamp')], 'Property', 'StandardStatus', 'StandardStatus', standardMap, never);
+    expect(res.passed).toBe(false);
+    expect(res.message).toContain('AccessibleApproachWithRamp');
+  });
+
+  it('an ignoreEnumerations field is exempt from SLV-validity too', () => {
+    const res = lookupResourceSlvValidity([row('CompletelyMadeUp')], 'Property', 'StandardStatus', 'StandardStatus', standardMap, always);
+    expect(res.passed).toBe(true);
+    expect(res.message).toContain('ignore-enumerations');
+  });
+
+  it('falls back to "standard in ANY DD enum" when the field cannot be resolved to a DD enum', () => {
+    // 'UnknownField' has no DD field record → standardValuesForField is undefined → isStandardValue fallback.
+    const good = lookupResourceSlvValidity([row('Active')], 'Property', 'UnknownField', 'UnknownField', standardMap, never);
+    expect(good.passed).toBe(true); // 'Active' is standard in some enum
+    const bad = lookupResourceSlvValidity([row('CompletelyMadeUp')], 'Property', 'UnknownField', 'UnknownField', standardMap, never);
+    expect(bad.passed).toBe(false);
+  });
+});


### PR DESCRIPTION
Brings mainline (`v1.0.0-pre`) current with what's already published on npm, and lands the cert-worker bundle fix.

## What this carries
Four commits, stacked — the Lookup Resource work shipped as **cert 0.10.4** (npm + desktop beta.9) but its source never landed on mainline; this PR fixes that *and* adds the 0.10.5 bundle fix on top:

1. `64ad5d8` — **Lookup Resource** certification (exhaustive fetch, per-run cache, tri-form presence, gating SLV-validity). Already published as 0.10.4; adversarially reviewed last session (0 blockers).
2. `1eaf269` — release: reso-certification **0.10.4**.
3. `62c27a8` — **fix: bundle-static legacy-schema + DD-reference loads** (reso-tools-private #102). The desktop cert-worker esbuild bundle couldn't load the legacy JSON-schema module or the DD reference JSON (computed `createRequire` + template-literal `require()` escape esbuild), so `$expand` per-item schema validation degraded to "unavailable" in the packaged app. Both loads are now bundle-static (lazy dynamic `import()` with a literal specifier; per-version `switch`). Behavior-preserving for CLI + cert-backend; runtime load smoke added in the bundler.
4. `7d1991a` — release: reso-certification **0.10.5**.

## Verification
- Full cert suite green: **1,064 passed / 2 expected-fail** (behavior-preserving).
- Cert-worker bundle now inlines the legacy schema + all three DD JSONs (0 escaped requires, 2.6 → 14.7mb); a new **runtime load smoke** builds the validator in the bundled context.
- **Adversarial review** of the fix: core holds, all five headline risk surfaces refuted; two low findings (stale header comment, silent `{}` metadata default) fixed and re-verified; the adjacent `resolveSettingsPath` exemptions concern verified as correct in the packaged app.

Both 0.10.4 and 0.10.5 are already `latest` on npm; this merge makes the source match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
