### PR TITLE
Core 2.1.0 loose ends: lookup-fields tests, paging cleanup, reconciler guard, CSDL namespace resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ The browser UI, Electron desktop shell, CORS proxy and test-data generator moved
 ## Common Commands
 
 ```bash
-npm test                    # Run all tests (1,963 across 8 packages)
+npm test                    # Run all tests (2,181 across 8 packages)
 npm run test:server         # Run server tests only
 npm run test:validation     # Run validation tests only
 npm run lint                # Biome lint check

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RESO Tools
 
-![Tests](https://img.shields.io/badge/tests-1963%20passed-brightgreen)
+![Tests](https://img.shields.io/badge/tests-2181%20passed-brightgreen)
 ![Compliance](https://img.shields.io/badge/RESO%20compliance-4%2F4%20suites-blue)
 [![Download](https://img.shields.io/github/v/release/RESOStandards/reso-tools?label=download&color=blue)](https://github.com/RESOStandards/reso-tools/releases/latest)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,25 @@
 
 ---
 
+## Web API Core 2.1.0 — `$expand` data-validation + version normalization (desktop v1.0.0-beta.12) – 2026-09-11
+
+A coordinated patch across `reso-metadata-utils` (0.1.1 → 0.1.2) and `reso-certification` (0.10.5 → 0.10.6), shipped in desktop **v1.0.0-beta.12**. Consumers on `^0.1.0` / `^0.10.0` pick these up automatically. Three separate bugs let Web API Core 2.1.0 `$expand` per-item schema validation silently skip in real (desktop / config-mode) runs; this closes all three and tightens the `$expand` gate.
+
+### `reso-metadata-utils` 0.1.2 – declared EntityTypes in the metadata report
+
+- **Contained / expansion-only types are no longer dropped.** `getAllFields` keyed the report off the entity container's EntitySets, so a declared EntityType with no EntitySet — an OData containment-navigation target (`ContainsTarget="true"`, e.g. a contained `Media` collection) — was omitted. Downstream JSON-Schema generation then emitted a `$ref` to a definition that was never built, ajv failed to compile, and the whole `$expand` validator degraded to a 200-only gate, so schema-invalid expanded data went uncaught (a false-pass). Every declared EntityType is now emitted, keyed by type name so a `Collection(Ns.Type)` reference always resolves; deduped against the served entry keys so a contained type can never clobber a served resource. No-op for conformant RESO metadata (EntitySet name == type name).
+
+### `reso-certification` 0.10.6 – `$expand` gating + Core version normalization
+
+- **Config-mode version normalization.** Config sources supply the Core version as `"2.1"` (two-part) while the gates compared against the literal `"2.1.0"`; a bare cast let `"2.1"` through, so the `$expand` schema-validator gate read false in config-file mode — the data-validation half never ran on desktop / config-mode runs (a false-pass). Versions are normalized once at the SDK boundary (`coerceCoreVersion`), and an unknown/newer version clamps **up** to the current minor rather than down to the oldest baseline.
+- **The `$expand` gate enforces the data.** A present expansion must be a Collection of the target EntityType (a JSON array of entity objects; a malformed 200 envelope fails). Non-2xx (403/501) skips — expansion is optional, and not-accessible ≠ non-conformant. A collection navigation-property-path returning 204 fails: a collection returns 200 with an empty result set, never 204 (OData §11.2.7 / web-api-core §2.5.10.2, §2.6.1).
+- **`$expand` and the navigation-property-path form must be data-consistent (OData §11.2.7).** Both resolve the same relationship on the same entity, so they must agree on whether related entities exist; a records↔empty disagreement is a determinate fail. Both legs treat an empty page + `@odata.nextLink` as has-records, so server-driven paging never false-fails.
+- **`$select` may return additional fields** (OData 4.01 §11.2.5.1 — a service may return more than requested): the prior extra-field warning is dropped.
+
+**Tests:** Full monorepo suite now 2,181 passing across 8 packages.
+
+---
+
 ## reso-certification 0.10.5 – 2026-09-02
 
 A published-package patch to `reso-certification` – no monorepo release. Consumers on `^0.10.0` pick it up automatically; behavior-preserving for the CLI and cert-backend (no test-count change), and no other package changed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5626,7 +5626,7 @@
     },
     "reso-certification": {
       "name": "@reso-standards/reso-certification",
-      "version": "0.10.5",
+      "version": "0.10.6",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@reso-standards/reso-client": "^0.2.0",
@@ -5764,7 +5764,7 @@
     },
     "reso-metadata-utils": {
       "name": "@reso-standards/reso-metadata-utils",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "fast-xml-parser": "^5.5.10"

--- a/reso-certification/package.json
+++ b/reso-certification/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reso-standards/reso-certification",
-  "version": "0.10.5",
+  "version": "0.10.6",
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",

--- a/reso-certification/src/metadata/dd-metadata-checks.ts
+++ b/reso-certification/src/metadata/dd-metadata-checks.ts
@@ -465,7 +465,7 @@ export const checkExpansionStructure = (
 
 /** The Lookup Resource (string representation) entity set name and its mandatory metadata fields. */
 const LOOKUP_RESOURCE = 'Lookup';
-const LOOKUP_MANDATORY_FIELDS: ReadonlyArray<string> = ['LookupKey', 'LookupName', 'LookupValue', 'ModificationTimestamp'];
+export const LOOKUP_MANDATORY_FIELDS: ReadonlyArray<string> = ['LookupKey', 'LookupName', 'LookupValue', 'ModificationTimestamp'];
 
 /**
  * Lookup Resource mandatory fields (metadata): when a provider serves the string representation (a

--- a/reso-certification/src/sdk/config.ts
+++ b/reso-certification/src/sdk/config.ts
@@ -1,6 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import type { AuthConfig } from '../test-runner/types.js';
 import type { AddEditConfig, EntityEventConfig, CoreConfig, DDConfig } from './types.js';
+import { coerceCoreVersion } from './core-versions.js';
 import { coerceDDVersion } from './dd-versions.js';
 
 // ── Config File Types ──
@@ -210,7 +211,7 @@ export const configEntryToCore = (entry: ConfigEntry, providerUoi: string): Core
     url: entry.serviceRootUri,
     auth: resolveAuthFromEntry(entry),
   },
-  version: (entry.version as '2.0.0' | '2.1.0') ?? '2.0.0',
+  version: coerceCoreVersion(entry.version),
   ...(entry.originatingSystemName ? { originatingSystemName: entry.originatingSystemName } : {}),
   ...(entry.originatingSystemId ? { originatingSystemId: entry.originatingSystemId } : {}),
   options: {

--- a/reso-certification/src/sdk/core-versions.ts
+++ b/reso-certification/src/sdk/core-versions.ts
@@ -22,3 +22,45 @@ export const CURRENT_CORE_VERSION: CoreVersion = '2.1.0';
 /** Type guard: is this exact value a supported Core version? Narrows `string` → `CoreVersion` without a cast. */
 export const isCoreVersion = (version: string): version is CoreVersion =>
   (SUPPORTED_CORE_VERSIONS as ReadonlyArray<string>).includes(version);
+
+/** Split a dotted version into numeric segments; a missing or non-numeric segment reads as 0. Tolerates both
+ *  two-part (`2.1`) and three-part (`2.1.0`) input so a comparison never hinges on the exact string shape. */
+const versionSegments = (version: string): ReadonlyArray<number> =>
+  version.split('.').map((segment) => Number.parseInt(segment, 10) || 0);
+
+/** `true` when `version` is greater than or equal to `target` by numeric segment comparison. Shape-tolerant:
+ *  `coreVersionGte('2.1', '2.1.0')` is `true`. This is the ONE comparator every version-gated branch routes
+ *  through — a future DD comparator / general semver comparator can be lifted from this shape (see the module
+ *  header). */
+export const coreVersionGte = (version: string, target: string): boolean => {
+  const actual = versionSegments(version);
+  const required = versionSegments(target);
+  const width = Math.max(actual.length, required.length);
+  const firstDifference = Array.from({ length: width }, (_, i) => (actual[i] ?? 0) - (required[i] ?? 0)).find(
+    (delta) => delta !== 0,
+  );
+  return (firstDifference ?? 0) >= 0;
+};
+
+/** `true` for Core 2.1.0 and later — the version line that introduced the serving-mask, empty-required-resource
+ *  routing, and $expand schema-validation carve-outs. Core 2.0.0 predates all three. The SINGLE boundary
+ *  predicate every 2.1.0-gated branch shares, so the boundary literal lives in exactly one place. */
+export const isCore21OrLater = (version: string): boolean => coreVersionGte(version, '2.1.0');
+
+/** Normalize any caller-supplied version string to a canonical {@link CoreVersion}. Config sources hand the Core
+ *  version over in DD's two-part shape (`2.1`) as often as the canonical three-part (`2.1.0`); both MUST resolve
+ *  to the exact `CoreVersion` literal the gates compare against. A bare `as CoreVersion` cast previously let
+ *  `'2.1'` masquerade as valid, which silently disabled every 2.1.0-gated branch (the $expand validator among
+ *  them). Matches by MAJOR.MINOR against {@link SUPPORTED_CORE_VERSIONS}; an absent or unrecognizable version
+ *  falls back to {@link CURRENT_CORE_VERSION} — the current minor. That means an unrecognized-because-NEWER
+ *  version (e.g. a future `2.2` not yet in the supported set) certifies under the strictest known profile rather
+ *  than silently downgrading to the oldest baseline, which would be a false-PASS (skipping every 2.1.0 gate). */
+export const coerceCoreVersion = (version: string | undefined): CoreVersion => {
+  if (version && isCoreVersion(version)) return version;
+  const [major, minor] = (version ?? '').split('.');
+  const match = SUPPORTED_CORE_VERSIONS.find((candidate) => {
+    const [candidateMajor, candidateMinor] = candidate.split('.');
+    return candidateMajor === major && candidateMinor === minor;
+  });
+  return match ?? CURRENT_CORE_VERSION;
+};

--- a/reso-certification/src/sdk/core.ts
+++ b/reso-certification/src/sdk/core.ts
@@ -13,6 +13,7 @@ import { runCoreResourceScenarios, runProviderScenarios, summarizeScenarios, typ
 import { resolveNoRecordsOutcome, resolveServingDecision } from '../web-api-core/serving.js';
 import { createExpandSchemaValidator, isEnumerationIgnored, loadValidationConfig } from './expand-schema.js';
 import { FETCH_METADATA, RUN_CORE_SCENARIOS } from './step-names.js';
+import { coerceCoreVersion, isCore21OrLater } from './core-versions.js';
 import { generateMetadataReport } from '@reso-standards/reso-metadata-utils';
 import { isDeadlineError, runSettled } from '@reso-standards/reso-client';
 import { createCertSession, createSessionRequester, type ODataRequester } from '../test-runner/requester.js';
@@ -305,7 +306,7 @@ const sampleAndTest = (config: CoreConfig): PipelineStep<CoreContext> => ({
         return undefined;
       }
     };
-    const expandValidator = version === '2.1.0' ? await buildExpandValidator() : undefined;
+    const expandValidator = isCore21OrLater(version) ? await buildExpandValidator() : undefined;
 
     // Provider-wide structural pass — run ONCE for the whole provider, BEFORE the per-resource gate, so the
     // metadata + service-document scenarios are always recorded even if every resource ends up masked. The
@@ -551,7 +552,7 @@ const writeComplianceReports = (config: CoreConfig): PipelineStep<CoreContext> =
     // outputPath is prepped (built + archived + mkdir'd) by
     // runCoreCompliance before the pipeline starts so the fetch step
     // can persist metadata.xml. Reuse it here instead of rebuilding.
-    const generators = coreReportGenerators(config.version ?? '2.0.0');
+    const generators = coreReportGenerators(coerceCoreVersion(config.version));
 
     const resourceReports = ctx.resourceReports as ReadonlyArray<ResourceTestReport> ?? [];
     const totalFailed = resourceReports.reduce((sum, r) => sum + r.summary.failed, 0);
@@ -608,13 +609,20 @@ export const runCoreCompliance = async (
   config: CoreConfig,
   onProgress?: (progress: import('./types.js').StepProgress) => void,
 ) => {
-  const pipeline = createCorePipeline(config);
-  const resources = config.resources ?? WELL_KNOWN_RESOURCES.map(r => r.resource);
-  const outputPath = await prepareOutputDir('web-api-core', config.version ?? '2.0.0', config);
+  // Normalize the Core version to its canonical CoreVersion at the SDK boundary. Config sources hand it over as
+  // "2.1" as often as "2.1.0", and EVERY version gate downstream (the $expand validator, the serving carve-outs,
+  // scenario selection) plus the output-dir path and the report's version stamp read from this one value. A bare
+  // cast previously let "2.1" through, silently disabling the 2.1.0 gates. coerceCoreVersion is idempotent, so a
+  // caller that already passed a canonical version is unaffected. See core-versions.ts.
+  const version = coerceCoreVersion(config.version);
+  const normalizedConfig: CoreConfig = { ...config, version };
+  const pipeline = createCorePipeline(normalizedConfig);
+  const resources = normalizedConfig.resources ?? WELL_KNOWN_RESOURCES.map(r => r.resource);
+  const outputPath = await prepareOutputDir('web-api-core', version, normalizedConfig);
   const initialContext: CoreContext = {
-    serverUrl: config.server.url,
-    version: config.version ?? '2.0.0',
-    enumMode: config.enumMode ?? 'auto',
+    serverUrl: normalizedConfig.server.url,
+    version,
+    enumMode: normalizedConfig.enumMode ?? 'auto',
     resources,
     outputPath,
   };

--- a/reso-certification/src/web-api-core/queries.ts
+++ b/reso-certification/src/web-api-core/queries.ts
@@ -389,8 +389,8 @@ const buildQueryForCategory = (
       return buildInOperatorUrl(serverUrl, resource, params, scenario);
     case 'expand':
       return buildExpandUrl(serverUrl, resource, params, scenario);
-    case 'paging':
-      return { url: `${serverUrl}/${resource}?$top=1&$count=true`, selectFields: [params.keyField] };
+    // 'paging' is dispatched in runScenario before buildScenarioQuery (it builds its own URLs), so it is
+    // intentionally omitted here — like 'lookup-resource' — and buildQueryForCategory returns undefined for it.
   }
 };
 

--- a/reso-certification/src/web-api-core/scenarios.ts
+++ b/reso-certification/src/web-api-core/scenarios.ts
@@ -5,6 +5,8 @@
  * A single generic runner executes them all.
  */
 
+import { coreVersionGte } from '../sdk/core-versions.js';
+
 /** Comparison operators for scalar filters. */
 export type ComparisonOp = 'eq' | 'ne' | 'gt' | 'ge' | 'lt' | 'le';
 
@@ -298,8 +300,8 @@ export const allScenarios: ReadonlyArray<CoreScenario> = [
   ...expandScenarios,
 ];
 
-/** Get scenarios applicable to a given version. */
+/** Get scenarios applicable to a given version: a scenario is included when the run version is at or above the
+ *  scenario's own `minVersion`. Data-driven off each scenario's declared minimum rather than a hardcoded version
+ *  branch, so a new version line (2.2.0) picks up 2.1.0 scenarios automatically. */
 export const scenariosForVersion = (version: '2.0.0' | '2.1.0'): ReadonlyArray<CoreScenario> =>
-  version === '2.0.0'
-    ? allScenarios.filter(s => s.minVersion === '2.0.0')
-    : allScenarios;
+  allScenarios.filter(s => coreVersionGte(version, s.minVersion));

--- a/reso-certification/src/web-api-core/serving.ts
+++ b/reso-certification/src/web-api-core/serving.ts
@@ -16,6 +16,7 @@
  */
 
 import type { EntityType, ParsedEntitySet } from '../test-runner/types.js';
+import { isCore21OrLater } from '../sdk/core-versions.js';
 import { REQUIRED_RESOURCES_V21, WELL_KNOWN_RESOURCES } from './sampling.js';
 
 /** Whether a resource is PRESENT / ABSENT in a served-top-level surface, or the surface is INDETERMINATE. */
@@ -106,7 +107,7 @@ export const resolveServingDecision = (args: {
   const { resource, entityType, version, servedEntitySets, declaredEntitySets } = args;
 
   // The carve-out is gated to Core 2.1.0+; 2.0.0 behaves exactly as written today (declared ⇒ assumed served).
-  if (version === '2.0.0') return 'run';
+  if (!isCore21OrLater(version)) return 'run';
   // Only recognized (well-known / required) resources are eligible to be masked.
   if (!MASKABLE_RESOURCES.has(resource)) return 'run';
 
@@ -141,6 +142,6 @@ export const resolveNoRecordsOutcome = (
   version: '2.0.0' | '2.1.0',
   hasTopLevelRecords: boolean,
 ): ServingDecision => {
-  if (hasTopLevelRecords || version === '2.0.0') return 'run';
+  if (hasTopLevelRecords || !isCore21OrLater(version)) return 'run';
   return REQUIRED_RESOURCES_V21.includes(resource) ? 'fail' : 'na';
 };

--- a/reso-certification/src/web-api-core/test-runner.ts
+++ b/reso-certification/src/web-api-core/test-runner.ts
@@ -988,6 +988,12 @@ const runScenario = async (
     return runEnumFamilyScenario(serverUrl, resource, scenario, params, authToken, start, op, requester);
   }
 
+  // Paging builds and walks its own URLs ($top=2 then $top=1), so it does not route through
+  // buildScenarioQuery — dispatch it before the skip-gate so it is never skipped for a "missing query".
+  if (scenario.category === 'paging') {
+    return runPagingScenario(serverUrl, resource, params, authToken, start, requester);
+  }
+
   // Build query — undefined means required params missing, skip.
   const query = buildScenarioQuery(serverUrl, resource, scenario, params);
   if (!query) {
@@ -997,9 +1003,6 @@ const runScenario = async (
   try {
     if (scenario.category === 'structural') {
       return runStructuralScenario(serverUrl, resource, scenario.assertion, query, params, authToken, start, requester);
-    }
-    if (scenario.category === 'paging') {
-      return runPagingScenario(serverUrl, resource, params, authToken, start, requester);
     }
     if (scenario.category === 'error') {
       const reqStart = Date.now();

--- a/reso-certification/src/web-api-core/test-runner.ts
+++ b/reso-certification/src/web-api-core/test-runner.ts
@@ -428,11 +428,27 @@ const collectExpandedItems = (
   navName: string,
 ): ReadonlyArray<Record<string, unknown>> =>
   records.flatMap((record) => {
+    if (record == null || typeof record !== 'object') return []; // null-safe: a null/non-object parent yields nothing
     const expanded = record[navName];
     return Array.isArray(expanded)
       ? expanded.filter((x): x is Record<string, unknown> => x != null && typeof x === 'object')
       : [];
   });
+
+/** Shape-check a PRESENT expanded / navigation-property-path collection VALUE: it MUST be a JSON array (`[]` when
+ *  empty, else a Collection of entity objects). Returns an error phrase when malformed — not an array, or an array
+ *  carrying a non-entity element (null, a scalar, a nested array) — else null. The objects' SCHEMA validity is
+ *  checked separately (validateExpandedItems); this is the shape gate the "must be a Collection of the target
+ *  EntityType" rule needs, so a garbage collection (Media:[null], {value:null}) can't pass with zero validation. */
+const collectionShapeError = (value: unknown): string | null => {
+  if (!Array.isArray(value)) {
+    return `value is ${value === null ? 'null' : typeof value}, not a JSON array`;
+  }
+  const badIdx = value.findIndex((el) => el === null || typeof el !== 'object' || Array.isArray(el));
+  return badIdx === -1
+    ? null
+    : `element ${badIdx} is ${value[badIdx] === null ? 'null' : Array.isArray(value[badIdx]) ? 'an array' : typeof value[badIdx]}, not an entity object`;
+};
 
 /**
  * Schema-validate every expanded child item under ONE collection nav against its target entity type — the
@@ -468,7 +484,10 @@ export const validateExpandedItems = (
 /**
  * Execute the $expand test for ONE declared collection nav (Core 2.1.0, GATING). GET
  * {resource}?$expand={nav}&$top=5, then:
- *   - non-200 → FAIL (a declared nav that cannot be expanded — the parallel of declared-but-not-served);
+ *   - non-2xx → SKIP (expansion not available to this client, e.g. 403 — an access/permission boundary,
+ *     OData 4.01 §11.2.5 "not available … not returned"; NOT a Core failure);
+ *   - 200 with an explicit `null` collection value → FAIL (a collection-valued property is a JSON array,
+ *     empty at most, never null);
  *   - 200 → schema-validate every expanded child item against `nav.targetType`; a schema-invalid item FAILS;
  *   - a transport/parse error (no determinate server response) → SKIPPED + errored (indeterminate, NOT a
  *     failure) so a network blip can't false-fail a compliant server.
@@ -501,12 +520,54 @@ const runOneExpandNav = async (
     const response = await requester.request({ method: 'GET', url: query.url, authToken });
     const requestLatency = Date.now() - reqStart;
     const responseCheck = assertODataResponse(response, 200);
+    // Gate the SKIP on the STATUS, not on assertODataResponse. $expand is OPTIONAL (RESO Core: "providers who
+    // support expand"; OData Intermediate conformance does not require it), so a NON-2xx is the spec-conformant
+    // "not supported / not authorised / no data" decline (OData §9.3.1 501 Not Implemented; §11.2 unsupported
+    // option MUST-fail-and-SHOULD-501; §11.2.5 permissions) → SKIP and report the status, never a determinate
+    // FAIL. A 200 whose OData envelope is malformed (missing/invalid OData-Version, null body) ALSO fails
+    // responseCheck — but that is a served-but-broken response, which we DO fault (below).
+    if (response.status < 200 || response.status >= 300) {
+      return {
+        tag,
+        name,
+        passed: true,
+        skipped: true,
+        assertions: [{ passed: true, message: `$expand ${nav.name}: HTTP ${response.status} — expansion not supported / not accessible for this client (optional per RESO Core; OData §9.3.1/§11.2); skipped, status reported` }],
+        duration: Date.now() - start,
+        requestLatency,
+        requestUrl: query.url,
+      };
+    }
     assertions.push(responseCheck);
     if (!responseCheck.passed) {
-      // A declared collection nav that non-200s cannot be expanded → determinate FAIL.
+      // Status IS 200 but the OData envelope is malformed (missing/invalid OData-Version, null body) — a
+      // served-but-broken expansion response ("we saw it, tested it, it outright fails") → determinate FAIL.
       return { tag, name, passed: false, skipped: false, assertions, duration: Date.now() - start, requestLatency, requestUrl: query.url };
     }
-    const records = extractRecords(response.body);
+    // Null/non-object parent entries (a malformed `{value:[null]}` base collection) are filtered out once here so
+    // NO downstream access (`nav.name in r`, `r[keyField]`, collectExpandedItems) can throw on a null record — a
+    // served-but-broken parent list must never surface as an indeterminate transport-error skip.
+    const records = extractRecords(response.body).filter((r): r is Record<string, unknown> => r != null && typeof r === 'object');
+    // A 2xx expansion MUST return a JSON array — `[]` when empty, else a Collection of ${nav.targetType} entities
+    // (RESO Core). Shape-check every parent's PRESENT nav value: a non-array (null/object/scalar) OR an array
+    // carrying a non-entity element is malformed → determinate FAIL. (An ABSENT nav is left to pass — open Q with
+    // Josh: must a 2xx expand of an advertised nav carry it as `[]`?) Parent records are null-guarded.
+    const shapeErr = records
+      .filter((r): r is Record<string, unknown> => r != null && typeof r === 'object' && nav.name in r && r[nav.name] !== undefined)
+      .map((r) => collectionShapeError(r[nav.name]))
+      .find((e): e is string => e !== null);
+    if (shapeErr) {
+      return {
+        tag,
+        name,
+        passed: false,
+        skipped: false,
+        assertions: [...assertions, { passed: false, message: `$expand ${nav.name}: expanded collection ${shapeErr} — a 2xx expansion must return an array ([] when empty, else a Collection of ${nav.targetType}); OData 4.01 JSON Format collection representation` }],
+        duration: Date.now() - start,
+        requestLatency,
+        requestUrl: query.url,
+      };
+    }
     const warnings = expandRrkWarnings(records, scenario, navParams);
     if (!validator) {
       // The expanded-item schema validator could not be built for this run (the provider's metadata did not
@@ -533,29 +594,67 @@ const runOneExpandNav = async (
     // the (large) parent record (the key is already in the $expand response). Assert 200 + a schema-valid
     // collection of the nav target type. An empty $expand response yields no key → the leg can't run (no data,
     // not a failure).
-    const parentKey = records.map((r) => r[params.keyField]).find((k) => k != null);
-    if (parentKey == null) {
+    // Prefer a "witness" parent whose $expand response returned items, so the has-records leg of the dual is
+    // exercised on real data; fall back to the first parent with a key (drives the empty↔empty comparison).
+    const parentItemsOf = (r: Record<string, unknown>): ReadonlyArray<unknown> => {
+      const value = r[nav.name];
+      return Array.isArray(value) ? value.filter((x) => x != null && typeof x === 'object') : [];
+    };
+    const chosenParent =
+      records.find((r) => r[params.keyField] != null && parentItemsOf(r).length > 0) ??
+      records.find((r) => r[params.keyField] != null);
+    if (chosenParent == null) {
       assertions.push({ passed: true, message: `$expand ${nav.name}: no parent key in the $expand response — navigation-property-path leg not exercised (no data)` });
     } else {
+      const parentKey = chosenParent[params.keyField];
+      const expandItemCount = parentItemsOf(chosenParent).length;
+      // A paged inline expansion can return an empty page for this parent alongside a `{nav}@odata.nextLink`
+      // sibling — related entities exist, just not on this page — so count that as has-records too (OData JSON
+      // Format §4.5.5). The same tolerance is applied to the nav-path leg below; without it, an empty-first-page
+      // server would false-fail the has-records dual.
+      const expandHasRecords = expandItemCount > 0 || chosenParent[`${nav.name}@odata.nextLink`] != null;
       const navPathUrl = `${serverUrl}/${resource}('${encodeURIComponent(String(parentKey))}')/${nav.name}`;
       const navResp = await requester.request({ method: 'GET', url: navPathUrl, authToken });
       const navStatus = assertODataResponse(navResp, 200);
-      assertions.push(
-        navStatus.passed
-          ? { passed: true, message: `Navigation-property-path GET ${resource}('…')/${nav.name} → 200` }
-          : { passed: false, message: `Navigation-property-path GET ${resource}('…')/${nav.name} → HTTP ${navResp.status} (expected 200; a declared collection expansion MUST be reachable via its navigation-property path — web-api-core.md §2.5.10.2)` },
-      );
-      if (navStatus.passed) {
-        const navItems = extractRecords(navResp.body);
-        const invalid = navItems.flatMap((item, index) => {
-          const { valid, errors } = validator.validate(item, nav.targetType);
-          return valid ? [] : [{ index, errors }];
-        });
-        assertions.push(
-          invalid.length === 0
-            ? { passed: true, message: `Navigation-property-path ${nav.name}: ${navItems.length} item(s) valid against ${nav.targetType}` }
-            : { passed: false, message: `Navigation-property-path ${nav.name}: ${invalid.length}/${navItems.length} item(s) schema-invalid against ${nav.targetType} — item ${invalid[0].index}: ${invalid[0].errors.slice(0, 3).join('; ') || 'schema validation failed'}` },
-        );
+      if (navResp.status < 200 || navResp.status >= 300) {
+        // Non-2xx nav-property-path GET → the expansion isn't served here (not supported / not accessible / no
+        // data); $expand is optional → not faulted, status reported (same rule as the primary leg). This is a
+        // "can't access" boundary, not a records comparison.
+        assertions.push({ passed: true, message: `Navigation-property-path GET ${resource}('…')/${nav.name} → HTTP ${navResp.status} — not supported / not accessible for this client (OData §9.3.1/§11.2); not faulted, status reported` });
+      } else if (!navStatus.passed) {
+        // A 2xx that is not 200 (e.g. 204 No Content) is the wrong code for a COLLECTION navigation-property-path:
+        // OData §11.2.7 requires the collection of related entities, empty ONLY as a 200 empty result set — a
+        // collection is never represented as 204 (204 is for a null single-valued nav). Served-but-wrong → FAIL.
+        assertions.push({ passed: false, message: `Navigation-property-path GET ${resource}('…')/${nav.name} → HTTP 200 expected but got a malformed/wrong-code response (${navStatus.message}) — a collection navigation-property-path returns 200 with an empty result set when none, never 204 (OData §11.2.7; web-api-core.md §2.5.10.2/§2.6.1)` });
+      } else {
+        // The nav-path collection value MUST be a JSON array of entity objects too (same rule as the inline leg —
+        // symmetry: `{value:null}` / a non-array / an array of non-entities is malformed, not a vacuous pass).
+        const navShapeErr = collectionShapeError((navResp.body as Record<string, unknown> | null)?.value);
+        if (navShapeErr) {
+          assertions.push({ passed: false, message: `Navigation-property-path ${nav.name}: collection ${navShapeErr} — a collection navigation-property-path must return a JSON array of ${nav.targetType} entities (web-api-core.md §2.5.10.2)` });
+        } else {
+          const navItems = extractRecords(navResp.body);
+          const navHasRecords = navItems.length > 0 || extractNextLink(navResp.body) != null;
+          // Data-consistency of the dual (OData §11.2.7): `$expand=X` and `Resource('key')/X` resolve the SAME
+          // relationship on the SAME entity, so they MUST agree on whether related entities exist — a collection
+          // nav-path is empty ONLY when none are related. If the $expand returned items for this parent but the
+          // nav-path is empty (or vice versa), the server contradicts itself on one relationship → determinate FAIL.
+          // (Both sides tolerate an empty page + @odata.nextLink as has-records, so paging never false-fails.)
+          if (expandHasRecords !== navHasRecords) {
+            assertions.push({ passed: false, message: `Navigation-property-path ${nav.name}: $expand=${nav.name} returned ${expandItemCount} item(s) for this ${params.keyField} but ${resource}('…')/${nav.name} returned ${navItems.length} — the $expand and navigation-property-path forms resolve the same relationship and MUST agree on whether related entities exist (OData §11.2.7; web-api-core.md §2.5.10.2)` });
+          } else {
+            assertions.push({ passed: true, message: `Navigation-property-path GET ${resource}('…')/${nav.name} → 200 (${navItems.length} item(s), consistent with $expand)` });
+            const invalid = navItems.flatMap((item, index) => {
+              const { valid, errors } = validator.validate(item, nav.targetType);
+              return valid ? [] : [{ index, errors }];
+            });
+            if (invalid.length > 0) {
+              assertions.push({ passed: false, message: `Navigation-property-path ${nav.name}: ${invalid.length}/${navItems.length} item(s) schema-invalid against ${nav.targetType} — item ${invalid[0].index}: ${invalid[0].errors.slice(0, 3).join('; ') || 'schema validation failed'}` });
+            } else if (navItems.length > 0) {
+              assertions.push({ passed: true, message: `Navigation-property-path ${nav.name}: ${navItems.length} item(s) valid against ${nav.targetType}` });
+            }
+          }
+        }
       }
     }
 
@@ -1313,28 +1412,22 @@ export const runStructuralScenario = async (
       // only that ≥1 selected field carries data (WebAPIServerCore.java `numFieldsWithData > 0`) — it iterates the
       // select list and never checks for fields OUTSIDE it. So "the server returned a field outside the $select
       // list" (it ignored the projection) is STRICTER THAN the oracle on an existing Core 2.0.0 element: a
-      // $select-ignoring server that passed the Commander must NOT newly fail here. We surface it as a NON-GATING
-      // WARNING (observe-then-flip, like single-enum `ne`), pending WG sign-off — never a verdict-gating fail. We
-      // also deliberately do not fault an ABSENT projected field (OData permits omitting a null property, §11.2.4.1).
+      // $select-ignoring server that passed the Commander must NOT newly fail here — and OData 4.01 §11.2.5.1
+      // settles it: $select "requests that the service return only the properties … and MAY return additional
+      // information", so returning fields outside the list is PERMITTED, not a defect. We therefore do not flag it.
+      // An ABSENT projected field is likewise not faulted (content returned "if available", §11.2.5.1).
       const records = extractRecords(response.body);
       const projectedDataFields = query.selectFields.filter(f => f !== params.keyField);
       if (projectedDataFields.length === 0) {
         assertions.push({ passed: true, message: '$select: no non-key field available to project — multi-field projection not exercised on this resource' });
       } else {
-        const selected = new Set(query.selectFields);
-        const extraField = records.flatMap(r => Object.keys(r)).find(k => !k.startsWith('@') && !selected.has(k));
-        if (extraField !== undefined) {
-          warnings.push(`$select projected {${query.selectFields.join(', ')}} but a returned record also carries unselected field '${extraField}' — the server did not narrow the projection. Stricter than Core 2.0.0 (the Commander does not check this); reported as a WARNING pending WG sign-off, not failed.`);
-          assertions.push({ passed: true, message: `$select projection: reported for review, not failed (see warnings) — unselected field '${extraField}' returned` });
-        } else {
-          const confirmed = projectedDataFields.filter(f => records.some(r => f in r));
-          assertions.push({
-            passed: true,
-            message: confirmed.length > 0
-              ? `$select honored: projection narrowed to the selected fields (present: ${confirmed.join(', ')})`
-              : '$select honored: returned records carry only selected fields (projected data field null/omitted on this page — not a defect)',
-          });
-        }
+        const confirmed = projectedDataFields.filter(f => records.some(r => f in r));
+        assertions.push({
+          passed: true,
+          message: confirmed.length > 0
+            ? `$select: projected fields present (${confirmed.join(', ')}); additional properties permitted (OData 4.01 §11.2.5.1)`
+            : '$select: projected data field null/omitted on this page — not a defect (OData 4.01 §11.2.5.1)',
+        });
       }
     } else {
       // service-document

--- a/reso-certification/tests/metadata/dd-metadata-checks.test.ts
+++ b/reso-certification/tests/metadata/dd-metadata-checks.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { resolve } from 'node:path';
 import {
   checkDisallowedSynonyms, checkClosedEnumValues, checkStandardLookupValuePresent, checkFieldTypes, checkExpansionStructure, checkSuggestedMaxConstraints,
-  checkLookupResourceFields, checkLookupNameAnnotations, runDdMetadataChecks,
+  checkLookupResourceFields, checkLookupNameAnnotations, runDdMetadataChecks, LOOKUP_MANDATORY_FIELDS,
 } from '../../src/metadata/dd-metadata-checks.js';
 import type { DdReference } from '../../src/metadata/dd-metadata-checks.js';
 import { generateReferenceArtifacts } from '../../src/metadata/reference-artifacts.js';
@@ -307,6 +307,37 @@ describe('Lookup Resource checks', () => {
       const findings = checkLookupResourceFields(makeReport(fields, []), reference);
       expect(findings).toHaveLength(1);
       expect(findings[0]).toMatchObject({ check: 'lookup-resource-fields', fieldName: 'ModificationTimestamp', severity: 'error' });
+    });
+
+    // F.3 — each mandatory field independently (order-independent; not keyed to ModificationTimestamp)
+    it.each([...LOOKUP_MANDATORY_FIELDS])('flags a missing %s', (missing) => {
+      const fields = LOOKUP_MANDATORY_FIELDS.filter((f) => f !== missing).map((fieldName) => ({ resourceName: 'Lookup', fieldName, type: 'Edm.String' }));
+      const findings = checkLookupResourceFields(makeReport(fields, []), reference);
+      expect(findings).toHaveLength(1);
+      expect(findings[0]).toMatchObject({ check: 'lookup-resource-fields', resourceName: 'Lookup', fieldName: missing, severity: 'error' });
+    });
+
+    // F.4 — multiple missing → one finding per missing field
+    it('emits one finding per missing mandatory field', () => {
+      const fields = ['LookupName', 'LookupValue'].map((fieldName) => ({ resourceName: 'Lookup', fieldName, type: 'Edm.String' })); // LookupKey + ModificationTimestamp absent
+      const findings = checkLookupResourceFields(makeReport(fields, []), reference);
+      expect(findings).toHaveLength(2);
+      expect(new Set(findings.map((f) => f.fieldName))).toEqual(new Set(['LookupKey', 'ModificationTimestamp']));
+      expect(findings.every((f) => f.check === 'lookup-resource-fields' && f.severity === 'error')).toBe(true);
+    });
+
+    // F.5 — the declaration gate must NOT require the optional StandardLookupValue / LegacyODataValue columns
+    // (declaration vs value: SLV's conditional presence is the separate checkStandardLookupValuePresent rule).
+    it('does not require the optional StandardLookupValue / LegacyODataValue columns', () => {
+      const mandatory = LOOKUP_MANDATORY_FIELDS.map((fieldName) => ({ resourceName: 'Lookup', fieldName, type: 'Edm.String' }));
+      expect(checkLookupResourceFields(makeReport(mandatory, []), reference)).toEqual([]);
+      const withOptionals = [...mandatory, ...['StandardLookupValue', 'LegacyODataValue'].map((fieldName) => ({ resourceName: 'Lookup', fieldName, type: 'Edm.String' }))];
+      expect(checkLookupResourceFields(makeReport(withOptionals, []), reference)).toEqual([]);
+    });
+
+    // drift-snapshot — locks the mandatory set against source drift
+    it('locks the mandatory Lookup field set (guards required-set drift)', () => {
+      expect([...LOOKUP_MANDATORY_FIELDS]).toEqual(['LookupKey', 'LookupName', 'LookupValue', 'ModificationTimestamp']);
     });
   });
 

--- a/reso-certification/tests/sdk/config.test.ts
+++ b/reso-certification/tests/sdk/config.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { resolve } from 'node:path';
 import { CURRENT_DD_VERSION } from '../../src/sdk/dd-versions.js';
+import { CURRENT_CORE_VERSION } from '../../src/sdk/core-versions.js';
 import {
   loadConfigFile,
   normalizeConfigFile,
@@ -182,7 +183,9 @@ describe('configEntryToEntityEvent', () => {
 });
 
 describe('configEntryToCore', () => {
-  it('converts with default version', () => {
+  it('converts an entry with no version to the current Core minor', () => {
+    // An absent version resolves to CURRENT_CORE_VERSION (the current minor), not the 2.0.0 baseline — an
+    // unknown version certifies under the strictest known profile rather than silently downgrading.
     const config = configEntryToCore({
       serviceRootUri: 'https://api.example.com',
       recipientUoi: 'R001',
@@ -191,7 +194,34 @@ describe('configEntryToCore', () => {
     }, 'P001');
 
     expect(config.endorsement).toBe('core');
-    expect(config.version).toBe('2.0.0');
+    expect(config.version).toBe(CURRENT_CORE_VERSION);
+  });
+
+  it('normalizes a two-part config version ("2.1") to the canonical Core literal ("2.1.0")', () => {
+    // The config-mode bug: reso-certification-utils supplies the Core version as "2.1", and the old bare
+    // `as CoreVersion` cast passed it straight through — so `version === '2.1.0'` gates (the $expand schema
+    // validator) never fired. The entry must resolve to the exact canonical literal.
+    const config = configEntryToCore({
+      serviceRootUri: 'https://api.example.com',
+      recipientUoi: 'R001',
+      providerUsi: 'S001',
+      token: 'test-token',
+      version: '2.1',
+    }, 'P001');
+
+    expect(config.version).toBe('2.1.0');
+  });
+
+  it('passes an already-canonical config version through unchanged', () => {
+    const config = configEntryToCore({
+      serviceRootUri: 'https://api.example.com',
+      recipientUoi: 'R001',
+      providerUsi: 'S001',
+      token: 'test-token',
+      version: '2.1.0',
+    }, 'P001');
+
+    expect(config.version).toBe('2.1.0');
   });
 
   it('threads OriginatingSystemName/ID from the entry (reso-certification-utils format)', () => {

--- a/reso-certification/tests/sdk/core-versions.test.ts
+++ b/reso-certification/tests/sdk/core-versions.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { SUPPORTED_CORE_VERSIONS, CURRENT_CORE_VERSION, isCoreVersion } from '../../src/sdk/core-versions.js';
+import {
+  SUPPORTED_CORE_VERSIONS,
+  CURRENT_CORE_VERSION,
+  isCoreVersion,
+  coerceCoreVersion,
+  coreVersionGte,
+  isCore21OrLater,
+} from '../../src/sdk/core-versions.js';
 import { scenariosForVersion } from '../../src/web-api-core/scenarios.js';
 
 describe('SUPPORTED_CORE_VERSIONS is the single source of truth', () => {
@@ -31,5 +38,64 @@ describe('isCoreVersion narrows safely (no `as` casts needed at the CLI boundary
     for (const bad of ['2.1', '2.2.0', '9.9.9', '', 'latest', '2.1.0 ']) {
       expect(isCoreVersion(bad)).toBe(false);
     }
+  });
+});
+
+describe('coerceCoreVersion normalizes any config-supplied shape to a canonical CoreVersion', () => {
+  it('maps the two-part DD shape to the three-part Core literal (the config-mode bug)', () => {
+    // Config sources hand the Core version over as "2.1"; the gates compare against the literal "2.1.0".
+    // A bare `as` cast let "2.1" through and silently disabled every 2.1.0-gated branch. This is the fix.
+    expect(coerceCoreVersion('2.1')).toBe('2.1.0');
+    expect(coerceCoreVersion('2.0')).toBe('2.0.0');
+  });
+
+  it('is idempotent on already-canonical input', () => {
+    expect(coerceCoreVersion('2.1.0')).toBe('2.1.0');
+    expect(coerceCoreVersion('2.0.0')).toBe('2.0.0');
+  });
+
+  it('falls back to CURRENT_CORE_VERSION (the current minor) for absent / unrecognizable input', () => {
+    // An unrecognized-because-newer version certifies under the strictest known profile, never the oldest
+    // baseline (that would be a false-PASS skipping every 2.1.0 gate). "9.9" (above the supported set) and
+    // garbage both clamp UP to the current minor rather than down to 2.0.0.
+    expect(coerceCoreVersion(undefined)).toBe(CURRENT_CORE_VERSION);
+    expect(coerceCoreVersion('')).toBe(CURRENT_CORE_VERSION);
+    expect(coerceCoreVersion('banana')).toBe(CURRENT_CORE_VERSION);
+    expect(coerceCoreVersion('9.9')).toBe(CURRENT_CORE_VERSION);
+    expect(CURRENT_CORE_VERSION).toBe('2.1.0');
+  });
+
+  it('ALWAYS produces a value that passes isCoreVersion (the cast can no longer lie)', () => {
+    for (const input of ['2.1', '2.0', '2.1.0', '2.0.0', '2.1.5', '', 'garbage', undefined]) {
+      expect(isCoreVersion(coerceCoreVersion(input))).toBe(true);
+    }
+  });
+});
+
+describe('coreVersionGte compares numerically and tolerates two- or three-part shapes', () => {
+  it('treats "2.1" and "2.1.0" as equal (shape-tolerant)', () => {
+    expect(coreVersionGte('2.1', '2.1.0')).toBe(true);
+    expect(coreVersionGte('2.1.0', '2.1')).toBe(true);
+  });
+  it('orders versions numerically, not lexically', () => {
+    expect(coreVersionGte('2.1.0', '2.0.0')).toBe(true);
+    expect(coreVersionGte('2.0.0', '2.1.0')).toBe(false);
+    expect(coreVersionGte('2.2.0', '2.1.0')).toBe(true); // future line clears the 2.1.0 bar
+    expect(coreVersionGte('2.10.0', '2.9.0')).toBe(true); // numeric, not string ("2.10" > "2.9")
+  });
+});
+
+describe('isCore21OrLater is the single 2.1.0 boundary predicate', () => {
+  it('is true for 2.1.0 and later — INCLUDING the two-part "2.1" a config supplies', () => {
+    // The regression that would have caught the bug: a "2.1" config must ENABLE the 2.1.0 gates
+    // (the $expand validator among them), not disable them.
+    expect(isCore21OrLater(coerceCoreVersion('2.1'))).toBe(true);
+    expect(isCore21OrLater('2.1')).toBe(true);
+    expect(isCore21OrLater('2.1.0')).toBe(true);
+    expect(isCore21OrLater('2.2.0')).toBe(true);
+  });
+  it('is false for the 2.0.0 baseline (both shapes)', () => {
+    expect(isCore21OrLater('2.0.0')).toBe(false);
+    expect(isCore21OrLater('2.0')).toBe(false);
   });
 });

--- a/reso-certification/tests/web-api-core/expand-gating.test.ts
+++ b/reso-certification/tests/web-api-core/expand-gating.test.ts
@@ -16,9 +16,12 @@ import { createExpandSchemaValidator } from '../../src/sdk/expand-schema.js';
 import { coreVerdict } from '../../src/sdk/core.js';
 
 // FULL Core 2.1.0 $expand gating. THE RULE (RESO standards lead): $expand is tested per declared COLLECTION
-// navigation property. No nav → N/A skip (never a failure). A declared collection nav is GATING: non-200 →
-// FAIL; 200 → schema-validate each expanded child item against its target entity type (a schema-invalid item →
-// FAIL). The RRK expanded-item warning still rides alongside, non-gating. A compliant server never false-fails.
+// navigation property. No nav → N/A skip (never a failure). A declared collection nav GATES on the DATA:
+// non-2xx → SKIP (expansion not available to this client, e.g. 403 — an access/permission boundary, OData 4.01
+// §11.2.5; not a Core failure); 200 with an explicit `null` collection value → FAIL (a collection is a JSON
+// array, never null); 200 with items → schema-validate each expanded child against its target entity type (a
+// schema-invalid item → FAIL). The RRK expanded-item warning rides alongside, non-gating. A compliant server
+// never false-fails, and enforcement runs only when the expansion actually returns data.
 
 const require = createRequire(import.meta.url);
 const { getReferenceMetadata } = require(resolve(import.meta.dirname, '../../src/etl/index.cjs'));
@@ -106,7 +109,11 @@ describe('runExpandNavScenarios — no collection nav → N/A skip (never a fail
 describe('runExpandNavScenarios — a declared collection nav is GATING', () => {
   it('200 + a schema-valid expanded item → PASS', async () => {
     const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
-    const req = requesterFor({ Media: okExpand([{ AboveGradeFinishedAreaSource: 'Appraiser' }]) });
+    // nav-path dual kept data-consistent with the $expand (records ↔ records) per §11.2.7.
+    const req = requesterFor(
+      { Media: okExpand([{ AboveGradeFinishedAreaSource: 'Appraiser' }]) },
+      { Media: navPathResponse([{ AboveGradeFinishedAreaSource: 'Appraiser' }]) },
+    );
     const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', req, validator);
     expect(results).toHaveLength(1);
     expect(results[0].tag).toBe('expand-Media');
@@ -116,13 +123,128 @@ describe('runExpandNavScenarios — a declared collection nav is GATING', () => 
     expect(summarizeScenarios(results).passed).toBe(1);
   });
 
-  it('a declared nav that non-200s → FAIL (declared but not expandable)', async () => {
+  it('a declared nav that non-2xx (e.g. 403 not-authorised) → SKIP, never a FAIL (access/permission boundary)', async () => {
+    // OData 4.01 §11.2.5: "Properties that are not available, for example due to permissions, are not returned."
+    // A 403 "Client is not authorised to $expand Resource" is an entitlement boundary, not a Core violation.
     const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
-    const req = requesterFor({ Media: status(400) });
+    const req = requesterFor({ Media: status(403) });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', req, validator);
+    expect(results[0].skipped).toBe(true);
+    expect(results[0].passed).toBe(true); // a skip is passed:true + skipped:true — never counted as a failure
+    expect(results[0].assertions.every((a) => a.passed)).toBe(true);
+    expect(results[0].assertions.some((a) => a.message.includes('403') && a.message.toLowerCase().includes('not supported') && a.message.toLowerCase().includes('skipped'))).toBe(true);
+    const summary = summarizeScenarios(results);
+    expect(summary.failed).toBe(0);
+    expect(summary.skipped).toBe(1);
+  });
+
+  it('a declared nav that 500s → SKIP, report the status, move on (a crash returns no data to test)', async () => {
+    // Josh: a 500 returns no data to test → skip (the "outright fail" is reserved for a testable 2xx response).
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    const req = requesterFor({ Media: status(500) });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', req, validator);
+    expect(results[0].skipped).toBe(true);
+    expect(results[0].passed).toBe(true); // a skip is passed:true + skipped:true — never a failure
+    expect(results[0].assertions.some((a) => a.message.includes('500'))).toBe(true); // status reported
+    expect(summarizeScenarios(results).failed).toBe(0);
+  });
+
+  it('200 with a NON-ARRAY collection value ({} / scalar / string) → FAIL (a collection must be a JSON array)', async () => {
+    // "outright fails": a 2xx whose expanded value isn't a Collection — not just null, but any non-array. Must be
+    // `[]` when empty, else a Collection of the target type.
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    for (const bad of [{} as unknown, 42 as unknown, 'x' as unknown]) {
+      const req = requesterFor({ Media: okExpand(bad) });
+      const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', req, validator);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].skipped).toBe(false);
+      expect(results[0].assertions.some((a) => !a.passed && a.message.toLowerCase().includes('not a json array'))).toBe(true);
+      expect(summarizeScenarios(results).failed).toBe(1);
+    }
+  });
+
+  it('a 200 with a MALFORMED OData envelope (missing OData-Version) → FAIL, not skip (served-but-broken)', async () => {
+    // The skip is gated on STATUS, not on assertODataResponse: a genuine 200 that is malformed (no OData-Version
+    // header) is a served-but-broken response, NOT a non-2xx decline → it must FAIL (keeping the diagnostic), and
+    // must never be mislabeled "not available / skipped".
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    const malformed200: ODataResponse = { status: 200, headers: {}, body: { value: [{ ListingKey: 'P1', Media: [{ AboveGradeFinishedAreaSource: 'Appraiser' }] }] }, rawBody: '{}' };
+    const req = requesterFor({ Media: malformed200 });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', req, validator);
+    expect(results[0].skipped).toBe(false);
+    expect(results[0].passed).toBe(false);
+    expect(summarizeScenarios(results).failed).toBe(1);
+  });
+
+  it('200 but an explicit null collection value → FAIL (a collection-valued property must be a JSON array, never null)', async () => {
+    // OData: a collection-valued property is a JSON array — empty at most, NEVER null. An explicit null is
+    // malformed data (distinct from an ABSENT nav, which is permitted "if available").
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    const req = requesterFor({ Media: okExpand(null) }); // { value: [{ ListingKey: 'P1', Media: null }] }
     const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', req, validator);
     expect(results[0].passed).toBe(false);
     expect(results[0].skipped).toBe(false);
+    expect(results[0].assertions.some((a) => !a.passed && a.message.includes('null') && a.message.toLowerCase().includes('array'))).toBe(true);
     expect(summarizeScenarios(results).failed).toBe(1);
+  });
+
+  it('200 with an EMPTY collection ([]) → PASS, not a null-fail (empty ≠ null; no data to enforce)', async () => {
+    // FALSE-POSITIVE guard: an empty array is a valid collection representation — it must NOT trip the null check.
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    const req = requesterFor({ Media: okExpand([]) }); // { value: [{ ListingKey: 'P1', Media: [] }] }
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', req, validator);
+    expect(results[0].passed).toBe(true);
+    expect(results[0].assertions.every((a) => a.passed)).toBe(true);
+    expect(summarizeScenarios(results).failed).toBe(0);
+  });
+
+  it('200 with the nav ABSENT from the record → PASS, not a null-fail (absent is permitted "if available", ≠ null)', async () => {
+    // FALSE-POSITIVE guard: an absent nav (server omitted it) is permitted per OData §11.2.5 — NOT the null violation.
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    const absent: ODataResponse = { status: 200, headers: { 'odata-version': '4.01' }, body: { value: [{ ListingKey: 'P1' }] }, rawBody: '{}' };
+    const req = requesterFor({ Media: absent });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', req, validator);
+    expect(results[0].passed).toBe(true);
+    expect(summarizeScenarios(results).failed).toBe(0);
+  });
+
+  it('200 with an array of NON-ENTITY elements (Media:[null] / [42] / ["x"]) → FAIL (must be a Collection of entity objects)', async () => {
+    // Closes the gap where an array of non-objects passed with zero validation (collectExpandedItems drops them).
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    for (const bad of [[null] as unknown, [42] as unknown, ['x'] as unknown, [['nested']] as unknown]) {
+      const req = requesterFor({ Media: okExpand(bad) });
+      const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', req, validator);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].skipped).toBe(false);
+      expect(results[0].assertions.some((a) => !a.passed && a.message.toLowerCase().includes('not an entity object'))).toBe(true);
+      expect(summarizeScenarios(results).failed).toBe(1);
+    }
+  });
+
+  it('a malformed collection FAILS even with NO validator built (shape is validator-independent; pins shape-before-validator ordering)', async () => {
+    // The shape gate runs BEFORE the no-validator skip-return: garbage shape is observable without a schema. If the
+    // shape check ever moved below `if (!validator)`, Media:{} / [null] with an unbuilt validator would silently
+    // skip-pass — this test catches that regression.
+    for (const bad of [{} as unknown, [null] as unknown]) {
+      const req = requesterFor({ Media: okExpand(bad) });
+      const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', req, undefined); // NO validator built
+      expect(results[0].passed).toBe(false);
+      expect(results[0].skipped).toBe(false);
+      expect(summarizeScenarios(results).failed).toBe(1);
+    }
+  });
+
+  it('200 with a null PARENT record ({value:[null]}) → handled without crashing (not a mislabeled transport-error skip)', async () => {
+    // A null parent entry must not throw `'Media' in null`; it is filtered, yielding a determinate result rather
+    // than the indeterminate errored-skip the crash used to produce.
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    const nullParent: ODataResponse = { status: 200, headers: { 'odata-version': '4.01' }, body: { value: [null] }, rawBody: '{}' };
+    const req = requesterFor({ Media: nullParent });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Property' }]), 'tok', req, validator);
+    expect(results[0].errored ?? false).toBe(false); // NOT an errored/transport-blip skip
+    expect(results[0].passed).toBe(true);            // a DETERMINATE result (null parent filtered), not an indeterminate skip
+    expect(results[0].skipped).toBe(false);
+    expect(summarizeScenarios(results).failed).toBe(0); // null parent filtered — a base-collection concern, not a Media fault
   });
 
   it('200 but a SCHEMA-INVALID expanded item → FAIL (validate the data, not just the 200)', async () => {
@@ -168,7 +290,11 @@ describe('runExpandNavScenarios — the RRK warning still rides alongside, non-g
     // the item must carry ONLY advertised fields. RRK 'WRONG' ≠ parent Property ListingKey 'P1' → non-gating
     // warning. (Validate against the Media target the expanded child actually is — matching the RRK doc: an
     // expanded Media's ResourceRecordKey should echo the parent Property's ListingKey.)
-    const req = requesterFor({ Media: okExpand([{ ResourceRecordKey: 'WRONG' }]) });
+    // nav-path dual kept data-consistent (records ↔ records, §11.2.7); the RRK mismatch is on the inline leg.
+    const req = requesterFor(
+      { Media: okExpand([{ ResourceRecordKey: 'WRONG' }]) },
+      { Media: navPathResponse([{ ResourceRecordKey: 'WRONG' }]) },
+    );
     const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, paramsFor([{ name: 'Media', targetType: 'Media' }]), 'tok', req, validator);
     expect(results[0].passed).toBe(true); // 200 + schema-valid → passes despite the RRK mismatch
     expect(results[0].warnings?.[0]).toContain('WRONG');
@@ -179,10 +305,18 @@ describe('runExpandNavScenarios — the RRK warning still rides alongside, non-g
 describe('runExpandNavScenarios — several navs, one bad fails exactly that nav', () => {
   it('Media (valid) passes and Rooms (schema-invalid) fails; the failure counts in the verdict tally', async () => {
     const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
-    const req = requesterFor({
-      Media: okExpand([{ AboveGradeFinishedAreaSource: 'Appraiser' }], 'Media'),
-      Rooms: okExpand([{ AboveGradeFinishedAreaSource: 'InvalidEnum' }], 'Rooms'),
-    });
+    // nav-path duals kept data-consistent with each $expand (§11.2.7): Media valid, Rooms carries the invalid item
+    // (so Rooms still fails on schema-invalidity, not on a nav-path consistency artifact).
+    const req = requesterFor(
+      {
+        Media: okExpand([{ AboveGradeFinishedAreaSource: 'Appraiser' }], 'Media'),
+        Rooms: okExpand([{ AboveGradeFinishedAreaSource: 'InvalidEnum' }], 'Rooms'),
+      },
+      {
+        Media: navPathResponse([{ AboveGradeFinishedAreaSource: 'Appraiser' }]),
+        Rooms: navPathResponse([{ AboveGradeFinishedAreaSource: 'InvalidEnum' }]),
+      },
+    );
     const results = await runExpandNavScenarios(
       'http://x',
       'Property',
@@ -223,17 +357,16 @@ describe('runExpandNavScenarios — the navigation-property-path second leg (A1)
     expect(summarizeScenarios(results).passed).toBe(1);
   });
 
-  it('the nav-path GET non-200 → FAIL (declared collection expansion not reachable via its navigation-property path)', async () => {
+  it('the nav-path GET non-2xx → NOT faulted (same access/permission boundary as the inline leg — OData §11.2.5)', async () => {
     const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
     const req = requesterFor(
-      { Media: okExpand([{ AboveGradeFinishedAreaSource: 'Appraiser' }]) }, // inline leg is fine
-      { Media: status(404) },                                              // but the nav-path leg 404s
+      { Media: okExpand([{ AboveGradeFinishedAreaSource: 'Appraiser' }]) }, // inline leg is fine (data enforced)
+      { Media: status(403) },                                              // but the nav-path leg 403s (not authorised)
     );
     const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, oneNav, 'tok', req, validator);
-    expect(results[0].passed).toBe(false);
-    expect(results[0].skipped).toBe(false);
-    expect(results[0].assertions.some((a) => !a.passed && a.message.includes('Navigation-property-path') && a.message.includes('404'))).toBe(true);
-    expect(summarizeScenarios(results).failed).toBe(1);
+    expect(results[0].passed).toBe(true); // inline leg validated real data; a 403 nav-path leg is not a conformance failure
+    expect(results[0].assertions.some((a) => a.passed && a.message.includes('Navigation-property-path') && a.message.includes('403') && a.message.toLowerCase().includes('not supported'))).toBe(true);
+    expect(summarizeScenarios(results).failed).toBe(0);
   });
 
   it('the nav-path GET 200 but a schema-invalid item → FAIL (the nav-path collection is validated too)', async () => {
@@ -248,6 +381,33 @@ describe('runExpandNavScenarios — the navigation-property-path second leg (A1)
     expect(summarizeScenarios(results).failed).toBe(1);
   });
 
+  it('the nav-path GET returns a null / non-array collection ({value:null}) → FAIL (same shape rule as the inline leg)', async () => {
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    const nullNavPath: ODataResponse = { status: 200, headers: { 'odata-version': '4.01' }, body: { value: null }, rawBody: '{}' };
+    const req = requesterFor(
+      { Media: okExpand([{ AboveGradeFinishedAreaSource: 'Appraiser' }]) }, // inline leg valid (real data)
+      { Media: nullNavPath },                                              // but the nav-path collection is null
+    );
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, oneNav, 'tok', req, validator);
+    expect(results[0].passed).toBe(false);
+    expect(results[0].assertions.some((a) => !a.passed && a.message.includes('Navigation-property-path') && a.message.toLowerCase().includes('not a json array'))).toBe(true);
+    expect(summarizeScenarios(results).failed).toBe(1);
+  });
+
+  it('the nav-path GET returns an array of NON-ENTITY elements ({value:[null]} / [42]) → FAIL (element shape checked on both legs)', async () => {
+    const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+    for (const badColl of [[null] as unknown, [42] as unknown]) {
+      const navBad: ODataResponse = { status: 200, headers: { 'odata-version': '4.01' }, body: { value: badColl }, rawBody: '{}' };
+      const req = requesterFor(
+        { Media: okExpand([{ AboveGradeFinishedAreaSource: 'Appraiser' }]) }, // inline leg valid
+        { Media: navBad },                                                   // nav-path collection has non-entity elements
+      );
+      const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, oneNav, 'tok', req, validator);
+      expect(results[0].passed).toBe(false);
+      expect(results[0].assertions.some((a) => !a.passed && a.message.includes('Navigation-property-path') && a.message.toLowerCase().includes('not an entity object'))).toBe(true);
+    }
+  });
+
   it('an empty $expand response yields no parent key → the nav-path leg is not exercised (no data, not a failure)', async () => {
     const validator = await createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
     // $expand returns zero parent records → no key to drive the keyed nav-path GET. The nav-path requester below
@@ -256,6 +416,87 @@ describe('runExpandNavScenarios — the navigation-property-path second leg (A1)
     const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, oneNav, 'tok', req, validator);
     expect(results[0].passed).toBe(true);
     expect(results[0].assertions.some((a) => a.passed && a.message.includes('no parent key') && a.message.includes('not exercised'))).toBe(true);
+  });
+});
+
+// The $expand form and the navigation-property-path form resolve the SAME relationship on the SAME source
+// entity, so they MUST agree on has-records (OData §11.2.7: a collection nav-path returns the related entities,
+// empty ONLY if none are related). The invariant: hasRecords($expand=X for key) === hasRecords(Parent('key')/X).
+describe('runExpandNavScenarios — the $expand ↔ nav-property-path dual must be data-consistent (§11.2.7)', () => {
+  const oneNavParams = paramsFor([{ name: 'Media', targetType: 'Property' }]);
+  const validItem = { AboveGradeFinishedAreaSource: 'Appraiser' };
+  const buildValidator = () => createExpandSchemaValidator({ metadataReport: report, version: '2.0' });
+
+  // (1) records ↔ records → PASS
+  it('records in $expand AND records on the nav-path → PASS (consistent)', async () => {
+    const validator = await buildValidator();
+    const req = requesterFor({ Media: okExpand([validItem]) }, { Media: navPathResponse([validItem]) });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, oneNavParams, 'tok', req, validator);
+    expect(results[0].passed).toBe(true);
+  });
+
+  // (2) no records ↔ no records → PASS
+  it('no records in $expand AND none on the nav-path → PASS (consistent empty↔empty)', async () => {
+    const validator = await buildValidator();
+    const req = requesterFor({ Media: okExpand([]) }, { Media: navPathResponse([]) });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, oneNavParams, 'tok', req, validator);
+    expect(results[0].passed).toBe(true);
+  });
+
+  // (3) no records in $expand BUT records on the nav-path → FAIL
+  it('no records in $expand BUT records on the nav-path → FAIL (§11.2.7 dual inconsistency)', async () => {
+    const validator = await buildValidator();
+    const req = requesterFor({ Media: okExpand([]) }, { Media: navPathResponse([validItem]) });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, oneNavParams, 'tok', req, validator);
+    expect(results[0].passed).toBe(false);
+    expect(results[0].assertions.some((a) => !a.passed && a.message.includes('Navigation-property-path') && a.message.includes('11.2.7'))).toBe(true);
+  });
+
+  // (4) records in $expand BUT none on the nav-path → FAIL (the case from the live fbs sweep)
+  it('records in $expand BUT none on the nav-path → FAIL (§11.2.7 dual inconsistency)', async () => {
+    const validator = await buildValidator();
+    const req = requesterFor({ Media: okExpand([validItem]) }, { Media: navPathResponse([]) });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, oneNavParams, 'tok', req, validator);
+    expect(results[0].passed).toBe(false);
+    expect(results[0].assertions.some((a) => !a.passed && a.message.includes('Navigation-property-path') && a.message.includes('11.2.7'))).toBe(true);
+  });
+
+  // wrong code: a collection nav-path returning 204 is non-conformant (must be 200 empty-set, never 204) —
+  // §11.2.7 / §2.6.1 — and fails even when $expand was ALSO empty (kept per option (b)).
+  it('204 No Content on a collection nav-path → FAIL (wrong code; empty collection must be 200 empty-set)', async () => {
+    const validator = await buildValidator();
+    const noContent: ODataResponse = { status: 204, headers: { 'odata-version': '4.01' }, body: null, rawBody: '' };
+    const req = requesterFor({ Media: okExpand([]) }, { Media: noContent });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, oneNavParams, 'tok', req, validator);
+    expect(results[0].passed).toBe(false);
+  });
+
+  // Paging tolerance: an empty first PAGE + @odata.nextLink still means related entities exist, so has-records
+  // reads true and the dual does NOT false-fail a conformant server (OData JSON Format §4.5.5).
+  it('records in $expand + nav-path empty first page WITH @odata.nextLink → PASS (paged, not a false-fail)', async () => {
+    const validator = await buildValidator();
+    const navPaged: ODataResponse = {
+      status: 200,
+      headers: { 'odata-version': '4.01' },
+      body: { value: [], '@odata.nextLink': "http://x/Property('P1')/Media?$skiptoken=1" },
+      rawBody: '{}',
+    };
+    const req = requesterFor({ Media: okExpand([validItem]) }, { Media: navPaged });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, oneNavParams, 'tok', req, validator);
+    expect(results[0].passed).toBe(true);
+  });
+
+  it('$expand empty inline page WITH {nav}@odata.nextLink + nav-path records → PASS (has-records both sides)', async () => {
+    const validator = await buildValidator();
+    const expandPaged: ODataResponse = {
+      status: 200,
+      headers: { 'odata-version': '4.01' },
+      body: { value: [{ ListingKey: 'P1', Media: [], 'Media@odata.nextLink': "http://x/Property('P1')/Media?$skiptoken=1" }] },
+      rawBody: '{}',
+    };
+    const req = requesterFor({ Media: expandPaged }, { Media: navPathResponse([validItem]) });
+    const results = await runExpandNavScenarios('http://x', 'Property', expandScenario, oneNavParams, 'tok', req, validator);
+    expect(results[0].passed).toBe(true);
   });
 });
 

--- a/reso-certification/tests/web-api-core/queries.test.ts
+++ b/reso-certification/tests/web-api-core/queries.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { buildLookupUrl, buildScenarioQuery, originatingSystemFilterClause } from '../../src/web-api-core/queries.js';
 import type { TestParams } from '../../src/web-api-core/sampling.js';
-import type { CoreScenario, FilterScenario, OrderByScenario, ErrorScenario, StructuralScenario } from '../../src/web-api-core/scenarios.js';
+import type { CoreScenario, FilterScenario, OrderByScenario, ErrorScenario, StructuralScenario, PagingScenario } from '../../src/web-api-core/scenarios.js';
 
 const baseParams: TestParams = {
   resource: 'Property',
@@ -32,6 +32,13 @@ describe('buildScenarioQuery', () => {
     const scenario: StructuralScenario = { tag: 'metadata-validation', name: 'Metadata', category: 'structural', assertion: 'metadata', minVersion: '2.0.0' };
     const result = buildScenarioQuery('http://localhost:8080', 'Property', scenario, baseParams);
     expect(result?.url).toBe('http://localhost:8080/$metadata');
+  });
+
+  // paging is dispatched in runScenario (it builds its own $top=2 / $top=1 URLs), so buildScenarioQuery
+  // intentionally returns undefined for it — locks the removal of the old dead paging case.
+  it('returns undefined for a paging scenario (paging builds its own URLs)', () => {
+    const scenario: PagingScenario = { tag: 'server-driven-paging', name: 'Server-driven paging (nextLink)', category: 'paging', assertion: 'nextLink', minVersion: '2.1.0' };
+    expect(buildScenarioQuery('http://localhost:8080', 'Property', scenario, baseParams)).toBeUndefined();
   });
 
   it('builds fetch-by-key URL', () => {

--- a/reso-certification/tests/web-api-core/select-projection.test.ts
+++ b/reso-certification/tests/web-api-core/select-projection.test.ts
@@ -40,20 +40,21 @@ describe('$select — multi-field projection built + the server must honor it', 
     const req = requesterReturning([{ ListingKey: '1', ModificationTimestamp: '2026-01-01T00:00:00Z' }]);
     const r = await runStructuralScenario('http://x', 'Property', 'select', q!, baseParams, 'tok', 0, req);
     expect(r.passed).toBe(true);
-    expect(r.assertions.some((a) => a.passed && a.message.includes('present: ModificationTimestamp'))).toBe(true);
+    expect(r.assertions.some((a) => a.passed && a.message.includes('projected fields present') && a.message.includes('ModificationTimestamp'))).toBe(true);
   });
 
-  it('WARNS (non-gating), does NOT fail, when a returned record carries a field OUTSIDE the $select list', async () => {
-    // A server that ignores $select returns every field, including ones never selected (e.g. ListPrice). The
-    // Commander (the oracle for this existing 2.0.0 element) never checks for fields outside the select list, so
-    // this must NOT newly fail a $select-ignoring server that passed the oracle — it rides the warning channel
-    // (observe-then-flip, like single-enum `ne`), pending WG sign-off.
+  it('PERMITS a field OUTSIDE the $select list — no fail, no warning (OData 4.01 §11.2.5.1 allows returning more)', async () => {
+    // OData 4.01 §11.2.5.1: $select "requests that the service return only the properties … and MAY return
+    // additional information." Returning fields beyond the select list is EXPLICITLY PERMITTED — not a defect and
+    // not even warning-worthy (which is also why the Commander, the oracle for this 2.0.0 element, never checked
+    // it). A $select-ignoring server that carries the projected field simply passes, no warning.
     const q = buildScenarioQuery('http://x', 'Property', selectScenario, baseParams);
     const req = requesterReturning([{ ListingKey: '1', ModificationTimestamp: '2026-01-01T00:00:00Z', ListPrice: 500000 }]);
     const r = await runStructuralScenario('http://x', 'Property', 'select', q!, baseParams, 'tok', 0, req);
-    expect(r.passed).toBe(true); // NON-gating — the beyond-oracle check never fails the provider
+    expect(r.passed).toBe(true);
     expect(r.assertions.every((a) => a.passed)).toBe(true);
-    expect(r.warnings?.some((w) => w.includes('ListPrice') && w.toLowerCase().includes('warning'))).toBe(true);
+    expect(r.warnings ?? []).toHaveLength(0); // the extra field is spec-permitted → NOT flagged at all
+    expect(r.assertions.some((a) => a.message.includes('projected fields present'))).toBe(true);
   });
 
   it('does NOT false-fail when the projected field is null/omitted (sparse field or null-omitting server)', async () => {

--- a/reso-metadata-utils/package.json
+++ b/reso-metadata-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reso-standards/reso-metadata-utils",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/RESOStandards/reso-tools.git",

--- a/reso-metadata-utils/src/csdl/parser.ts
+++ b/reso-metadata-utils/src/csdl/parser.ts
@@ -674,19 +674,36 @@ export const getFieldsForResource = (schema: CsdlSchema, resourceName: string): 
 
 /**
  * Extract field metadata for all resources in a schema.
- * Returns a record keyed by entity set name.
+ *
+ * Served resources (backed by an EntitySet) are keyed by their EntitySet name. Declared EntityTypes with NO
+ * EntitySet — e.g. a containment-navigation (`ContainsTarget="true"`) target such as a contained Media
+ * collection — are legal OData entities and valid `$expand` targets, so their fields are emitted too, keyed by
+ * type name (which is how a qualified `Collection(Ns.Type)` reference resolves downstream). Without them, JSON
+ * schema generation emits a `$ref` to a definition that was never built. A type already surfaced by an
+ * EntitySet is not repeated.
  */
 export const getAllFields = (schema: CsdlSchema): Readonly<Record<string, ReadonlyArray<FieldInfo>>> => {
   if (!schema.entityContainer) return {};
 
   const entityTypeMap = new Map(schema.entityTypes.map(et => [et.name, et]));
 
-  return Object.fromEntries(
-    schema.entityContainer.entitySets.map(es => {
-      const typeName = extractTypeName(es.entityType);
-      const entityType = entityTypeMap.get(typeName);
-      if (!entityType) return [es.name, []];
-      return [es.name, getFieldsForEntityType(schema, entityType, es.name)];
-    })
-  );
+  // Served resources: one entry per EntitySet, keyed by the EntitySet name (the queryable resource name).
+  const servedEntries = schema.entityContainer.entitySets.map(es => {
+    const entityType = entityTypeMap.get(extractTypeName(es.entityType));
+    return [es.name, entityType ? getFieldsForEntityType(schema, entityType, es.name) : []] as const;
+  });
+
+  // Every declared EntityType ALSO keyed by its TYPE name, so a type-qualified reference — `Collection(Ns.Type)`
+  // on a nav, which downstream JSON-Schema generation resolves as `#/definitions/{TypeName}` — always finds a
+  // definition. This covers both containment-nav targets that have no EntitySet AND served types whose EntitySet
+  // name differs from the type name (either would otherwise dangle). Dedup against the served ENTRY KEYS
+  // (EntitySet names), NOT against type names: keying entries by type name while deduping by type name is what
+  // let a contained type silently clobber an unrelated served resource. For conformant RESO metadata (EntitySet
+  // name == type name) a served type is already keyed under that name, so it is simply skipped here — a no-op.
+  const servedKeys = new Set(servedEntries.map(([key]) => key));
+  const typeEntries = schema.entityTypes
+    .filter(et => !servedKeys.has(et.name))
+    .map(et => [et.name, getFieldsForEntityType(schema, et, et.name)] as const);
+
+  return Object.fromEntries([...servedEntries, ...typeEntries]);
 };

--- a/reso-metadata-utils/src/csdl/parser.ts
+++ b/reso-metadata-utils/src/csdl/parser.ts
@@ -232,9 +232,12 @@ const parseEntityTypes = (rawEntityTypes: ReadonlyArray<Record<string, unknown>>
 
     const rawProperties = (rawEntity.Property as ReadonlyArray<Record<string, unknown>>) ?? [];
     const rawNavProperties = (rawEntity.NavigationProperty as ReadonlyArray<Record<string, unknown>>) ?? [];
+    // The declaring schema's namespace (injected at flatMap time) — forms this type's FQDN.
+    const namespace = rawEntity.__schemaNamespace as string | undefined;
 
     return {
       name,
+      ...(namespace !== undefined && { namespace }),
       key,
       properties: parseProperties(rawProperties, aliasMap),
       navigationProperties: parseNavigationProperties(rawNavProperties, aliasMap),
@@ -259,9 +262,12 @@ const parseComplexTypes = (rawComplexTypes: ReadonlyArray<Record<string, unknown
 
     const rawProperties = (rawComplex.Property as ReadonlyArray<Record<string, unknown>>) ?? [];
     const rawNavProperties = (rawComplex.NavigationProperty as ReadonlyArray<Record<string, unknown>>) ?? [];
+    // The declaring schema's namespace (injected at flatMap time) — forms this type's FQDN.
+    const namespace = rawComplex.__schemaNamespace as string | undefined;
 
     return {
       name,
+      ...(namespace !== undefined && { namespace }),
       properties: parseProperties(rawProperties, aliasMap),
       navigationProperties: parseNavigationProperties(rawNavProperties, aliasMap),
       ...(rawComplex['@_BaseType'] !== undefined && {
@@ -469,12 +475,18 @@ export const parseCsdlXml = (xml: string): CsdlSchema => {
       .map(s => [s['@_Alias'] as string, s['@_Namespace'] as string])
   );
 
-  // Merge elements from all schemas
-  const rawEntityTypes: ReadonlyArray<Record<string, unknown>> = schemas.flatMap(s => (s.EntityType as ReadonlyArray<Record<string, unknown>>) ?? []);
+  // Merge elements from all schemas. Each type carries the namespace of the schema it was declared in
+  // (multi-schema EDMX splits types across namespaces — e.g. entities in org.reso.metadata, enums in
+  // org.reso.metadata.enums); the injected __schemaNamespace forms each type's FQDN downstream.
+  const rawEntityTypes: ReadonlyArray<Record<string, unknown>> = schemas.flatMap(s =>
+    ((s.EntityType as ReadonlyArray<Record<string, unknown>>) ?? []).map(e => ({ ...e, __schemaNamespace: s['@_Namespace'] }))
+  );
   const rawEnumTypes: ReadonlyArray<Record<string, unknown>> = schemas.flatMap(s =>
     ((s.EnumType as ReadonlyArray<Record<string, unknown>>) ?? []).map(e => ({ ...e, __schemaNamespace: s['@_Namespace'] }))
   );
-  const rawComplexTypes: ReadonlyArray<Record<string, unknown>> = schemas.flatMap(s => (s.ComplexType as ReadonlyArray<Record<string, unknown>>) ?? []);
+  const rawComplexTypes: ReadonlyArray<Record<string, unknown>> = schemas.flatMap(s =>
+    ((s.ComplexType as ReadonlyArray<Record<string, unknown>>) ?? []).map(e => ({ ...e, __schemaNamespace: s['@_Namespace'] }))
+  );
   const rawActions: ReadonlyArray<Record<string, unknown>> = schemas.flatMap(s => (s.Action as ReadonlyArray<Record<string, unknown>>) ?? []);
   const rawFunctions: ReadonlyArray<Record<string, unknown>> = schemas.flatMap(s => (s.Function as ReadonlyArray<Record<string, unknown>>) ?? []);
   // EntityContainer is typically in one schema — find it

--- a/reso-metadata-utils/src/csdl/types.ts
+++ b/reso-metadata-utils/src/csdl/types.ts
@@ -48,6 +48,11 @@ export interface CsdlNavigationProperty {
 /** An entity type definition. */
 export interface CsdlEntityType {
   readonly name: string;
+  /**
+   * The namespace the entity type was declared in. Multi-schema EDMX can split types across
+   * namespaces; this forms the type's full FQDN for reference resolution (mirrors CsdlEnumType).
+   */
+  readonly namespace?: string;
   readonly key: ReadonlyArray<string>;
   readonly properties: ReadonlyArray<CsdlProperty>;
   readonly navigationProperties: ReadonlyArray<CsdlNavigationProperty>;
@@ -64,6 +69,11 @@ export interface CsdlEntityType {
 /** A complex type definition (structured type without a key). */
 export interface CsdlComplexType {
   readonly name: string;
+  /**
+   * The namespace the complex type was declared in. Multi-schema EDMX can split types across
+   * namespaces; this forms the type's full FQDN for reference resolution (mirrors CsdlEnumType).
+   */
+  readonly namespace?: string;
   readonly baseType?: string;
   readonly abstract?: boolean;
   readonly openType?: boolean;

--- a/reso-metadata-utils/src/csdl/validator.ts
+++ b/reso-metadata-utils/src/csdl/validator.ts
@@ -137,26 +137,50 @@ export const validateCsdl = (schema: CsdlSchema, odataVersion: '4.0' | '4.01' = 
     });
   }
 
-  // Build set of known type names for reference checking
-  const knownTypeNames = new Set([
-    ...schema.entityTypes.map(et => `${schema.namespace}.${et.name}`),
-    ...schema.enumTypes.map(et => `${schema.namespace}.${et.name}`),
-    ...schema.complexTypes.map(ct => `${schema.namespace}.${ct.name}`)
+  // The FQDN a declared type is registered under: its OWN namespace when it carries one (multi-schema
+  // EDMX splits types across namespaces — a provider may put enums in a separate namespace, e.g.
+  // org.reso.metadata.enums distinct from org.reso.metadata), else the schema namespace (a
+  // single-namespace document). The namespace strings are provider-chosen; RESO fixes no vocabulary of
+  // FQDNs — an FQDN is just the key that links a reference to its declaration.
+  const fqdn = (t: { readonly name: string; readonly namespace?: string }): string => `${t.namespace ?? schema.namespace}.${t.name}`;
+
+  // Every type this document declares — entity, enum, complex — registered under its true FQDN. This
+  // drives a referential-integrity check, NOT a check against any known/blessed FQDN set (there is none
+  // for RESO): a reference is valid iff it links to a declaration here. Registering all kinds
+  // symmetrically under their own namespace keeps this set consistent with declaredNamespaces below.
+  const declaredTypeFqdns = new Set([
+    ...schema.entityTypes.map(fqdn),
+    ...schema.enumTypes.map(fqdn),
+    ...schema.complexTypes.map(fqdn)
+  ]);
+
+  // The namespaces this document actually declares a type in — the primary namespace plus every distinct
+  // namespace any entity, enum, or complex type is declared in. A reference qualified with one of these
+  // SHOULD link to a declaration here; if it links to nothing it's dangling — a broken internal link. A
+  // reference in any OTHER namespace is external — declared in some schema this document doesn't contain,
+  // which the validator can't see — so it's left alone. Building this from ALL type kinds (not enums
+  // alone) is what keeps a conformant provider that co-locates, say, a complex type with its enums in a
+  // non-primary namespace from false-failing.
+  const declaredNamespaces = new Set<string>([
+    schema.namespace,
+    ...schema.entityTypes.map(et => et.namespace ?? schema.namespace),
+    ...schema.enumTypes.map(et => et.namespace ?? schema.namespace),
+    ...schema.complexTypes.map(ct => ct.namespace ?? schema.namespace)
   ]);
 
   /**
-   * A referenced type is an UNRESOLVED LOCAL reference when it names this schema's OWN namespace (or is a bare,
-   * implicitly-local name) yet no such type is declared here. Only a genuinely EXTERNAL name — qualified with a
-   * DIFFERENT namespace, whose schema this validator can't see — is allowed to go unresolved. Previously every
-   * site used a bare `!type.includes('.')` escape, which waved through ANY dotted name, including
-   * `${schema.namespace}.DoesNotExist`; that masked same-namespace dangling references (a typo'd or renamed nav
-   * target, base type, entity-set type, or property type) as if they were external. This resolves them instead.
+   * A type reference is a DANGLING reference when it points into a namespace this document declares
+   * types in (or is a bare, implicitly-primary name) yet links to no type declared here — a broken
+   * internal link (a typo'd or renamed target). A reference into a namespace this document declares
+   * NOTHING in is EXTERNAL — resolved by some schema this validator can't see — and is left alone. This
+   * is internal referential integrity, not conformance to any canonical FQDN: the FQDN is only the
+   * provider-chosen key that links a reference to its declaration.
    */
-  const isUnresolvedLocalType = (typeName: string): boolean => {
-    if (knownTypeNames.has(typeName)) return false;
+  const isDanglingReference = (typeName: string): boolean => {
+    if (declaredTypeFqdns.has(typeName)) return false; // links to a type declared here
     const lastDot = typeName.lastIndexOf('.');
-    if (lastDot === -1) return true; // bare name → implicitly this schema's namespace → must be declared here
-    return typeName.slice(0, lastDot) === schema.namespace; // same-namespace qualified name → must be declared here
+    if (lastDot === -1) return true; // bare name → implicitly the primary namespace → must be declared here
+    return declaredNamespaces.has(typeName.slice(0, lastDot)); // a declared namespace but no such type → broken link
   };
 
   /**
@@ -166,9 +190,9 @@ export const validateCsdl = (schema: CsdlSchema, odataVersion: '4.0' | '4.01' = 
   const validatePropertyType = (propType: string, propPath: string): void => {
     const typeToCheck = isCollectionType(propType) ? unwrapCollection(propType) : propType;
 
-    if (!isEdmPrimitive(typeToCheck) && isUnresolvedLocalType(typeToCheck)) {
-      // A same-namespace (or bare) type that isn't declared here is a dangling local reference; a
-      // different-namespace type is an external reference this validator can't resolve and is allowed.
+    if (!isEdmPrimitive(typeToCheck) && isDanglingReference(typeToCheck)) {
+      // A reference into a declared namespace that links to no type here is dangling (a broken link); a
+      // reference into a namespace this document doesn't declare is external, and this validator allows it.
       errors.push({
         path: propPath,
         message: `Property type '${propType}' is not a valid Edm primitive or known type`,
@@ -207,7 +231,7 @@ export const validateCsdl = (schema: CsdlSchema, odataVersion: '4.0' | '4.01' = 
 
     for (const navProp of entityType.navigationProperties) {
       const targetType = isCollectionType(navProp.type) ? unwrapCollection(navProp.type) : navProp.type;
-      if (isUnresolvedLocalType(targetType)) {
+      if (isDanglingReference(targetType)) {
         errors.push({
           path: `${etPath}/NavigationProperty(${navProp.name})`,
           message: `Navigation property references unknown entity type '${targetType}'`,
@@ -216,7 +240,7 @@ export const validateCsdl = (schema: CsdlSchema, odataVersion: '4.0' | '4.01' = 
       }
     }
 
-    if (entityType.baseType && isUnresolvedLocalType(entityType.baseType)) {
+    if (entityType.baseType && isDanglingReference(entityType.baseType)) {
       errors.push({
         path: etPath,
         message: `BaseType '${entityType.baseType}' is not a known entity type`,
@@ -229,7 +253,7 @@ export const validateCsdl = (schema: CsdlSchema, odataVersion: '4.0' | '4.01' = 
   for (const complexType of schema.complexTypes) {
     const ctPath = `ComplexType(${complexType.name})`;
 
-    if (complexType.baseType && isUnresolvedLocalType(complexType.baseType)) {
+    if (complexType.baseType && isDanglingReference(complexType.baseType)) {
       errors.push({
         path: ctPath,
         message: `BaseType '${complexType.baseType}' is not a known complex type`,
@@ -243,7 +267,7 @@ export const validateCsdl = (schema: CsdlSchema, odataVersion: '4.0' | '4.01' = 
 
     for (const navProp of complexType.navigationProperties) {
       const targetType = isCollectionType(navProp.type) ? unwrapCollection(navProp.type) : navProp.type;
-      if (isUnresolvedLocalType(targetType)) {
+      if (isDanglingReference(targetType)) {
         errors.push({
           path: `${ctPath}/NavigationProperty(${navProp.name})`,
           message: `Navigation property references unknown entity type '${targetType}'`,
@@ -253,9 +277,10 @@ export const validateCsdl = (schema: CsdlSchema, odataVersion: '4.0' | '4.01' = 
     }
   }
 
-  // Build lookup maps for entity container validation
+  // Build lookup maps for entity container validation (keyed by each entity's true FQDN, so a binding
+  // or referential-constraint reference into a non-primary namespace resolves to the declared type).
   const entityTypeMap = new Map(
-    schema.entityTypes.map(et => [`${schema.namespace}.${et.name}`, et])
+    schema.entityTypes.map(et => [fqdn(et), et])
   );
   const entitySetMap = schema.entityContainer
     ? new Map(schema.entityContainer.entitySets.map(es => [es.name, es]))
@@ -269,7 +294,7 @@ export const validateCsdl = (schema: CsdlSchema, odataVersion: '4.0' | '4.01' = 
     for (const entitySet of schema.entityContainer.entitySets) {
       const esPath = `EntityContainer/EntitySet(${entitySet.name})`;
 
-      if (isUnresolvedLocalType(entitySet.entityType)) {
+      if (isDanglingReference(entitySet.entityType)) {
         errors.push({
           path: esPath,
           message: `Entity set references unknown entity type '${entitySet.entityType}'`,

--- a/reso-metadata-utils/tests/csdl-parser.test.ts
+++ b/reso-metadata-utils/tests/csdl-parser.test.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { discoverResources, getEntityType, getEnumType, parseCsdlXml } from '../src/csdl/parser.js';
+import { discoverResources, getAllFields, getEntityType, getEnumType, parseCsdlXml } from '../src/csdl/parser.js';
 
 // Minimal EDMX for unit tests (includes NavigationProperty)
 const minimalEdmx = `<?xml version="1.0" encoding="utf-8"?>
@@ -623,5 +623,83 @@ describe('parseCsdlXml — sample-metadata.xml compatibility', () => {
     expect(property).toBeDefined();
     expect(property?.key.length).toBeGreaterThan(0);
     expect(property?.properties.length).toBeGreaterThan(0);
+  });
+});
+
+describe('getAllFields — contained (ContainsTarget) entity types', () => {
+  // Property has a containment nav (ContainsTarget="true") to Media, which is declared as an EntityType but
+  // has NO EntitySet — a legal OData contained entity and a valid $expand target. getAllFields must emit its
+  // fields (keyed by type name) so downstream schema generation can define/validate it; otherwise a
+  // Collection(Media) $ref dangles against a missing definition.
+  const containedEntityEdmx = `<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="org.reso.metadata" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Property">
+        <Key><PropertyRef Name="ListingKey"/></Key>
+        <Property Name="ListingKey" Type="Edm.String" Nullable="false"/>
+        <NavigationProperty Name="Media" Type="Collection(org.reso.metadata.Media)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="Media">
+        <Key><PropertyRef Name="MediaKey"/></Key>
+        <Property Name="MediaKey" Type="Edm.String" Nullable="false"/>
+        <Property Name="MediaURL" Type="Edm.String" Nullable="true"/>
+      </EntityType>
+      <EntityContainer Name="Default">
+        <EntitySet Name="Property" EntityType="org.reso.metadata.Property"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>`;
+
+  it('emits fields for a declared EntityType with no EntitySet (keyed by type name)', () => {
+    const all = getAllFields(parseCsdlXml(containedEntityEdmx));
+    expect(Object.keys(all)).toContain('Media');
+    expect(all.Media?.map(f => f.fieldName).sort()).toEqual(['MediaKey', 'MediaURL']);
+  });
+
+  it('still emits the served EntitySet-backed resource', () => {
+    const all = getAllFields(parseCsdlXml(containedEntityEdmx));
+    expect(Object.keys(all)).toContain('Property');
+  });
+});
+
+describe('getAllFields — EntitySet name ≠ type name (key-space alignment)', () => {
+  // EntitySet "Listings" is backed by EntityType "Property" (set name ≠ type name), and a SEPARATE EntityType
+  // "Listings" is declared with no EntitySet — its name collides with the set name. Downstream $refs are keyed
+  // by TYPE name, so the served type must also be reachable by type name (else a `#/definitions/Property` ref
+  // dangles), and the unrelated contained type must never clobber the served resource.
+  const skewedEdmx = `<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="org.reso.metadata" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Property">
+        <Key><PropertyRef Name="ListingKey"/></Key>
+        <Property Name="ListingKey" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <EntityType Name="Listings">
+        <Key><PropertyRef Name="ListingsKey"/></Key>
+        <Property Name="ListingsKey" Type="Edm.String" Nullable="false"/>
+      </EntityType>
+      <EntityContainer Name="Default">
+        <EntitySet Name="Listings" EntityType="org.reso.metadata.Property"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>`;
+
+  it('emits the served type under its TYPE name too, so a type-qualified $ref resolves (closes the dangling-ref gap)', () => {
+    const all = getAllFields(parseCsdlXml(skewedEdmx));
+    expect(Object.keys(all)).toContain('Listings'); // the served EntitySet key
+    expect(Object.keys(all)).toContain('Property');  // ...and the backing type, keyed by type name
+    expect(all.Property?.map(f => f.fieldName)).toContain('ListingKey');
+  });
+
+  it('never lets a same-named contained type clobber the served resource', () => {
+    const all = getAllFields(parseCsdlXml(skewedEdmx));
+    // The "Listings" entry is the SERVED resource (backed by Property → ListingKey), not the unrelated
+    // contained "Listings" type (which would carry ListingsKey). The served fields survive.
+    expect(all.Listings?.map(f => f.fieldName)).toContain('ListingKey');
+    expect(all.Listings?.map(f => f.fieldName)).not.toContain('ListingsKey');
   });
 });

--- a/reso-metadata-utils/tests/csdl-validator.test.ts
+++ b/reso-metadata-utils/tests/csdl-validator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { CsdlSchema } from '../src/csdl/types.js';
 import { validateCsdl } from '../src/csdl/validator.js';
+import { parseCsdlXml } from '../src/csdl/parser.js';
 
 const validSchema: CsdlSchema = {
   namespace: 'org.reso.metadata',
@@ -32,7 +33,7 @@ const validSchema: CsdlSchema = {
     name: 'Default',
     // Keep the base fixture's container empty so a test can override `entityTypes` without the inherited
     // container dangling an entity-set reference to a type it replaced (the validator now resolves same-namespace
-    // references — see `isUnresolvedLocalType`). Tests that exercise the entity-set / binding rules declare their
+    // references — see `isDanglingReference`). Tests that exercise the entity-set / binding rules declare their
     // own populated container below.
     entitySets: [],
     singletons: [],
@@ -577,7 +578,7 @@ describe('validateCsdl', () => {
   // --- A11: same-namespace type-reference resolution ---
   // The validator once waved through ANY dotted type name as an "external reference" (a bare `!type.includes('.')`
   // escape). That masked a `org.reso.metadata.Typo` — a dangling reference to THIS schema's own namespace — as if
-  // it were external. `isUnresolvedLocalType` now resolves same-namespace (and bare) references while still leaving
+  // it were external. `isDanglingReference` now resolves same-namespace (and bare) references while still leaving
   // genuinely external (different-namespace) names unresolved, so real cross-namespace metadata never false-errors.
 
   it('A11: a navigation target qualified with this schema’s namespace but undeclared → ERROR (previously masked)', () => {
@@ -669,22 +670,129 @@ describe('validateCsdl', () => {
     expect(result.errors.some(e => e.message.includes('Ghost') && e.message.includes('entity type'))).toBe(true);
   });
 
-  it('A11: a property type in the enums sub-namespace (external to this schema) is left unresolved — mirrors real RESO metadata', () => {
-    const schema: CsdlSchema = {
-      ...validSchema,
-      entityTypes: [
-        {
-          name: 'Property',
-          key: ['ListingKey'],
-          properties: [
-            { name: 'ListingKey', type: 'Edm.String' },
-            { name: 'Status', type: 'org.reso.metadata.enums.StandardStatus' } // different namespace → external → escaped
-          ],
-          navigationProperties: []
-        }
-      ]
-    };
-    const result = validateCsdl(schema);
-    expect(result.valid).toBe(true);
+  // --- A11b: enum sub-namespace resolution (the org.reso.metadata / .enums split) ---
+  // Real RESO metadata declares enums in their OWN namespace (org.reso.metadata.enums), a sibling
+  // <Schema> in the same EDMX. The validator resolves references into any namespace the schema
+  // actually declares a type in — positively confirming valid enum properties and catching dangling
+  // ones — while still leaving genuinely external (undeclared) namespaces unresolved.
+  const ENUMS_NS = 'org.reso.metadata.enums';
+  const withSplitEnum = (statusType: string): CsdlSchema => ({
+    ...validSchema,
+    entityTypes: [
+      {
+        name: 'Property',
+        key: ['ListingKey'],
+        properties: [
+          { name: 'ListingKey', type: 'Edm.String' },
+          { name: 'Status', type: statusType }
+        ],
+        navigationProperties: []
+      }
+    ],
+    enumTypes: [
+      { name: 'StandardStatus', namespace: ENUMS_NS, members: [{ name: 'Active', value: '0' }, { name: 'Pending', value: '1' }] }
+    ]
+  });
+
+  it('A11b: a property typed as an enum DECLARED in the split enums namespace resolves cleanly (positively resolved, not merely escaped)', () => {
+    expect(validateCsdl(withSplitEnum(`${ENUMS_NS}.StandardStatus`)).valid).toBe(true);
+  });
+
+  it('A11b: a dangling reference into the DECLARED enums namespace → ERROR (previously masked as external)', () => {
+    // The schema declares org.reso.metadata.enums.StandardStatus, so that namespace is local; a typo'd
+    // sibling is a dangling local reference, no longer waved through as "external".
+    const result = validateCsdl(withSplitEnum(`${ENUMS_NS}.StandrdStatus`));
+    expect(result.valid).toBe(false);
+    expect(result.errors.some(e => e.message.includes('StandrdStatus'))).toBe(true);
+  });
+
+  it('A11b: a reference into a namespace the schema declares NOTHING in stays external — no false error (resolution is provider-derived)', () => {
+    expect(validateCsdl(withSplitEnum('com.vendor.ext.SomeEnum')).valid).toBe(true);
+  });
+
+  it('A11b: end-to-end — a split-namespace EDMX resolves its enum property through parseCsdlXml → validateCsdl', () => {
+    // Proves the seam: the parser captures each enum's own namespace and the validator resolves against it.
+    const edmx = `<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx Version="4.01" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="org.reso.metadata" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Property">
+        <Key><PropertyRef Name="ListingKey"/></Key>
+        <Property Name="ListingKey" Type="Edm.String"/>
+        <Property Name="StandardStatus" Type="org.reso.metadata.enums.StandardStatus"/>
+      </EntityType>
+      <EntityContainer Name="Default">
+        <EntitySet Name="Property" EntityType="org.reso.metadata.Property"/>
+      </EntityContainer>
+    </Schema>
+    <Schema Namespace="org.reso.metadata.enums" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EnumType Name="StandardStatus" UnderlyingType="Edm.Int32">
+        <Member Name="Active" Value="0"/>
+        <Member Name="Pending" Value="1"/>
+      </EnumType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>`;
+    expect(validateCsdl(parseCsdlXml(edmx), '4.01').valid).toBe(true);
+    // A typo in the enum reference is now caught end-to-end (was masked as external before the union).
+    const typo = validateCsdl(parseCsdlXml(edmx.replace('org.reso.metadata.enums.StandardStatus', 'org.reso.metadata.enums.Typo')), '4.01');
+    expect(typo.valid).toBe(false);
+    expect(typo.errors.some(e => e.message.includes('Typo'))).toBe(true);
+  });
+
+  // --- A11c: cross-type namespace resolution (regression guard for the adversarial false-fail) ---
+  // A non-primary namespace may declare an ENTITY or COMPLEX type — not only enums — that other schemas
+  // reference by its true FQDN. Because every declared type (not just enums) is registered under its own
+  // namespace, such a reference RESOLVES instead of false-failing; a typo'd sibling in that same declared
+  // namespace still errors. Both cases run through parseCsdlXml → validateCsdl to prove the parser stamps
+  // the namespace onto entity/complex types and the validator resolves against it.
+
+  it('A11c: a complex type declared in the enums namespace, referenced by a property, resolves (no false-fail)', () => {
+    const edmx = `<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx Version="4.01" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="org.reso.metadata" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Property">
+        <Key><PropertyRef Name="ListingKey"/></Key>
+        <Property Name="ListingKey" Type="Edm.String"/>
+        <Property Name="Box" Type="org.reso.metadata.enums.GeoBox"/>
+      </EntityType>
+      <EntityContainer Name="Default"><EntitySet Name="Property" EntityType="org.reso.metadata.Property"/></EntityContainer>
+    </Schema>
+    <Schema Namespace="org.reso.metadata.enums" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EnumType Name="StandardStatus" UnderlyingType="Edm.Int32"><Member Name="Active" Value="0"/></EnumType>
+      <ComplexType Name="GeoBox"><Property Name="North" Type="Edm.Double"/></ComplexType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>`;
+    expect(validateCsdl(parseCsdlXml(edmx), '4.01').valid).toBe(true);
+    const typo = validateCsdl(parseCsdlXml(edmx.replace('enums.GeoBox"', 'enums.GeoBoxTypo"')), '4.01');
+    expect(typo.valid).toBe(false);
+    expect(typo.errors.some(e => e.message.includes('GeoBoxTypo'))).toBe(true);
+  });
+
+  it('A11c: an entity type co-located with an enum in a non-primary namespace, referenced by nav + entity-set, resolves', () => {
+    const edmx = `<?xml version="1.0" encoding="UTF-8"?>
+<edmx:Edmx Version="4.01" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="org.reso.metadata" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Property">
+        <Key><PropertyRef Name="ListingKey"/></Key>
+        <Property Name="ListingKey" Type="Edm.String"/>
+        <Property Name="LocalStatus" Type="com.vendor.local.LocalStatus"/>
+        <NavigationProperty Name="LocalThings" Type="Collection(com.vendor.local.LocalResource)"/>
+      </EntityType>
+      <EntityContainer Name="Default">
+        <EntitySet Name="Property" EntityType="org.reso.metadata.Property"/>
+        <EntitySet Name="LocalResources" EntityType="com.vendor.local.LocalResource"/>
+      </EntityContainer>
+    </Schema>
+    <Schema Namespace="com.vendor.local" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EnumType Name="LocalStatus" UnderlyingType="Edm.Int32"><Member Name="X" Value="0"/></EnumType>
+      <EntityType Name="LocalResource"><Key><PropertyRef Name="Id"/></Key><Property Name="Id" Type="Edm.String"/></EntityType>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>`;
+    expect(validateCsdl(parseCsdlXml(edmx), '4.01').valid).toBe(true);
   });
 });

--- a/reso-metadata-utils/tests/serializer.test.ts
+++ b/reso-metadata-utils/tests/serializer.test.ts
@@ -157,3 +157,48 @@ describe('error handling', () => {
     expect(() => serializeMetadataReport(schema, '2.0')).toThrow('EntityContainer');
   });
 });
+
+// A resource whose collection nav is a containment navigation (ContainsTarget="true") targets a CONTAINED
+// entity type: it is legally declared as an EntityType but has NO top-level EntitySet (it is addressed
+// through the parent's nav path). Such a type is still a valid $expand target, so its fields MUST appear in
+// the report — otherwise downstream JSON-Schema generation emits a $ref to a definition that was never built.
+// Mirrors the real-world shape (a Property with a contained Media collection) with no vendor data.
+const containedEntityEdmx = `<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:DataServices>
+    <Schema Namespace="org.reso.metadata" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      <EntityType Name="Property">
+        <Key><PropertyRef Name="ListingKey"/></Key>
+        <Property Name="ListingKey" Type="Edm.String" Nullable="false"/>
+        <NavigationProperty Name="Media" Type="Collection(org.reso.metadata.Media)" ContainsTarget="true"/>
+      </EntityType>
+      <EntityType Name="Media">
+        <Key><PropertyRef Name="MediaKey"/></Key>
+        <Property Name="MediaKey" Type="Edm.String" Nullable="false"/>
+        <Property Name="MediaURL" Type="Edm.String" Nullable="true"/>
+      </EntityType>
+      <EntityContainer Name="Default">
+        <EntitySet Name="Property" EntityType="org.reso.metadata.Property"/>
+      </EntityContainer>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>`;
+
+describe('serializeMetadataReport — contained (ContainsTarget) entity types', () => {
+  const report = serializeMetadataReport(parseCsdlXml(containedEntityEdmx), '2.0');
+
+  it('keeps resources scoped to served EntitySets (a contained type is not a top-level resource)', () => {
+    // resources[] is legitimately the served set — a contained type must NOT show up here.
+    expect(report.resources.map(r => r.resourceName)).toEqual(['Property']);
+  });
+
+  it('includes fields for a declared-but-unhosted contained EntityType (Media)', () => {
+    const mediaFields = report.fields.filter(f => f.resourceName === 'Media');
+    expect(mediaFields.map(f => f.fieldName).sort()).toEqual(['MediaKey', 'MediaURL']);
+  });
+
+  it("still records Property's containment nav as an expansion field", () => {
+    const nav = report.fields.find(f => f.resourceName === 'Property' && f.fieldName === 'Media');
+    expect(nav?.isExpansion).toBe(true);
+  });
+});

--- a/reso-reference-server/tests/lookup-reconciler.test.ts
+++ b/reso-reference-server/tests/lookup-reconciler.test.ts
@@ -1,0 +1,86 @@
+import { resolve } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { gunzipSync } from 'node:zlib';
+import { describe, expect, it } from 'vitest';
+import Database from 'better-sqlite3';
+import { loadMetadata, getFieldsForResource, getKeyFieldForResource } from '../src/metadata/loader.js';
+import { TARGET_RESOURCES } from '../src/metadata/types.js';
+import { generateSqliteSchema } from '../src/db/sqlite-schema-generator.js';
+import { createSqliteDal } from '../src/db/sqlite-dal.js';
+import { applySeedData } from '../src/seed-data.js';
+import { reconcileLookups } from '../src/metadata/lookup-reconciler.js';
+import type { DataAccessLayer, ResourceContext, CollectionQueryOptions, CollectionResult } from '../src/db/data-access.js';
+
+const metadataPath = resolve(import.meta.dirname, '../server-metadata.json');
+
+// The "City fix": City is an OPEN enum with no seeded Lookup rows, but the committed Property seed carries
+// real City values. reconcileLookups — wired into applySeedData (it was orphaned once by the static-seed
+// split) — backfills those values into /Lookup so the reference server passes cert from its own seed
+// (RCP-039: every served enum value must be advertised in the Lookup Resource). This suite locks both the
+// WIRING and the backfill mechanism so neither can silently regress.
+
+describe('applySeedData reconciles lookups (City fix regression guard)', () => {
+  it('backfills served open-lookup values into the Lookup Resource end-to-end', async () => {
+    const metadata = await loadMetadata(metadataPath);
+    const db = new Database(':memory:'); // bare handle: FKs off by default, so seed insert order is irrelevant
+    const resourceSpecs = [...TARGET_RESOURCES, 'Lookup']
+      .map((resource) => ({ resourceName: resource, keyField: getKeyFieldForResource(resource), fields: getFieldsForResource(metadata, resource) }))
+      .filter((spec) => spec.fields.length > 0);
+    for (const statement of generateSqliteSchema(resourceSpecs)) db.exec(statement);
+    const dal = createSqliteDal(db);
+
+    await applySeedData(dal, metadata);
+
+    // Expected City set = distinct City values in the committed seed (computed, not hardcoded, so it stays
+    // green if the seed evolves — but goes from 39 to 0 and FAILS if reconcileLookups is ever un-wired).
+    const seed = JSON.parse(
+      gunzipSync(readFileSync(resolve(import.meta.dirname, '../seed-data/seed.json.gz'))).toString(),
+    ) as { readonly Property?: ReadonlyArray<Record<string, unknown>> };
+    const expectedCities = new Set((seed.Property ?? []).map((p) => p.City).filter(Boolean));
+
+    const ctx: ResourceContext = { resource: 'Lookup', keyField: 'LookupKey', fields: getFieldsForResource(metadata, 'Lookup'), navigationBindings: [] };
+    const result = await dal.queryCollection(ctx, { $filter: "LookupName eq 'City'", $top: 10000 });
+    const served = new Set(result.value.map((r) => r.LookupValue));
+
+    expect(expectedCities.size).toBeGreaterThan(0);
+    expect(served).toEqual(expectedCities);
+    expect([...served]).toContain('Cleveland');
+    expect(result.value.every((r) => r.LookupName === 'City' && typeof r.LookupKey === 'string' && r.LookupKey.length > 0)).toBe(true);
+  });
+});
+
+describe('reconcileLookups (open-enum backfill mechanism)', () => {
+  const fakeDal = (): { readonly dal: DataAccessLayer; readonly store: Array<Record<string, unknown>> } => {
+    const store: Array<Record<string, unknown>> = [];
+    const dal = {
+      insert: async (_ctx: ResourceContext, record: Readonly<Record<string, unknown>>) => {
+        store.push({ ...record });
+        return record;
+      },
+      queryCollection: async (_ctx: ResourceContext, options?: CollectionQueryOptions): Promise<CollectionResult> => {
+        const name = /LookupName eq '([^']+)'/.exec(options?.$filter ?? '')?.[1];
+        return { value: store.filter((r) => r.LookupName === name) };
+      },
+    } as unknown as DataAccessLayer; // partial mock — reconcileLookups only calls insert + queryCollection
+    return { dal, store };
+  };
+
+  it('inserts scalar and collection open-enum values in one pass', async () => {
+    const metadata = await loadMetadata(metadataPath);
+    const { dal, store } = fakeDal();
+    // City is a scalar open-enum; BuildingFeatures is a Collection open-enum (exercises the array path).
+    const inserted = await reconcileLookups(dal, metadata, 'Property', [{ City: 'Cleveland', BuildingFeatures: ['Fireplace', 'Deck'] }]);
+    expect(store.some((r) => r.LookupName === 'City' && r.LookupValue === 'Cleveland')).toBe(true);
+    expect(store.filter((r) => r.LookupName === 'BuildingFeatures').map((r) => r.LookupValue).sort()).toEqual(['Deck', 'Fireplace']);
+    expect(inserted).toBe(3);
+  });
+
+  it('is idempotent — skips values already present in the Lookup Resource', async () => {
+    const metadata = await loadMetadata(metadataPath);
+    const { dal, store } = fakeDal();
+    store.push({ LookupName: 'City', LookupValue: 'Cleveland' });
+    const inserted = await reconcileLookups(dal, metadata, 'Property', [{ City: 'Cleveland' }, { City: 'Hartford' }]);
+    expect(inserted).toBe(1);
+    expect(store.filter((r) => r.LookupName === 'City').map((r) => r.LookupValue).sort()).toEqual(['Cleveland', 'Hartford']);
+  });
+});


### PR DESCRIPTION
## What

The Core 2.1.0 "loose ends" — small correctness follow-ups after the #287 engine-corrections merge. Branched off `v1.0.0-pre`. Underlying tracker: **#294**.

- **Lookup Resource required-fields tests** — the rule is already oracle-correct (RCP-032 / Commander parity); added F.3 (each mandatory field independently), F.4 (one finding per missing field), F.5 (the optional `StandardLookupValue`/`LegacyODataValue` conflation guard), and a drift snapshot. Exported `LOOKUP_MANDATORY_FIELDS` as the single source the tests drive off. No runtime change.
- **Paging cleanup** — *not* a one-line delete: the dead `buildQueryForCategory('paging')` case's truthy return was load-bearing for the `!query` skip-gate, so a naive delete would false-**skip** paging on a compliant server. Fix: dispatch paging in `runScenario` before `buildScenarioQuery` (like `lookup-resource`/enum-family), then remove the dead case; `buildScenarioQuery` now returns `undefined` for paging (contract test added). No verdict/assertion change.
- **Reconciler regression test** — end-to-end `applySeedData reconciles lookups` (the City fix) asserting `/Lookup` advertises the 39 distinct served City values, plus `reconcileLookups` unit cases (scalar + Collection open-enum backfill, idempotency). Test-only; the wiring already regressed once.
- **CSDL type-reference resolution (metadata-nav)** — the semantic validator checks internal referential integrity: a type reference is valid iff it *links* to a type declared in the same document (there is no canonical set of RESO FQDNs). It previously resolved against the single primary namespace only, so a reference into a split sub-namespace (real RESO puts enums in e.g. `org.reso.metadata.enums`) escaped as "external" — a valid enum property was never positively resolved and a typo'd one was masked. Now every declared type (entity, enum, complex) registers under its true FQDN and references resolve against the union of all declared namespaces — positively resolving split-namespace refs and catching dangling ones, without false-failing genuinely-external references. The parser stamps the declaring namespace onto entity/complex types too (symmetry with enums). Naming reworded to the linking framing: `isDanglingReference` / `declaredNamespaces` / `declaredTypeFqdns`.

### SLV note (no code change here)

An earlier draft version-gated the `StandardLookupValue` metadata check to DD ≥ 2.0. That was **reverted** — SLV was required from DD 1.7 (Lookup Resource inception), so gating it off would false-*pass* a non-conformant 1.7 Lookup-Resource provider. The check runs for every DD version (still a non-gating warning pending the WG severity flip). `dd.ts` is unchanged from `v1.0.0-pre`.

## Decisions (no change)

- **`in` on single enums** — runs against both `Edm.EnumType` and `Edm.String` (OData 4.01). The both-representation behavior is correct; pinning to the string form only would open a false-N/A → false-pass hole for pure-`EnumType` providers. Closed, no change.

## Deferred → #294

- **Model `<TypeDefinition>`** in the CSDL validator so a property typed as a declared TypeDefinition resolves. Pre-existing for a primary-namespace TypeDefinition; the metadata-nav change widens it to a TypeDefinition co-located with an enum/entity/complex type in a non-primary namespace. Zero incidence across 64 real provider `$metadata` files, but legal conformant CSDL, so the never-false-fail rule applies. Tracked in #294.

## Verification

Full suites green — **reso-metadata-utils 120, reso-certification 1214 + 2 expected-fail, reso-reference-server 286** — typecheck across all packages, Biome clean. The metadata-nav change went through two rounds of pre-merge review; a cross-type false-fail found in the first round (a conformant provider co-locating a complex/entity type with an enum in a non-primary namespace) was fixed and re-verified.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
